### PR TITLE
refactor(router): use getConfig for order instead of filename

### DIFF
--- a/e2e/fixtures/fs-router/src/pages/page-parts/_part-dynamic.tsx
+++ b/e2e/fixtures/fs-router/src/pages/page-parts/_part-dynamic.tsx
@@ -4,4 +4,5 @@ export default function Part() {
 
 export const getConfig = () => ({
   render: 'dynamic',
+  order: 1,
 });

--- a/e2e/fixtures/fs-router/src/pages/page-parts/_part-static.tsx
+++ b/e2e/fixtures/fs-router/src/pages/page-parts/_part-static.tsx
@@ -4,4 +4,5 @@ export default function Part() {
 
 export const getConfig = () => ({
   render: 'static',
+  order: 0,
 });

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -162,21 +162,10 @@ export function unstable_fsRouter(
             ...config,
           });
         } else if (pathItems.at(-1)?.startsWith('_part')) {
-          const order = parseInt(
-            pathItems.at(-1)!.split('-')[0]!.slice('_part'.length),
-          );
-          if (Number.isNaN(order)) {
-            throw new Error(
-              'Invalid page part order: ' +
-                pathItems.at(-1)! +
-                '. Please use the following convention: _part[order]-component.tsx',
-            );
-          }
           createPagePart({
             path,
             component: mod.default,
             render: 'dynamic',
-            order,
             ...config,
           });
         } else {


### PR DESCRIPTION
convention is: 
```ts
type PagePartFilename = `_part${string}.tsx`
// order must be defined in `getConfig`
```