### PR TITLE
test: add debug logs for flaky create-vite test failure

### DIFF
--- a/packages/create-waku/src/tests/cli-with-args.test.ts
+++ b/packages/create-waku/src/tests/cli-with-args.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { SyncOptions, SyncResult } from 'execa';
 import { execaCommandSync } from 'execa';
-import { afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { afterEach, beforeAll, describe, expect, onTestFailed, test } from 'vitest';
 
 const CLI_PATH = path.join(import.meta.dirname, '../../dist/index.js');
 
@@ -18,8 +18,17 @@ const run = <SO extends SyncOptions>(
   args: string[],
   options?: SO,
 ): SyncResult<SO> => {
+  const command = `node ${CLI_PATH} ${args.join(' ')}`;
+  const result = execaCommandSync(command, options);
+  onTestFailed(() => {
+    console.error("======= CLI:", command)
+    console.error("======= stdout")
+    console.error(result.stdout)
+    console.error("======= stderr")
+    console.error(result.stderr)
+  });
   // @ts-expect-error relies on exactOptionalPropertyTypes being false
-  return execaCommandSync(`node ${CLI_PATH} ${args.join(' ')}`, options);
+  return result;
 };
 
 // Helper to create a non-empty directory

--- a/packages/create-waku/src/tests/cli-with-args.test.ts
+++ b/packages/create-waku/src/tests/cli-with-args.test.ts
@@ -28,11 +28,13 @@ const run = <SO extends SyncOptions>(
   const command = `node ${CLI_PATH} ${args.join(' ')}`;
   const result = execaCommandSync(command, options);
   onTestFailed(() => {
-    console.error('======= CLI:', command);
+    console.error('======= command');
+    console.error(command);
     console.error('======= stdout');
     console.error(result.stdout);
     console.error('======= stderr');
     console.error(result.stderr);
+    console.error('=======');
   });
   // @ts-expect-error relies on exactOptionalPropertyTypes being false
   return result;

--- a/packages/create-waku/src/tests/cli-with-args.test.ts
+++ b/packages/create-waku/src/tests/cli-with-args.test.ts
@@ -2,7 +2,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { SyncOptions, SyncResult } from 'execa';
 import { execaCommandSync } from 'execa';
-import { afterEach, beforeAll, describe, expect, onTestFailed, test } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  onTestFailed,
+  test,
+} from 'vitest';
 
 const CLI_PATH = path.join(import.meta.dirname, '../../dist/index.js');
 
@@ -21,11 +28,11 @@ const run = <SO extends SyncOptions>(
   const command = `node ${CLI_PATH} ${args.join(' ')}`;
   const result = execaCommandSync(command, options);
   onTestFailed(() => {
-    console.error("======= CLI:", command)
-    console.error("======= stdout")
-    console.error(result.stdout)
-    console.error("======= stderr")
-    console.error(result.stderr)
+    console.error('======= CLI:', command);
+    console.error('======= stdout');
+    console.error(result.stdout);
+    console.error('======= stderr');
+    console.error(result.stderr);
   });
   // @ts-expect-error relies on exactOptionalPropertyTypes being false
   return result;


### PR DESCRIPTION
It looks like this one is frequently failing (including Vite ecosystem ci sometimes https://github.com/vitejs/vite-ecosystem-ci/actions/runs/16108041683/job/45446816642).

```
  packages/create-waku test: ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
  packages/create-waku test:  FAIL  src/tests/cli-with-args.test.ts > create-waku CLI with args > accepts example option from command line
  packages/create-waku test: AssertionError: expected '' to contain 'Setting up project...'
  packages/create-waku test: - Expected
  packages/create-waku test: + Received
  packages/create-waku test: - Setting up project...
  packages/create-waku test:  ❯ src/tests/cli-with-args.test.ts:122:20
  packages/create-waku test:     120|       { cwd: import.meta.dirname, timeout: 30000, reject: false },
  packages/create-waku test:     121|     );
  packages/create-waku test:     122|     expect(stdout).toContain('Setting up project...');
  packages/create-waku test:        |                    ^
  packages/create-waku test:     123|   }, 30000);
  packages/create-waku test:     124| 
  packages/create-waku test: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```

To help debugging the issue, I added `onTestFailed` to reveal the cli logs in case of failures.
