### PR TITLE
fix(create-waku): do not ask package name by default

### DIFF
--- a/packages/create-waku/src/index.ts
+++ b/packages/create-waku/src/index.ts
@@ -71,9 +71,6 @@ const { values } = parseArgs({
     'project-name': {
       type: 'string',
     },
-    'package-name': {
-      type: 'string',
-    },
     'skip-install': {
       type: 'boolean',
     },
@@ -144,16 +141,13 @@ async function doPrompts() {
           return Promise.resolve(true);
         },
         packageName: () => {
-          if (values['package-name']) {
-            return Promise.resolve(values['package-name']);
-          }
           if (isValidPackageName(targetDir)) {
             return Promise.resolve(undefined);
           }
           return p.text({
             message: 'Package name',
             validate: (dir: string) => {
-              if (dir && !isValidPackageName(dir)) {
+              if (!isValidPackageName(dir)) {
                 return 'Invalid package.json name';
               }
             },
@@ -177,10 +171,7 @@ async function doPrompts() {
 
     return {
       ...results,
-      packageName:
-        values['package-name'] ||
-        results.packageName ||
-        toValidPackageName(targetDir),
+      packageName: results.packageName || toValidPackageName(targetDir),
       templateName: values.template ?? templateNames[0]!,
       targetDir,
     };
@@ -201,7 +192,6 @@ Options:
   --template            Specify a template
   --example             Specify an example use as a template
   --project-name        Specify a project name
-  --package-name        Specify a package name
   --skip-install        Skip installation of dependencies
   -h, --help            Display this help message
 `);

--- a/packages/create-waku/src/index.ts
+++ b/packages/create-waku/src/index.ts
@@ -147,6 +147,9 @@ async function doPrompts() {
           if (values['package-name']) {
             return Promise.resolve(values['package-name']);
           }
+          if (isValidPackageName(targetDir)) {
+            return Promise.resolve(undefined);
+          }
           return p.text({
             message: 'Package name',
             validate: (dir: string) => {

--- a/packages/create-waku/src/tests/cli-with-args.test.ts
+++ b/packages/create-waku/src/tests/cli-with-args.test.ts
@@ -48,9 +48,13 @@ describe('create-waku CLI with args', () => {
   });
 
   test('should not prompt for the project name if supplied', () => {
-    const { stdout } = run(['--project-name', projectName], { cwd: __dirname });
+    const { stdout } = run(['--project-name', projectName], {
+      cwd: __dirname,
+      timeout: 30000,
+      reject: false,
+    });
     expect(stdout).not.toContain('Project Name');
-  });
+  }, 10000);
 
   test('prompts for the template selection', () => {
     const { stdout } = run(['--project-name', projectName, '--choose']);
@@ -105,7 +109,7 @@ describe('create-waku CLI with args', () => {
         '--project-name',
         projectName,
         '--example',
-        'https://github.com/dai-shi/waku/tree/main/examples/01_template',
+        'https://github.com/wakujs/waku/tree/main/examples/01_template',
       ],
       { cwd: __dirname, timeout: 30000, reject: false },
     );

--- a/packages/create-waku/src/tests/cli-with-args.test.ts
+++ b/packages/create-waku/src/tests/cli-with-args.test.ts
@@ -47,19 +47,13 @@ describe('create-waku CLI with args', () => {
     expect(stdout).toContain('Project Name');
   });
 
-  test('prompts for the package name', () => {
-    const { stdout } = run(['--project-name', projectName]);
-    expect(stdout).toContain('Package name');
+  test('should not prompt for the project name if supplied', () => {
+    const { stdout } = run(['--project-name', projectName], { cwd: __dirname });
+    expect(stdout).not.toContain('Project Name');
   });
 
   test('prompts for the template selection', () => {
-    const { stdout } = run([
-      '--project-name',
-      projectName,
-      '--package-name',
-      projectName,
-      '--choose',
-    ]);
+    const { stdout } = run(['--project-name', projectName, '--choose']);
     expect(stdout).toContain('Choose a starter template');
   });
 
@@ -89,7 +83,6 @@ describe('create-waku CLI with args', () => {
     expect(stdout).toContain('--template');
     expect(stdout).toContain('--example');
     expect(stdout).toContain('--project-name');
-    expect(stdout).toContain('--package-name');
   });
 
   test('displays help message with -h alias', () => {
@@ -100,14 +93,7 @@ describe('create-waku CLI with args', () => {
 
   test('accepts template option from command line', () => {
     const { stdout } = run(
-      [
-        '--project-name',
-        projectName,
-        '--package-name',
-        projectName,
-        '--template',
-        '01_template',
-      ],
+      ['--project-name', projectName, '--template', '01_template'],
       { cwd: __dirname },
     );
     expect(stdout).toContain('Setting up project...');
@@ -117,8 +103,6 @@ describe('create-waku CLI with args', () => {
     const { stdout } = run(
       [
         '--project-name',
-        projectName,
-        '--package-name',
         projectName,
         '--example',
         'https://github.com/dai-shi/waku/tree/main/examples/01_template',
@@ -130,14 +114,7 @@ describe('create-waku CLI with args', () => {
 
   test('shows installation instructions after setup', () => {
     const { stdout } = run(
-      [
-        '--project-name',
-        projectName,
-        '--package-name',
-        projectName,
-        '--template',
-        '01_template',
-      ],
+      ['--project-name', projectName, '--template', '01_template'],
       { cwd: __dirname, timeout: 30000, reject: false },
     );
 
@@ -145,31 +122,15 @@ describe('create-waku CLI with args', () => {
   }, 10000);
 
   test('handles choose flag to explicitly prompt for template', () => {
-    const { stdout } = run(
-      [
-        '--project-name',
-        projectName,
-        '--package-name',
-        projectName,
-        '--choose',
-      ],
-      {
-        cwd: __dirname,
-      },
-    );
+    const { stdout } = run(['--project-name', projectName, '--choose'], {
+      cwd: __dirname,
+    });
     expect(stdout).toContain('Choose a starter template');
   });
 
   test('starts installation process after template selection', () => {
     const { stdout } = run(
-      [
-        '--project-name',
-        projectName,
-        '--package-name',
-        projectName,
-        '--template',
-        '01_template',
-      ],
+      ['--project-name', projectName, '--template', '01_template'],
       { cwd: __dirname, timeout: 30000, reject: false },
     );
     expect(stdout).toContain('Setting up project...');
@@ -180,8 +141,6 @@ describe('create-waku CLI with args', () => {
     const { stdout } = run(
       [
         '--project-name',
-        projectName,
-        '--package-name',
         projectName,
         '--template',
         '01_template',


### PR DESCRIPTION
We should keep the previous behavior.