### PR TITLE
Support installing Waku package from git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,3 +1080,15 @@ Please join our friendly [GitHub discussions](https://github.com/wakujs/waku/dis
 ## Roadmap
 
 Waku is in active development and we’re seeking additional contributors. Check out our [roadmap](https://github.com/wakujs/waku/issues/24) for more information.
+
+## Contributing
+
+To build an app with an experimental version of Waku, change the `waku` dependency in the app's `package.json` to `"github:<REPO_OWNER>/waku#<GIT_REF>&path:/packages/waku"` and run `pnpm install`. For example:
+
+```json
+{
+  "dependencies": {
+    "waku": "github:your_username/waku#your_branch&path:/packages/waku"
+  }
+}
+```

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -79,7 +79,8 @@
     "test:watch": "vitest",
     "compile": "rm -rf dist *.tsbuildinfo && pnpm run compile:code && pnpm run compile:types && cp ../../README.md .",
     "compile:code": "swc src -d dist --strip-leading-paths",
-    "compile:types": "tsc --project tsconfig.json"
+    "compile:types": "tsc --project tsconfig.json",
+    "prepare": "pnpm run compile"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Prior to this commit, when installing Waku from a git repository, the `dist` directory would not be built, and all `waku` CLI commands would throw an `ERR_MODULE_NOT_FOUND` error.

This commit adds a `prepare` command to `packages/waku/package.json`, which is just an alias for `pnpm run compile`.  pnpm will automatically run `prepare` when installing the package from a git repo, thus solving the problem.

Also, documentation about referencing a package inside a monorepo seems to be scarce and inaccurate (many sources specify incorrect syntax). Therefore, this commit adds instructions to the README on how to build an app that uses an experimental version of Waku.