### PR TITLE
wip: e2e tests for #1437 and #1441

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -153,23 +153,51 @@ for (const mode of ['DEV', 'PRD'] as const) {
     // https://github.com/wakujs/waku/issues/1255
     test('long suspense', async ({ page }) => {
       await page.goto(`http://localhost:${port}/long-suspense/1`);
+      await expect(page.getByTestId('long-suspense')).toHaveText('Loading...');
+      await expect(page.getByTestId('long-suspense-component')).toHaveCount(2);
       await expect(
         page.getByRole('heading', { name: 'Long Suspense Page 1' }),
       ).toBeVisible();
       await page.click("a[href='/long-suspense/2']");
-      await expect(page.getByTestId('long-suspense')).toHaveText('Loading...');
+      await expect(page.getByTestId('long-suspense-pending')).toHaveText(
+        'Pending...',
+      );
+      await expect(page.getByTestId('long-suspense')).toHaveCount(0);
       await expect(
         page.getByRole('heading', { name: 'Long Suspense Page 2' }),
+      ).toBeVisible();
+      await page.click("a[href='/long-suspense/3']");
+      await expect(page.getByTestId('long-suspense')).toHaveText('Loading...');
+      await expect(page.getByTestId('long-suspense-pending')).toHaveCount(0);
+      await expect(
+        page.getByRole('heading', { name: 'Long Suspense Page 3' }),
       ).toBeVisible();
     });
 
     // https://github.com/wakujs/waku/issues/1437
     test('static long suspense', async ({ page }) => {
-      await page.goto(`http://localhost:${port}/static-long-suspense/3`);
-      await expect(page.getByText('Long Suspense Page 3')).toBeVisible();
-      await page.click("a[href='/static-long-suspense/4']");
-      await expect(page.getByText('Loading...')).not.toBeVisible();
-      await expect(page.getByText('Long Suspense Page 4')).toBeVisible();
+      await page.goto(`http://localhost:${port}/static-long-suspense/4`);
+      // no loading state for static
+      await expect(page.getByTestId('long-suspense')).toHaveCount(0);
+      await expect(page.getByTestId('long-suspense-component')).toHaveCount(2);
+      await expect(
+        page.getByRole('heading', { name: 'Long Suspense Page 4' }),
+      ).toBeVisible();
+      await page.click("a[href='/static-long-suspense/5']");
+      // It flashes very briefly
+      // await expect(page.getByTestId('long-suspense-pending')).toHaveCount(1);
+      await expect(page.getByTestId('long-suspense')).toHaveCount(0);
+      await expect(
+        page.getByRole('heading', { name: 'Long Suspense Page 5' }),
+      ).toBeVisible();
+      await page.click("a[href='/static-long-suspense/6']");
+      // It flashes very briefly
+      // await expect(page.getByTestId('long-suspense-pending')).toHaveCount(0);
+      // No loading state with static
+      await expect(page.getByTestId('long-suspense')).toHaveCount(0);
+      await expect(
+        page.getByRole('heading', { name: 'Long Suspense Page 6' }),
+      ).toBeVisible();
     });
 
     test('api hi', async () => {

--- a/e2e/fixtures/create-pages/src/components/LongSuspenseLayout.tsx
+++ b/e2e/fixtures/create-pages/src/components/LongSuspenseLayout.tsx
@@ -4,7 +4,11 @@ import { Link } from 'waku';
 
 export const SlowComponent = async ({ children }: { children?: ReactNode }) => {
   await new Promise((resolve) => setTimeout(resolve, 1000));
-  return <div>{children || 'Slow Component'}</div>;
+  return (
+    <div data-testid="long-suspense-component">
+      {children || 'Slow Component'}
+    </div>
+  );
 };
 
 export const StaticLongSuspenseLayout = ({
@@ -15,10 +19,23 @@ export const StaticLongSuspenseLayout = ({
   return (
     <div>
       <h2>Static Long Suspense Layout</h2>
-      <Link to="/static-long-suspense/4" unstable_pending="...">
-        Click Me
-      </Link>
-      <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+      <div>
+        <Link
+          to="/static-long-suspense/5"
+          unstable_pending={
+            <div data-testid="long-suspense-pending">Pending...</div>
+          }
+        >
+          Click Me
+        </Link>
+      </div>
+      <div>
+        <Link to="/static-long-suspense/6">Click Me Too</Link>
+      </div>
+      <Suspense fallback={<div data-testid="long-suspense">Loading...</div>}>
+        <SlowComponent />
+        {children}
+      </Suspense>
     </div>
   );
 };
@@ -27,11 +44,23 @@ export const LongSuspenseLayout = ({ children }: { children: ReactNode }) => {
   return (
     <div>
       <h2>Long Suspense Layout</h2>
-      <Link to="/long-suspense/2">Click Me</Link>
+      <div>
+        <Link
+          to="/long-suspense/2"
+          unstable_pending={
+            <div data-testid="long-suspense-pending">Pending...</div>
+          }
+        >
+          Click Me
+        </Link>
+      </div>
+      <div>
+        <Link to="/long-suspense/3">Click Me Too</Link>
+      </div>
       <Suspense fallback={<div data-testid="long-suspense">Loading...</div>}>
         <SlowComponent />
+        {children}
       </Suspense>
-      {children}
     </div>
   );
 };

--- a/e2e/fixtures/create-pages/src/entries.tsx
+++ b/e2e/fixtures/create-pages/src/entries.tsx
@@ -97,21 +97,39 @@ const pages: ReturnType<typeof createPages> = createPages(
     }),
 
     createLayout({
-      render: 'dynamic',
+      render: 'static',
       path: '/long-suspense',
       component: LongSuspenseLayout,
     }),
 
     createPage({
-      render: 'static',
+      render: 'dynamic',
       path: '/long-suspense/1',
-      component: () => <h3>Long Suspense Page 1</h3>,
+      component: () => (
+        <SlowComponent>
+          <h3>Long Suspense Page 1</h3>
+        </SlowComponent>
+      ),
     }),
 
     createPage({
-      render: 'static',
+      render: 'dynamic',
       path: '/long-suspense/2',
-      component: () => <h3>Long Suspense Page 2</h3>,
+      component: () => (
+        <SlowComponent>
+          <h3>Long Suspense Page 2</h3>
+        </SlowComponent>
+      ),
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/long-suspense/3',
+      component: () => (
+        <SlowComponent>
+          <h3>Long Suspense Page 3</h3>
+        </SlowComponent>
+      ),
     }),
 
     createLayout({
@@ -121,15 +139,33 @@ const pages: ReturnType<typeof createPages> = createPages(
     }),
 
     createPage({
-      render: 'dynamic',
-      path: '/static-long-suspense/3',
-      component: () => <SlowComponent>Long Suspense Page 3</SlowComponent>,
+      render: 'static',
+      path: '/static-long-suspense/4',
+      component: () => (
+        <SlowComponent>
+          <h3>Long Suspense Page 4</h3>
+        </SlowComponent>
+      ),
     }),
 
     createPage({
-      render: 'dynamic',
-      path: '/static-long-suspense/4',
-      component: () => <SlowComponent>Long Suspense Page 4</SlowComponent>,
+      render: 'static',
+      path: '/static-long-suspense/5',
+      component: () => (
+        <SlowComponent>
+          <h3>Long Suspense Page 5</h3>
+        </SlowComponent>
+      ),
+    }),
+
+    createPage({
+      render: 'static',
+      path: '/static-long-suspense/6',
+      component: () => (
+        <SlowComponent>
+          <h3>Long Suspense Page 6</h3>
+        </SlowComponent>
+      ),
     }),
 
     createPage({

--- a/e2e/fixtures/fs-router/src/pages/dynamic/[name].tsx
+++ b/e2e/fixtures/fs-router/src/pages/dynamic/[name].tsx
@@ -1,0 +1,17 @@
+export default async function DynamicOnePage({ name }: { name: string }) {
+  await simulateLoadTime(100);
+
+  return (
+    <h2>
+      Dynamic ${name} Page Time {new Date().toISOString()}
+    </h2>
+  );
+}
+
+function simulateLoadTime(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const getConfig = () => ({
+  render: 'dynamic',
+});

--- a/e2e/fixtures/fs-router/src/pages/dynamic/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/dynamic/_layout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import { Suspense } from 'react';
+import { Link } from 'waku';
+
+type LoaderLayoutProps = { children: ReactNode };
+
+export default async function LoaderLayout({ children }: LoaderLayoutProps) {
+  return (
+    <div>
+      <nav>
+        <Link to="/dynamic/one" unstable_pending="Pending Dynamic One">
+          Dynamic One With Transition
+        </Link>
+        <Link to="/dynamic/two" unstable_pending="Pending Dynamic Two">
+          Dynamic Two With Transition
+        </Link>
+        <Link to="/dynamic/three">Dynamic Three Without Transition</Link>
+      </nav>
+      <Suspense fallback="Loading...">{children}</Suspense>
+    </div>
+  );
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'static',
+  } as const;
+};

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -145,6 +145,33 @@ for (const mode of ['DEV', 'PRD'] as const) {
       expect(dynamicPageTime).not.toBe(staticPageTime);
     });
 
+    test('dynamic route transitions', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/dynamic/one`);
+      const pageTime = (
+        await page.getByRole('heading', { name: 'Page Time' }).textContent()
+      )?.split('Time ')[1];
+      expect(pageTime).toBeTruthy();
+
+      // Load page two, verify the existing time continues to display
+      // await page.click("a[href='/dynamic/two']");
+      // await page.waitForTimeout(50);
+      // await expect(
+      //   page.getByRole('heading', { name: 'Page Time' }),
+      // ).toBeVisible();
+      // const newPageTime = (
+      //   await page.getByRole('heading', { name: 'Page Time' }).textContent()
+      // )?.split('Page ')[1];
+      // expect(newPageTime).toBe(pageTime);
+
+      // Once page two loads (there will be a heading with "Dynamic two" content))
+      // verify the time is different
+      // expect(newPageTime).not.toBe(pageTime);
+
+      // load page one, confirm the page shows the existing content while transitioning
+
+      // load page three, the loading fallback should display while loading since there is no transition
+    });
+
     test('alt click', async ({ page }) => {
       await page.goto(`http://localhost:${port}`);
       await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();


### PR DESCRIPTION
This updated fixture and tests demonstrate the intended behavior for pages that take a long time to load.

When I run the e2e locally, the "long response" test is failing in PRD. I'm not sure why. I built the create-pages fixture and run it with `pnpm run build && pnpm run start` and the behavior at https://localhost:8080/long-suspense/1 is correct.
