### PR TITLE
test: ensure server function is async

### DIFF
--- a/e2e/fixtures/fs-router/src/functions/say-hello.tsx
+++ b/e2e/fixtures/fs-router/src/functions/say-hello.tsx
@@ -2,7 +2,7 @@
 
 import { SayHello } from '../components/say-hello.js';
 
-export function sayHello() {
+export async function sayHello() {
   const promise = new Promise<string>((resolve) =>
     setTimeout(() => resolve('React'), 1000),
   );

--- a/e2e/fixtures/rsc-basic/modules/ai/src/server.js
+++ b/e2e/fixtures/rsc-basic/modules/ai/src/server.js
@@ -1,4 +1,3 @@
-'use server';
 import { InternalProvider } from './shared.js';
 import { jsx } from 'react/jsx-runtime';
 


### PR DESCRIPTION
I extracted a change from https://github.com/wakujs/waku/pull/1493. I found these two since my plugin rejects non async function with "use server".