### PR TITLE
fix: make scroll reset happen only after navigation

### DIFF
--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -453,17 +453,6 @@ class CustomErrorHandler extends Component<
 
 const getRouteSlotId = (path: string) => 'route:' + decodeURIComponent(path);
 
-const handleScroll = () => {
-  const { hash } = window.location;
-  const { state } = window.history;
-  const element = hash && document.getElementById(hash.slice(1));
-  window.scrollTo({
-    left: 0,
-    top: element ? element.getBoundingClientRect().top + window.scrollY : 0,
-    behavior: state?.waku_new_path ? 'instant' : 'auto',
-  });
-};
-
 const InnerRouter = ({
   routerData,
   initialRoute,
@@ -481,6 +470,7 @@ const InnerRouter = ({
     ...initialRoute,
     hash: '',
   }));
+  const shouldScroll = useRef(false);
   // Update the route post-load to include the current hash.
   useEffect(() => {
     setRoute((prev) => {
@@ -503,9 +493,7 @@ const InnerRouter = ({
         const rscParams = createRscParams(route.query);
         refetch(rscPath, rscParams);
       }
-      if (options.shouldScroll) {
-        handleScroll();
-      }
+      shouldScroll.current = options.shouldScroll;
       setRoute(route);
     },
     [refetch, staticPathSet],
@@ -558,6 +546,20 @@ const InnerRouter = ({
       locationListeners.delete(callback);
     };
   }, [changeRoute, locationListeners]);
+
+  useEffect(() => {
+    if (!shouldScroll.current) return;
+    shouldScroll.current = false;
+
+    const { hash } = window.location;
+    const { state } = window.history;
+    const element = hash && document.getElementById(hash.slice(1));
+    window.scrollTo({
+      left: 0,
+      top: element ? element.getBoundingClientRect().top + window.scrollY : 0,
+      behavior: state?.waku_new_path ? 'instant' : 'auto',
+    });
+  });
 
   const routeElement = createElement(Slot, { id: getRouteSlotId(route.path) });
   const rootElement = createElement(


### PR DESCRIPTION
I noticed that currently scroll resetting happens immediately when a route change is requested, even even though it can take a while for the route change to be finalized. This is a bit jarring since the user will first see two events when clicking a Link component: first the page scrolls up, then the next page loads. This change makes it so the scroll reset only happens on the next render, so you just see a single change.

Not sure if this is the best way to fix it. After some tinkering, I think using the ref+effect combo is the way to go. I also moved handleScroll to be fully inside the effect because what happens inside handleScroll is important for stuff like figuring out what kind of effect to use, I think it's safer to have less indirection there.