### PR TITLE
fix: automatically pick available hmr port

### DIFF
--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -1,6 +1,6 @@
 import { Readable, Writable } from 'node:stream';
 import { Server } from 'node:http';
-import type { AddressInfo } from 'node:net';
+import net, { type AddressInfo } from 'node:net';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createServer as createViteServer } from 'vite';
 import viteReact from '@vitejs/plugin-react';

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -1,5 +1,6 @@
 import { Readable, Writable } from 'node:stream';
 import { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createServer as createViteServer } from 'vite';
 import viteReact from '@vitejs/plugin-react';
@@ -29,7 +30,6 @@ import { rscDelegatePlugin } from '../plugins/vite-plugin-rsc-delegate.js';
 import type { ClonableModuleNode, Middleware } from './types.js';
 import { fsRouterTypegenPlugin } from '../plugins/vite-plugin-fs-router-typegen.js';
 import { hackTailwindcss4Stackblitz } from '../plugins/hack-tailwindcss4-stackblitz.js';
-import type { AddressInfo } from 'node:net';
 
 // TODO there is huge room for refactoring in this file
 
@@ -93,7 +93,7 @@ async function getFreePort(): Promise<number> {
   return new Promise<number>((resolve) => {
     const srv = net.createServer();
     srv.listen(0, () => {
-      const port = (srv.address() as net.AddressInfo).port;
+      const port = (srv.address() as AddressInfo).port;
       srv.close(() => resolve(port));
     });
   });

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -157,7 +157,7 @@ const createMainViteServer = (
           appType: 'mpa',
           server: {
             middlewareMode: true,
-            hmr: { port: await findAvailablePort() },
+            hmr: { port: await getFreePort() },
           },
         },
         config,

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -89,19 +89,15 @@ const splitByLastEndTag = (input: string): readonly [string, string] => {
   }
 };
 
-const findAvailablePort = async () => {
-  const server = new Server();
-  await new Promise((resolve) =>
-    server.listen(
-      // listen on the `0` port, which the OS will then assign an available port
-      0,
-      () => resolve(undefined),
-    ),
-  );
-  const port = (server.address() as AddressInfo).port;
-  server.close();
-  return port;
-};
+async function getFreePort(): Promise<number> {
+  return new Promise<number>((resolve) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
 
 const createMainViteServer = (
   env: Record<string, string>,


### PR DESCRIPTION
## Details:

Fixes: #1464 

This is maybe a bit of a naive fix - but it uses the underlying OS (or an implementation of Node.js / the JS runtime in use while running Waku) to select an available port and then we specify that within the Vite `server.hmr` options for the main vite server.

I tested applying a similar change to the two other places ([here](https://github.com/wakujs/waku/blob/0f5d360550a6c1deb9b34080a264b07f95467834/packages/waku/src/lib/utils/vite-loader.ts#L11-L19), and [here](https://github.com/wakujs/waku/blob/0f5d360550a6c1deb9b34080a264b07f95467834/packages/waku/src/lib/middleware/dev-server-impl.ts#L270-L325)) where we call `createServer` from `vite` - but it seems like those had no impact and making only this change seemed to fix the issue for me.

### Testing

I tested this a bit manually, specifically I used this relatively bare bones reproduction repo: https://github.com/hamlim/waku-conflicting-hmr-port-reproduction, and then did the following:

- Compiled changes to `waku` locally
- Clone and install deps for `waku-conflicting-hmr-port-reproduction` repo (bun i)
- `rm -rf ./waku-conflicting-hmr-port-reproduction/node_modules/waku`
- `cp -r ./waku/packages/waku ./waku-conflicting-hmr-port-reproduction/node_modules/waku`
- `rm -rf ./waku-conflicting-hmr-port-reproduction/node_modules/waku/node_modules`
- `bun run dev` (at root of `waku-conflicting-hmr-port-reproduction` repo)
- Open both `localhost:3000` and `localhost:3001`
- Check both consoles to see no errors about hmr
- Make a change to one app and save the file - see only that app refresh
- Make a change to the other app and save the file - see only the other app refresh

The reason for the convoluted way to pull in the local version of the `waku` package was that I was running into issues with conflicting react packages from waku's local `node_modules/react` package (for initial testing I used a `file:` dependency as a resolution in my root package.json). I maybe could have tested with a slightly different flow - but the hacky `rm -rf` and `cp -r` setup above seemed to work fine.