### PR TITLE
Move instructions for trying experimental version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to waku
+# Contributing to Waku
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@ pnpm install
 
 ## Building
 
-Before you start, make sure to build the waku so that the examples can be run.
+Before you start, make sure to build Waku so that the examples can be run.
 
 ```shell
 pnpm run compile
@@ -38,4 +38,16 @@ We are using [playwright](https://playwright.dev/) for end-to-end testing.
 
 ```shell
 pnpm run e2e
+```
+
+## Trying an experimental version
+
+To try an app with an experimental version of Waku, change the `waku` dependency in the app's `package.json` to `"github:<REPO_OWNER>/waku#<GIT_REF>&path:/packages/waku"` and run `pnpm install`. For example:
+
+```json
+{
+  "dependencies": {
+    "waku": "github:your_username/waku#your_branch&path:/packages/waku"
+  }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -1236,4 +1236,4 @@ Waku is in active development and we’re seeking additional contributors. Check
 
 ## Contributing
 
-If you would like to contribute, please see [CONTRIBUTING.md](./CONTRIBUTING.md)!
+If you would like to contribute, please see [CONTRIBUTING.md](https://github.com/wakujs/waku/blob/main/CHANGELOG.md)!

--- a/README.md
+++ b/README.md
@@ -1236,12 +1236,4 @@ Waku is in active development and we’re seeking additional contributors. Check
 
 ## Contributing
 
-To build an app with an experimental version of Waku, change the `waku` dependency in the app's `package.json` to `"github:<REPO_OWNER>/waku#<GIT_REF>&path:/packages/waku"` and run `pnpm install`. For example:
-
-```json
-{
-  "dependencies": {
-    "waku": "github:your_username/waku#your_branch&path:/packages/waku"
-  }
-}
-```
+If you would like to contribute, please see [CONTRIBUTING.md](./CONTRIBUTING.md)!

--- a/README.md
+++ b/README.md
@@ -1236,4 +1236,4 @@ Waku is in active development and we’re seeking additional contributors. Check
 
 ## Contributing
 
-If you would like to contribute, please see [CONTRIBUTING.md](https://github.com/wakujs/waku/blob/main/CHANGELOG.md)!
+If you would like to contribute, please see [CONTRIBUTING.md](https://github.com/wakujs/waku/blob/main/CONTRIBUTING.md)!


### PR DESCRIPTION
Follow-up to #1344.

This moves the instructions for trying experimental version of Waku from `README.md` to `CONTRIBUTING.md`.

This also adds a link to `CONTRIBUTING.md` in `README.md` in order to increase visibility.

---

Per https://github.com/wakujs/waku/pull/1344#discussion_r2027952490.
