### PR TITLE
test: add a spec for unstable_allowServer

### DIFF
--- a/e2e/fixtures/rsc-basic/src/components/App.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/App.tsx
@@ -1,6 +1,6 @@
 // no "use server" detective
 
-import { ClientCounter } from './ClientCounter.js';
+import { ClientCounter, someConfigs } from './ClientCounter.js';
 import { ServerPing } from './ServerPing/index.js';
 import { ServerBox } from './Box.js';
 import { ServerProvider } from './ServerAction/Server.js';
@@ -22,6 +22,7 @@ const App = ({ name, params }: { name: string; params: unknown }) => {
             <ClientActionsConsumer />
           </ServerProvider>
           <ServerThrows />
+          <p data-testid="some-config-foo">{someConfigs.foo}</p>
         </ServerBox>
       </body>
     </html>

--- a/e2e/fixtures/rsc-basic/src/components/ClientCounter.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ClientCounter.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react';
 import { useRefetch } from 'waku/minimal/client';
+import { unstable_allowServer as allowServer } from 'waku/client';
 
 import { ClientBox } from './Box.js';
 
@@ -47,3 +48,7 @@ export const ClientCounter = ({ params }: { params: unknown }) => {
     </ClientBox>
   );
 };
+
+export const someConfigs = allowServer({
+  foo: 'value-1234',
+});

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -154,4 +154,10 @@ test.describe(`rsc-basic`, () => {
     ).toHaveText(FETCH_ERROR_MESSAGES[browserName]);
     ({ port, stopApp } = await startApp(mode));
   });
+
+  test('allowServer', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/`);
+    await expect(page.getByTestId('app-name')).toHaveText('Waku');
+    await expect(page.getByTestId('some-config-foo')).toHaveText('value-1234');
+  });
 });


### PR DESCRIPTION
This adds a basic e2e test for `unstable_allowServer` capability.