### PR TITLE
fix: fix double fetch on client after server redirection

### DIFF
--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -445,14 +445,12 @@ const NotFound = ({
   return has404 ? null : createElement('h1', null, 'Not Found');
 };
 
-const errorRedirectionMap = new WeakMap<object, boolean>();
-
 const Redirect = ({
   error,
   to,
   reset,
 }: {
-  error: any;
+  error: unknown;
   to: string;
   reset: () => void;
 }) => {
@@ -461,12 +459,14 @@ const Redirect = ({
     throw new Error('Missing Router');
   }
   const { changeRoute } = router;
+  const handledErrorSet = useRef(new WeakSet());
   useEffect(() => {
     // ensure single re-fetch per server redirection error on StrictMode
-    if (errorRedirectionMap.get(error)) {
+    // https://github.com/wakujs/waku/pull/1512
+    if (handledErrorSet.current.has(error as object)) {
       return;
     }
-    errorRedirectionMap.set(error, true);
+    handledErrorSet.current.add(error as object);
 
     const url = new URL(to, window.location.href);
     // FIXME this condition seems too naive


### PR DESCRIPTION
Extracted from https://github.com/wakujs/waku/pull/1493

I noticed that there are duplicate RSC fetching on server-side redirection of http://localhost:3000/async when running `pnpm -C e2e/fixtures/ssr-redirect dev`. This is because `StrictMode` triggering `useEffect` twice inside `Redirect` error boundary. I added `WeakMap` of `Error` instance to avoid triggering `changeRoute` twice. This just counters against `StrictMode`, so it's not a fundamental solution though.

It looks like this was causing flakiness on Vite RSC PR https://github.com/wakujs/waku/pull/1493, so I moved a fix separately here since this affects only router implementation.

<details><summary>Network devtools before/after</summary>

See `destination.txt` request at the end:

## Before

![image](https://github.com/user-attachments/assets/1bacd4e6-f745-4cfd-87dd-8caeb49406f6)

## After

![image](https://github.com/user-attachments/assets/c66bb521-8290-40f9-8313-5b95aaae6c60)

</details>