### PR TITLE
test: remove redundant tests

### DIFF
--- a/e2e/broken-links.spec.ts
+++ b/e2e/broken-links.spec.ts
@@ -68,6 +68,8 @@ test.describe(`broken-links: normal server`, async () => {
 });
 
 test.describe('broken-links: static server', () => {
+  test.skip(({ mode }) => mode !== 'PRD');
+
   let port: number;
   let stopApp: () => Promise<void>;
   test.beforeAll(async () => {
@@ -137,43 +139,41 @@ test.describe('broken-links: static server', () => {
   });
 });
 
-for (const mode of ['DEV', 'PRD'] as const) {
-  test.describe(`broken-links/dynamic-not-found: ${mode}`, async () => {
-    let port: number;
-    let stopApp: () => Promise<void>;
-    test.beforeAll(async () => {
-      ({ port, stopApp } = await startApp(mode));
-    });
-    test.afterAll(async () => {
-      await stopApp();
-    });
-
-    test('access sync page directly', async ({ page }) => {
-      await page.goto(`http://localhost:${port}/dynamic-not-found/sync`);
-      await expect(page.getByRole('heading')).toHaveText('Custom not found');
-      await expect(page).toHaveTitle('Custom Not Found Title');
-    });
-
-    test('access async page directly', async ({ page }) => {
-      await page.goto(`http://localhost:${port}/dynamic-not-found/async`);
-      await expect(page.getByRole('heading')).toHaveText('Custom not found');
-      await expect(page).toHaveTitle('Custom Not Found Title');
-    });
-
-    test('access sync page with client navigation', async ({ page }) => {
-      await page.goto(`http://localhost:${port}/`);
-      await expect(page.getByRole('heading')).toHaveText('Index');
-      await page.click("a[href='/dynamic-not-found/sync']");
-      await expect(page.getByRole('heading')).toHaveText('Custom not found');
-      await expect(page).toHaveTitle('Custom Not Found Title');
-    });
-
-    test('access async page with client navigation', async ({ page }) => {
-      await page.goto(`http://localhost:${port}/`);
-      await expect(page.getByRole('heading')).toHaveText('Index');
-      await page.click("a[href='/dynamic-not-found/async']");
-      await expect(page.getByRole('heading')).toHaveText('Custom not found');
-      await expect(page).toHaveTitle('Custom Not Found Title');
-    });
+test.describe(`broken-links/dynamic-not-found`, async () => {
+  let port: number;
+  let stopApp: () => Promise<void>;
+  test.beforeAll(async ({ mode }) => {
+    ({ port, stopApp } = await startApp(mode));
   });
-}
+  test.afterAll(async () => {
+    await stopApp();
+  });
+
+  test('access sync page directly', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/dynamic-not-found/sync`);
+    await expect(page.getByRole('heading')).toHaveText('Custom not found');
+    await expect(page).toHaveTitle('Custom Not Found Title');
+  });
+
+  test('access async page directly', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/dynamic-not-found/async`);
+    await expect(page.getByRole('heading')).toHaveText('Custom not found');
+    await expect(page).toHaveTitle('Custom Not Found Title');
+  });
+
+  test('access sync page with client navigation', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/`);
+    await expect(page.getByRole('heading')).toHaveText('Index');
+    await page.click("a[href='/dynamic-not-found/sync']");
+    await expect(page.getByRole('heading')).toHaveText('Custom not found');
+    await expect(page).toHaveTitle('Custom Not Found Title');
+  });
+
+  test('access async page with client navigation', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/`);
+    await expect(page.getByRole('heading')).toHaveText('Index');
+    await page.click("a[href='/dynamic-not-found/async']");
+    await expect(page.getByRole('heading')).toHaveText('Custom not found');
+    await expect(page).toHaveTitle('Custom Not Found Title');
+  });
+});


### PR DESCRIPTION
Extracted from https://github.com/wakujs/waku/pull/1493. This for-loop seems redundant since DEV / PROD runs are already split  as playwright projects.