### PR TITLE
fix(docs): use absolute URL for example

### DIFF
--- a/docs/guides/react-compiler.mdx
+++ b/docs/guides/react-compiler.mdx
@@ -35,4 +35,4 @@ export default defineConfig({
 });
 ```
 
-Check out [a working example](../../examples/05_compiler), or visit the [StackBlitz demo](https://stackblitz.com/github/wakujs/waku/tree/main/examples/05_compiler) with Waku v0.21.12 and up.
+Check out [a working example](https://github.com/wakujs/waku/tree/main/examples/05_compiler), or visit the [StackBlitz demo](https://stackblitz.com/github/wakujs/waku/tree/main/examples/05_compiler) with Waku v0.21.12 and up.


### PR DESCRIPTION
It’s a small fix. Found it while going through your docs.

The issue also exists in `docs/minimal-api.mdx` but it doesn’t look like it’s accessible publicly so I left it untouched. LMK if you want the URLs fixed there as well.

---

💖