### PR TITLE
feat: async refetch

### DIFF
--- a/e2e/fixtures/rsc-basic/src/components/ClientCounter.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ClientCounter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { useRefetch } from 'waku/minimal/client';
 
 import { ClientBox } from './Box.js';
@@ -8,6 +8,7 @@ import { ClientBox } from './Box.js';
 export const ClientCounter = ({ params }: { params: unknown }) => {
   const [count, setCount] = useState(0);
   const refetch = useRefetch();
+  const [isPending, startTransition] = useTransition();
   return (
     <ClientBox data-testid="client-counter">
       <p data-testid="count">{count}</p>
@@ -30,6 +31,19 @@ export const ClientCounter = ({ params }: { params: unknown }) => {
         Refetch with params
       </button>
       <div data-testid="refetch-params">{JSON.stringify(params)}</div>
+      <button
+        data-testid="refetch5"
+        onClick={() =>
+          startTransition(async () => {
+            await refetch('with-transition');
+          })
+        }
+      >
+        Refetch with transition
+      </button>
+      <div data-testid="refetch-transition">
+        {isPending ? 'pending' : 'idle'}
+      </div>
     </ClientBox>
   );
 };

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -83,6 +83,22 @@ for (const mode of ['DEV', 'PRD'] as const) {
       );
     });
 
+    test('refetch with transition', async ({ page }) => {
+      await page.route(/.*\/RSC\/.*/, async (route) => {
+        await new Promise((r) => setTimeout(r, 100));
+        await route.continue();
+      });
+      await page.goto(`http://localhost:${port}/`);
+      await page.getByTestId('refetch1').click();
+      await expect(page.getByTestId('app-name')).toHaveText('foo');
+      await page.getByTestId('refetch5').click();
+      await expect(page.getByTestId('refetch-transition')).toHaveText(
+        'pending',
+      );
+      await expect(page.getByTestId('app-name')).toHaveText('with-transition');
+      await expect(page.getByTestId('refetch-transition')).toHaveText('idle');
+    });
+
     test('server action', async ({ page }) => {
       await page.goto(`http://localhost:${port}/`);
       await expect(page.getByTestId('app-name')).toHaveText('Waku');

--- a/examples/08_jotai-demo/src/lib/waku-jotai/client.tsx
+++ b/examples/08_jotai-demo/src/lib/waku-jotai/client.tsx
@@ -80,7 +80,9 @@ export const BaseSyncAtoms = ({
         const rscParams = {
           jotai_atomValues: serializedAtomValues,
         };
-        refetch(...createRscPathAndRscParams(rscPath, rscParams));
+        refetch(...createRscPathAndRscParams(rscPath, rscParams)).catch((e) => {
+          console.error('Failed to refetch:', e);
+        });
       };
       const unsub = store.sub(atomValuesAtom, () => {
         callback(store.get(atomValuesAtom));

--- a/examples/08_jotai-demo/src/lib/waku-jotai/client.tsx
+++ b/examples/08_jotai-demo/src/lib/waku-jotai/client.tsx
@@ -80,9 +80,8 @@ export const BaseSyncAtoms = ({
         const rscParams = {
           jotai_atomValues: serializedAtomValues,
         };
-        refetch(...createRscPathAndRscParams(rscPath, rscParams)).catch((e) => {
-          console.error('Failed to refetch:', e);
-        });
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        refetch(...createRscPathAndRscParams(rscPath, rscParams));
       };
       const unsub = store.sub(atomValuesAtom, () => {
         callback(store.get(atomValuesAtom));

--- a/examples/35_nesting/src/components/Counter.tsx
+++ b/examples/35_nesting/src/components/Counter.tsx
@@ -11,7 +11,9 @@ export const Counter = ({ enableInnerApp }: { enableInnerApp?: boolean }) => {
     if (enableInnerApp) {
       const nextCount = count + 1;
       setCount(nextCount);
-      refetch('InnerApp=' + nextCount);
+      refetch('InnerApp=' + nextCount).catch((e) => {
+        console.error('Failed to refetch:', e);
+      });
     } else {
       setCount((c) => c + 1);
     }
@@ -21,7 +23,9 @@ export const Counter = ({ enableInnerApp }: { enableInnerApp?: boolean }) => {
       startTransition(() => {
         const nextCount = count + 1;
         setCount(nextCount);
-        refetch('InnerApp=' + nextCount);
+        refetch('InnerApp=' + nextCount).catch((e) => {
+          console.error('Failed to refetch:', e);
+        });
       });
     } else {
       setCount((c) => c + 1);

--- a/examples/35_nesting/src/components/Counter.tsx
+++ b/examples/35_nesting/src/components/Counter.tsx
@@ -7,25 +7,21 @@ export const Counter = ({ enableInnerApp }: { enableInnerApp?: boolean }) => {
   const [count, setCount] = useState(0);
   const [isPending, startTransition] = useTransition();
   const refetch = useRefetch();
-  const handleClick = () => {
+  const handleClick = async () => {
     if (enableInnerApp) {
       const nextCount = count + 1;
       setCount(nextCount);
-      refetch('InnerApp=' + nextCount).catch((e) => {
-        console.error('Failed to refetch:', e);
-      });
+      await refetch('InnerApp=' + nextCount)
     } else {
       setCount((c) => c + 1);
     }
   };
   const handleClickWithTransition = () => {
     if (enableInnerApp) {
-      startTransition(() => {
+      startTransition(async () => {
         const nextCount = count + 1;
         setCount(nextCount);
-        refetch('InnerApp=' + nextCount).catch((e) => {
-          console.error('Failed to refetch:', e);
-        });
+        await refetch('InnerApp=' + nextCount);
       });
     } else {
       setCount((c) => c + 1);

--- a/examples/35_nesting/src/components/Counter.tsx
+++ b/examples/35_nesting/src/components/Counter.tsx
@@ -17,15 +17,9 @@ export const Counter = ({ enableInnerApp }: { enableInnerApp?: boolean }) => {
     }
   };
   const handleClickWithTransition = () => {
-    if (enableInnerApp) {
-      startTransition(async () => {
-        const nextCount = count + 1;
-        setCount(nextCount);
-        await refetch('InnerApp=' + nextCount);
-      });
-    } else {
-      setCount((c) => c + 1);
-    }
+    startTransition(async () => {
+      await handleClick();
+    });
   };
   return (
     <div style={{ border: '3px blue dashed', margin: '1em', padding: '1em' }}>

--- a/examples/35_nesting/src/components/Counter.tsx
+++ b/examples/35_nesting/src/components/Counter.tsx
@@ -11,7 +11,7 @@ export const Counter = ({ enableInnerApp }: { enableInnerApp?: boolean }) => {
     if (enableInnerApp) {
       const nextCount = count + 1;
       setCount(nextCount);
-      await refetch('InnerApp=' + nextCount)
+      await refetch('InnerApp=' + nextCount);
     } else {
       setCount((c) => c + 1);
     }

--- a/examples/53_islands/src/main.tsx
+++ b/examples/53_islands/src/main.tsx
@@ -5,7 +5,9 @@ import { Root, Slot, useRefetch } from 'waku/minimal/client';
 const DynamicFether = () => {
   const refetch = useRefetch();
   useEffect(() => {
-    refetch('dynamic');
+    refetch('dynamic').catch((e) => {
+      console.error('Failed to refetch:', e);
+    });
   }, [refetch]);
   return null;
 };

--- a/examples/54_jotai/src/lib/waku-jotai/client.tsx
+++ b/examples/54_jotai/src/lib/waku-jotai/client.tsx
@@ -80,7 +80,9 @@ export const BaseSyncAtoms = ({
         const rscParams = {
           jotai_atomValues: serializedAtomValues,
         };
-        refetch(...createRscPathAndRscParams(rscPath, rscParams));
+        refetch(...createRscPathAndRscParams(rscPath, rscParams)).catch((e) => {
+          console.error('Failed to refetch:', e);
+        });
       };
       const unsub = store.sub(atomValuesAtom, () => {
         callback(store.get(atomValuesAtom));

--- a/examples/54_jotai/src/lib/waku-jotai/client.tsx
+++ b/examples/54_jotai/src/lib/waku-jotai/client.tsx
@@ -80,9 +80,8 @@ export const BaseSyncAtoms = ({
         const rscParams = {
           jotai_atomValues: serializedAtomValues,
         };
-        refetch(...createRscPathAndRscParams(rscPath, rscParams)).catch((e) => {
-          console.error('Failed to refetch:', e);
-        });
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        refetch(...createRscPathAndRscParams(rscPath, rscParams));
       };
       const unsub = store.sub(atomValuesAtom, () => {
         callback(store.get(atomValuesAtom));

--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -157,8 +157,8 @@ const rectifyHtml = () => {
   });
 };
 
-// FIXME Why does it error on the first time?
-let hackToIgnoreTheVeryFirstError = true;
+// FIXME Why does it error on the first and second time?
+let hackToIgnoreFirstTwoErrors = 2;
 
 export async function renderHtml(
   config: ConfigDev | ConfigPrd,
@@ -238,7 +238,7 @@ export async function renderHtml(
             ? null
             : await getExtractFormState(ctx)(actionResult),
         onError(err) {
-          if (hackToIgnoreTheVeryFirstError) {
+          if (hackToIgnoreFirstTwoErrors) {
             return;
           }
           console.error(err);
@@ -264,8 +264,8 @@ export async function renderHtml(
     injected.allReady = readable.allReady;
     return injected as never;
   } catch (e) {
-    if (hackToIgnoreTheVeryFirstError) {
-      hackToIgnoreTheVeryFirstError = false;
+    if (hackToIgnoreFirstTwoErrors) {
+      hackToIgnoreFirstTwoErrors--;
       return renderHtml(
         config,
         ctx,

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -225,7 +225,7 @@ export const prefetchRsc = (
 };
 
 const RefetchContext = createContext<
-  (rscPath: string, rscParams?: unknown) => void
+  (rscPath: string, rscParams?: unknown) => Promise<void>
 >(() => {
   throw new Error('Missing Root component');
 });
@@ -255,10 +255,11 @@ export const Root = ({
     fetchCache[SET_ELEMENTS] = setElements;
   }, [fetchCache]);
   const refetch = useCallback(
-    (rscPath: string, rscParams?: unknown) => {
+    async (rscPath: string, rscParams?: unknown) => {
       // clear cache entry before fetching
       delete fetchCache[ENTRY];
       const data = fetchRsc(rscPath, rscParams, fetchCache);
+      await data;
       setElements((prev) => mergeElementsPromise(prev, data));
     },
     [fetchCache],

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -259,6 +259,13 @@ export const Root = ({
       // clear cache entry before fetching
       delete fetchCache[ENTRY];
       const data = fetchRsc(rscPath, rscParams, fetchCache);
+      // HACK this pending workaround is required only for
+      // e2e/fixtures/ssr-catch-error/src/components/client-layout.tsx
+      const pending = Promise.resolve(data).then(
+        () => ({}),
+        () => ({}),
+      );
+      setElements((prev) => mergeElementsPromise(prev, pending));
       await data;
       setElements((prev) => mergeElementsPromise(prev, data));
     },

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -283,31 +283,6 @@ export const useElement = (id: string) => {
   return elements[id];
 };
 
-const InnerSlot = ({
-  id,
-  children,
-  unstable_fallback,
-}: {
-  id: string;
-  children?: ReactNode;
-  unstable_fallback?: ReactNode;
-}) => {
-  const element = useElement(id);
-  const isValidElement = element !== undefined;
-  if (!isValidElement) {
-    if (unstable_fallback) {
-      return unstable_fallback;
-    }
-    throw new Error('Invalid element: ' + id);
-  }
-  return createElement(
-    ChildrenContextProvider,
-    { value: children },
-    // FIXME is there `isReactNode` type checker?
-    element as ReactNode,
-  );
-};
-
 /**
  * Slot component
  * This is used under the Root component.
@@ -331,7 +306,20 @@ export const Slot = ({
   children?: ReactNode;
   unstable_fallback?: ReactNode;
 }) => {
-  return createElement(InnerSlot, { id, unstable_fallback }, children);
+  const element = useElement(id);
+  const isValidElement = element !== undefined;
+  if (!isValidElement) {
+    if (unstable_fallback) {
+      return unstable_fallback;
+    }
+    throw new Error('Invalid element: ' + id);
+  }
+  return createElement(
+    ChildrenContextProvider,
+    { value: children },
+    // FIXME is there `isReactNode` type checker?
+    element as ReactNode,
+  );
 };
 
 /**

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -249,8 +249,6 @@ export const Root = ({
       const dataWithoutErrors = Promise.resolve(data).catch(() => ({}));
       setElements((prev) => mergeElementsPromise(prev, dataWithoutErrors));
       await data;
-      // TODO remove this additional setElements
-      setElements((prev) => mergeElementsPromise(prev, data));
     },
     [fetchCache],
   );

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -496,12 +496,12 @@ const InnerRouter = ({
   }, [initialRoute]);
 
   const changeRoute: ChangeRoute = useCallback(
-    (route, options) => {
+    async (route, options) => {
       const { skipRefetch } = options || {};
       if (!staticPathSet.has(route.path) && !skipRefetch) {
         const rscPath = encodeRoutePath(route.path);
         const rscParams = createRscParams(route.query);
-        refetch(rscPath, rscParams);
+        await refetch(rscPath, rscParams);
       }
       if (options.shouldScroll) {
         handleScroll();

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -21,14 +21,7 @@ import type {
   MouseEvent,
 } from 'react';
 
-import {
-  prefetchRsc,
-  Root,
-  Slot,
-  useRefetch,
-  ThrowError_UNSTABLE as ThrowError,
-  useResetError_UNSTABLE as useResetError,
-} from '../minimal/client.js';
+import { prefetchRsc, Root, Slot, useRefetch } from '../minimal/client.js';
 import {
   encodeRoutePath,
   ROUTE_ID,
@@ -367,7 +360,6 @@ const NotFound = ({
   has404: boolean;
   reset: () => void;
 }) => {
-  const resetError = useResetError();
   const router = useContext(RouterContext);
   if (!router) {
     throw new Error('Missing Router');
@@ -377,15 +369,13 @@ const NotFound = ({
     if (has404) {
       const url = new URL('/404', window.location.href);
       changeRoute(parseRoute(url), { shouldScroll: true });
-      resetError?.();
       reset();
     }
-  }, [has404, resetError, reset, changeRoute]);
+  }, [has404, reset, changeRoute]);
   return has404 ? null : createElement('h1', null, 'Not Found');
 };
 
 const Redirect = ({ to, reset }: { to: string; reset: () => void }) => {
-  const resetError = useResetError();
   const router = useContext(RouterContext);
   if (!router) {
     throw new Error('Missing Router');
@@ -408,9 +398,8 @@ const Redirect = ({ to, reset }: { to: string; reset: () => void }) => {
       url,
     );
     changeRoute(parseRoute(url), { shouldScroll: newPath });
-    resetError?.();
     reset();
-  }, [to, resetError, reset, changeRoute]);
+  }, [to, reset, changeRoute]);
   return null;
 };
 
@@ -581,18 +570,7 @@ const InnerRouter = ({
       : createElement(Slot, { id: getRouteSlotId(route.path) });
   const rootElement = createElement(
     Slot,
-    {
-      id: 'root',
-      unstable_handleError:
-        // @ts-expect-error intentional hack
-        // eslint-disable-next-line no-constant-binary-expression
-        null &&
-        createElement(
-          CustomErrorHandler,
-          { has404 },
-          createElement(ThrowError),
-        ),
-    },
+    { id: 'root' },
     createElement(CustomErrorHandler, { has404 }, routeElement),
   );
   return createElement(
@@ -721,7 +699,7 @@ export function INTERNAL_ServerRouter({
   const routeElement = createElement(Slot, { id: getRouteSlotId(route.path) });
   const rootElement = createElement(
     Slot,
-    { id: 'root', unstable_handleError: null },
+    { id: 'root' },
     createElement('meta', { name: 'httpstatus', content: `${httpstatus}` }),
     routeElement,
   );

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -440,6 +440,10 @@ class CustomErrorHandler extends Component<
   }
 }
 
+const ThrowError = ({ error }: { error: unknown }) => {
+  throw error;
+};
+
 const getRouteSlotId = (path: string) => 'route:' + decodeURIComponent(path);
 
 const handleScroll = () => {
@@ -563,10 +567,7 @@ const InnerRouter = ({
 
   const routeElement =
     err !== null
-      ? // TODO let's revisit very soon HACK for now
-        createElement(() => {
-          throw err;
-        })
+      ? createElement(ThrowError, { error: err })
       : createElement(Slot, { id: getRouteSlotId(route.path) });
   const rootElement = createElement(
     Slot,

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -558,7 +558,13 @@ const InnerRouter = ({
           url,
         );
       }
-      changeRoute(parseRoute(url), { skipRefetch: true, shouldScroll: false });
+      // TODO this setTimeout is a workaround for now.
+      setTimeout(() => {
+        changeRoute(parseRoute(url), {
+          skipRefetch: true,
+          shouldScroll: false,
+        });
+      });
     };
     locationListeners.add(callback);
     return () => {


### PR DESCRIPTION
ref: https://github.com/wakujs/waku/pull/1391#discussion_r2069602375

This is a breaking change behavior-wise. We need to catch errors with try-catch and the error doesn't go to the error boundary by default.

- [x] make refetch async
- [x] fix e2e
- [x] refactor
- [x] add refetch with transaction test