### PR TITLE
chore: use customConditions to support go to definition internally

### DIFF
--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -18,51 +18,63 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "waku-internal": "./src/main.ts",
       "types": "./dist/main.d.ts",
       "react-server": "./dist/main.react-server.js",
       "default": "./dist/main.js"
     },
     "./config": {
+      "waku-internal": "./src/config.ts",
       "types": "./dist/config.d.ts",
       "default": "./dist/config.js"
     },
     "./middleware/*": {
+      "waku-internal": "./src/middleware/*.ts",
       "types": "./dist/middleware/*.d.ts",
       "default": "./dist/middleware/*.js"
     },
     "./unstable_internals": {
+      "waku-internal": "./src/unstable_internals.ts",
       "types": "./dist/unstable_internals.d.ts",
       "default": "./dist/unstable_internals.js"
     },
     "./unstable_hono": {
+      "waku-internal": "./src/unstable_hono.ts",
       "types": "./dist/unstable_hono.d.ts",
       "default": "./dist/unstable_hono.js"
     },
     "./client": {
+      "waku-internal": "./src/client.ts",
       "types": "./dist/client.d.ts",
       "default": "./dist/client.js"
     },
     "./server": {
+      "waku-internal": "./src/server.ts",
       "types": "./dist/server.d.ts",
       "default": "./dist/server.js"
     },
     "./minimal/client": {
+      "waku-internal": "./src/minimal/client.ts",
       "types": "./dist/minimal/client.d.ts",
       "default": "./dist/minimal/client.js"
     },
     "./minimal/server": {
+      "waku-internal": "./src/minimal/server.ts",
       "types": "./dist/minimal/server.d.ts",
       "default": "./dist/minimal/server.js"
     },
     "./router": {
+      "waku-internal": "./src/router/index.ts",
       "types": "./dist/router/base-types.d.ts",
       "default": "./dist/router/base-types.js"
     },
     "./router/client": {
+      "waku-internal": "./src/router/client.ts",
       "types": "./dist/router/client.d.ts",
       "default": "./dist/router/client.js"
     },
     "./router/server": {
+      "waku-internal": "./src/router/server.ts",
       "types": "./dist/router/server.d.ts",
       "default": "./dist/router/server.js"
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
       "waku": ["./packages/waku/src/main.ts"],
       "waku/*": ["./packages/waku/src/*.ts"]
     },
-    "noErrorTruncation": true
+    "noErrorTruncation": true,
+    "customConditions": ["waku-internal"]
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
![Kapture 2025-04-05 at 21 29 21](https://github.com/user-attachments/assets/541a207e-0c33-4a18-bea4-afccaa05f9c5)

This makes it so "go to definition" works from internal packages. I find it quite helpful for developing.

blog post describing this approach: https://colinhacks.com/essays/live-types-typescript-monorepo