### PR TITLE
experimental(router): expose get rsc params

### DIFF
--- a/packages/waku/src/router/server.ts
+++ b/packages/waku/src/router/server.ts
@@ -1,5 +1,6 @@
 export {
   unstable_defineRouter,
+  unstable_getRscParams,
   unstable_rerenderRoute,
   unstable_notFound,
   unstable_redirect,


### PR DESCRIPTION
and make the internal parseRscParams function more robust. This feels a bit suboptimal though.