### PR TITLE
fix: patch react refresh properly

### DIFF
--- a/packages/waku/src/lib/plugins/patch-react-refresh.ts
+++ b/packages/waku/src/lib/plugins/patch-react-refresh.ts
@@ -11,7 +11,7 @@ export const patchReactRefresh = <T extends PluginOption[]>(options: T): T =>
       return {
         ...option,
         transformIndexHtml(...args) {
-          const result = origTransformIndexHtml(...args);
+          const result = origTransformIndexHtml.call(this, ...args);
           if (Array.isArray(result)) {
             return result.map((item) => ({
               ...item,


### PR DESCRIPTION
While the current patch code works fine as `this` is `undefined` for current Vite, Vite 7+ will pass the context (https://github.com/vitejs/vite/pull/19936) and the current code doesn't work anymore.
This PR changes the code to call the hook function with the original `this`.

This PR should fix the ecosystem-ci failure.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/15291891294/job/43012757791#step:8:665