### PR TITLE
test(cli): extend example install test timeout

### DIFF
--- a/packages/create-waku/src/tests/cli-with-args.test.ts
+++ b/packages/create-waku/src/tests/cli-with-args.test.ts
@@ -120,7 +120,7 @@ describe('create-waku CLI with args', () => {
       { cwd: import.meta.dirname, timeout: 30000, reject: false },
     );
     expect(stdout).toContain('Setting up project...');
-  }, 10000);
+  }, 30000);
 
   test('shows installation instructions after setup', () => {
     const { stdout } = run(


### PR DESCRIPTION
This will make the test less flakey. Example failure: https://github.com/wakujs/waku/actions/runs/14988122768/job/42105823351