### PR TITLE
chore: add pkg.pr.new

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,9 +1,11 @@
 name: pkg-pr-new
-"on":
+
+on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
+    types: [opened, synchronize]
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -13,10 +15,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm run compile
-      - name: pkg-pr-new
-        run: |
-          npx pkg-pr-new publish --comment=off packages/waku
+      - run: pnpm dlx pkg-pr-new publish packages/waku


### PR DESCRIPTION
Extracted from https://github.com/wakujs/waku/pull/1493#discussion_r2181491876

I didn't meant to include this on main repo, but I suppose it would be beneficial. I get annoyed by the pkg.pr.new comment, so I normally set `--comment=off`. Please feel free to adjust as you like.

To use this, Github app needs to be enabled on this repo via https://github.com/apps/pkg-pr-new