### PR TITLE
chore(create-waku): cloudflare .gitignore

### DIFF
--- a/examples/07_cloudflare/.gitignore
+++ b/examples/07_cloudflare/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.env*
+*.tsbuildinfo
+.cache
+.DS_Store
+*.pem
+.wrangler
+

--- a/examples/07_cloudflare/.gitignore
+++ b/examples/07_cloudflare/.gitignore
@@ -6,4 +6,3 @@ dist
 .DS_Store
 *.pem
 .wrangler
-


### PR DESCRIPTION
I noticed we don't have a `.gitignore` in 07_cloudflare.