### PR TITLE
chore: remove unused react/experimental types

### DIFF
--- a/e2e/fixtures/broken-links/tsconfig.json
+++ b/e2e/fixtures/broken-links/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/create-pages/tsconfig.json
+++ b/e2e/fixtures/create-pages/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist"

--- a/e2e/fixtures/define-router/tsconfig.json
+++ b/e2e/fixtures/define-router/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/fs-router/tsconfig.json
+++ b/e2e/fixtures/fs-router/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist"

--- a/e2e/fixtures/hot-reload/tsconfig.json
+++ b/e2e/fixtures/hot-reload/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/monorepo/packages/waku-project/tsconfig.json
+++ b/e2e/fixtures/monorepo/packages/waku-project/tsconfig.json
@@ -10,7 +10,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist"

--- a/e2e/fixtures/partial-build/tsconfig.json
+++ b/e2e/fixtures/partial-build/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist"

--- a/e2e/fixtures/render-type/tsconfig.json
+++ b/e2e/fixtures/render-type/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/rsc-asset/tsconfig.json
+++ b/e2e/fixtures/rsc-asset/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental", "vite/client"],
+    "types": ["vite/client"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/rsc-basic/tsconfig.json
+++ b/e2e/fixtures/rsc-basic/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/rsc-css-modules/tsconfig.json
+++ b/e2e/fixtures/rsc-css-modules/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/ssg-performance/tsconfig.json
+++ b/e2e/fixtures/ssg-performance/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/ssg-wildcard/tsconfig.json
+++ b/e2e/fixtures/ssg-wildcard/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist"

--- a/e2e/fixtures/ssr-basic/tsconfig.json
+++ b/e2e/fixtures/ssr-basic/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/ssr-catch-error/tsconfig.json
+++ b/e2e/fixtures/ssr-catch-error/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/ssr-context-provider/tsconfig.json
+++ b/e2e/fixtures/ssr-context-provider/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/ssr-redirect/tsconfig.json
+++ b/e2e/fixtures/ssr-redirect/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist"

--- a/e2e/fixtures/ssr-swr/tsconfig.json
+++ b/e2e/fixtures/ssr-swr/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist"

--- a/e2e/fixtures/ssr-target-bundle/tsconfig.json
+++ b/e2e/fixtures/ssr-target-bundle/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
   },

--- a/e2e/fixtures/use-router/tsconfig.json
+++ b/e2e/fixtures/use-router/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist"

--- a/examples/01_template/tsconfig.json
+++ b/examples/01_template/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/03_demo/tsconfig.json
+++ b/examples/03_demo/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["node", "react/experimental"],
+    "types": ["node"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/04_cssmodules/tsconfig.json
+++ b/examples/04_cssmodules/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/05_compiler/tsconfig.json
+++ b/examples/05_compiler/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/06_form-demo/tsconfig.json
+++ b/examples/06_form-demo/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["node", "react/experimental"],
+    "types": ["node"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/11_fs-router/tsconfig.json
+++ b/examples/11_fs-router/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/12_nossr/tsconfig.json
+++ b/examples/12_nossr/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/21_create-pages/tsconfig.json
+++ b/examples/21_create-pages/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/22_define-router/tsconfig.json
+++ b/examples/22_define-router/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/31_minimal/tsconfig.json
+++ b/examples/31_minimal/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/33_promise/tsconfig.json
+++ b/examples/33_promise/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/34_functions/tsconfig.json
+++ b/examples/34_functions/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["node", "react/experimental"],
+    "types": ["node"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/35_nesting/tsconfig.json
+++ b/examples/35_nesting/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/36_form/tsconfig.json
+++ b/examples/36_form/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["node", "react/experimental"],
+    "types": ["node"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/37_css/tsconfig.json
+++ b/examples/37_css/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/38_cookies/tsconfig.json
+++ b/examples/38_cookies/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental", "node"],
+    "types": ["node"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/39_api/tsconfig.json
+++ b/examples/39_api/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/41_path-alias/tsconfig.json
+++ b/examples/41_path-alias/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx",
     "paths": {
       "@/*": ["./src/*"]

--- a/examples/42_react-tweet/tsconfig.json
+++ b/examples/42_react-tweet/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/43_weave-render/tsconfig.json
+++ b/examples/43_weave-render/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/45_view-transitions/tsconfig.json
+++ b/examples/45_view-transitions/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/51_spa/tsconfig.json
+++ b/examples/51_spa/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/52_tanstack-router/tsconfig.json
+++ b/examples/52_tanstack-router/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/53_islands/tsconfig.json
+++ b/examples/53_islands/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/54_jotai/tsconfig.json
+++ b/examples/54_jotai/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "types": ["node", "react/experimental"]
+    "types": ["node"]
   },
   "include": ["src", "src/theme.json"],
   "references": [


### PR DESCRIPTION
The new types no longer require it.