### PR TITLE
fix: Cannot update a component ("Root") while rendering a different component warning

### DIFF
--- a/e2e/fixtures/rsc-basic/src/components/ServerPing/Counter.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ServerPing/Counter.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useState, Suspense } from 'react';
 import type { ReactNode } from 'react';
+
+import { getData } from './actions.js';
 
 export type CounterProps = {
   ping: () => Promise<string>;
@@ -13,6 +15,7 @@ export function Counter({ increase, ping, wrap }: CounterProps) {
   const [pong, setPong] = useState<string | null>(null);
   const [counter, setCounter] = useState(0);
   const [wrapped, setWrapped] = useState<ReactNode>(null);
+  const [showServerData, setShowServerData] = useState(false);
   return (
     <div>
       <p data-testid="pong">{pong}</p>
@@ -50,6 +53,13 @@ export function Counter({ increase, ping, wrap }: CounterProps) {
       >
         wrap
       </button>
+      <button
+        data-testid="show-server-data"
+        onClick={() => setShowServerData(true)}
+      >
+        Show Server Data
+      </button>
+      {showServerData && <Suspense fallback="Loading...">{getData()}</Suspense>}
     </div>
   );
 }

--- a/e2e/fixtures/rsc-basic/src/components/ServerPing/actions.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ServerPing/actions.tsx
@@ -13,3 +13,7 @@ export const increase = async (value: number) => {
 export const wrap = async (node: ReactNode) => {
   return <span className="via-server">{node}</span>;
 };
+
+export const getData = async () => {
+  return <span className="server-data">Server Data</span>;
+};

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -33,6 +33,8 @@ for (const mode of ['DEV', 'PRD'] as const) {
     });
 
     test('server ping', async ({ page }) => {
+      const messages: string[] = [];
+      page.on('console', (msg) => messages.push(msg.text()));
       await page.goto(`http://localhost:${port}/`);
       await expect(page.getByTestId('app-name')).toHaveText('Waku');
 
@@ -66,6 +68,22 @@ for (const mode of ['DEV', 'PRD'] as const) {
           .getByTestId('wrapped')
           .locator('.via-server'),
       ).toHaveText('okay');
+
+      // https://github.com/wakujs/waku/issues/1420
+      await page
+        .getByTestId('server-ping')
+        .getByTestId('show-server-data')
+        .click();
+      await expect(
+        page.getByTestId('server-ping').locator('.server-data'),
+      ).toHaveText('Server Data');
+      expect(
+        messages.some((m) =>
+          /Cannot update a component \S+ while rendering a different component/.test(
+            m,
+          ),
+        ),
+      ).toBe(false);
     });
 
     test('refetch', async ({ page }) => {

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -127,6 +127,7 @@ export const unstable_callServerRsc = async (
         );
   const data = enhanceCreateData(createData)(responsePromise);
   const dataWithoutErrors = Promise.resolve(data).catch(() => ({}));
+  await Promise.resolve(); // FIXME a workaround for #1420
   fetchCache[SET_ELEMENTS]?.((prev) =>
     mergeElementsPromise(prev, dataWithoutErrors),
   );


### PR DESCRIPTION
fix #1420 

To be honest, I'm not sure if server action should trigger suspense or not. It was the intention in #1396 to make `callServerRsc` and `refetch` somewhat consistent. We should learn the expected behavior more in the future.