### PR TITLE
test(fs-router): e2e test for alt click to use alt key

### DIFF
--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -129,7 +129,7 @@ for (const mode of ['DEV', 'PRD'] as const) {
       });
       await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
       await page.click("a[href='/foo']", {
-        modifiers: ['ControlOrMeta'],
+        modifiers: ['Alt'],
       });
       await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
     });


### PR DESCRIPTION
to fix the flakiness

from the docs it shows that macos is the one to use the meta key, which might help explain why the flakiness is only on mac

<img width="889" alt="image" src="https://github.com/user-attachments/assets/d423d4f2-d23b-43d9-8265-6a6c855c436e" />

changing to alt should eliminate this as a possibility
