### PR TITLE
chore: separate css examples for stylex and vanilla-extract

### DIFF
--- a/examples/37_css-vanilla-extract/package.json
+++ b/examples/37_css-vanilla-extract/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "37_css-vanilla-extract",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev",
+    "build": "waku build",
+    "start": "waku start"
+  },
+  "dependencies": {
+    "@vanilla-extract/css": "1.17.4",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "react-server-dom-webpack": "19.1.0",
+    "waku": "0.23.3"
+  },
+  "devDependencies": {
+    "@types/react": "19.1.8",
+    "@types/react-dom": "19.1.6",
+    "@vanilla-extract/vite-plugin": "4.0.19"
+  }
+}

--- a/examples/37_css-vanilla-extract/src/client.css.ts
+++ b/examples/37_css-vanilla-extract/src/client.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+export const clientStyle = style({
+  border: '1px orange solid',
+  padding: '0.5rem',
+  margin: '0.5rem'
+});

--- a/examples/37_css-vanilla-extract/src/components/counter.tsx
+++ b/examples/37_css-vanilla-extract/src/components/counter.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useState } from 'react';
+import { clientStyle } from '../client.css';
+
+export const Counter = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+      <button
+        onClick={() => setCount((c) => c + 1)}
+        className={clientStyle}
+      >
+        Client Style: {count} (orange)
+      </button>
+  );
+};

--- a/examples/37_css-vanilla-extract/src/pages/index.tsx
+++ b/examples/37_css-vanilla-extract/src/pages/index.tsx
@@ -1,0 +1,37 @@
+// import { Link } from 'waku';
+
+import { Counter } from "../components/counter";
+import { serverStyle } from "../server.css";
+
+// import { Counter } from '../components/counter';
+
+export default async function HomePage() {
+  // const data = await getData();
+
+  return (
+    <div>
+      <div className={serverStyle}>
+        Server Style (green)
+      </div>
+      <div>
+        <Counter />
+      </div>
+    </div>
+  );
+}
+
+// const getData = async () => {
+//   const data = {
+//     title: 'Waku',
+//     headline: 'Waku',
+//     body: 'Hello world!',
+//   };
+
+//   return data;
+// };
+
+// export const getConfig = async () => {
+//   return {
+//     render: 'static',
+//   } as const;
+// };

--- a/examples/37_css-vanilla-extract/src/server.css.ts
+++ b/examples/37_css-vanilla-extract/src/server.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+export const serverStyle = style({
+  border: '1px green solid',
+  padding: '0.5rem',
+  margin: '0.5rem'
+});

--- a/examples/37_css-vanilla-extract/tsconfig.json
+++ b/examples/37_css-vanilla-extract/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/examples/37_css-vanilla-extract/vite.config.ts
+++ b/examples/37_css-vanilla-extract/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import { stylex } from 'vite-plugin-stylex-dev';
+
+// FIXME we would like to avoid this hack
+const hackCssPluginNeededForStylex = () => {
+  return {
+    name: 'hack-css-plugin-needed-for-stylex',
+    apply: 'serve' as const,
+    resolveId(id: string) {
+      if (id.endsWith('.css') && !id.endsWith('.vanilla.css')) {
+        return id;
+      }
+    },
+  };
+};
+
+const vanillaExtractPluginInstance = vanillaExtractPlugin();
+
+// FIXME we would like this to waku.config.ts using unstable_viteConfigs.
+export default defineConfig({
+  plugins: [
+    hackCssPluginNeededForStylex(),
+    vanillaExtractPluginInstance,
+    stylex(),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1192,6 +1192,80 @@ importers:
         specifier: 0.7.5
         version: 0.7.5(rollup@4.44.0)
 
+  examples/37_css-stylex:
+    dependencies:
+      '@stylexjs/stylex':
+        specifier: 0.13.1
+        version: 0.13.1
+      '@vanilla-extract/css':
+        specifier: 1.17.4
+        version: 1.17.4
+      classnames:
+        specifier: 2.3.2
+        version: 2.3.2
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      react-server-dom-webpack:
+        specifier: 19.1.0
+        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.99.9)
+      waku:
+        specifier: 0.23.3
+        version: link:../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: 19.1.8
+        version: 19.1.8
+      '@types/react-dom':
+        specifier: 19.1.6
+        version: 19.1.6(@types/react@19.1.8)
+      '@vanilla-extract/vite-plugin':
+        specifier: 4.0.19
+        version: 4.0.19(@types/node@24.0.4)(lightningcss@1.30.1)(terser@5.43.1)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0))
+      rollup:
+        specifier: 4.44.0
+        version: 4.44.0
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vite:
+        specifier: 7.0.0
+        version: 7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite-plugin-stylex-dev:
+        specifier: 0.7.5
+        version: 0.7.5(rollup@4.44.0)
+
+  examples/37_css-vanilla-extract:
+    dependencies:
+      '@vanilla-extract/css':
+        specifier: 1.17.4
+        version: 1.17.4
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      react-server-dom-webpack:
+        specifier: 19.1.0
+        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.99.9)
+      waku:
+        specifier: 0.23.3
+        version: link:../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: 19.1.8
+        version: 19.1.8
+      '@types/react-dom':
+        specifier: 19.1.6
+        version: 19.1.6(@types/react@19.1.8)
+      '@vanilla-extract/vite-plugin':
+        specifier: 4.0.19
+        version: 4.0.19(@types/node@24.0.4)(lightningcss@1.30.1)(terser@5.43.1)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0))
+
   examples/38_cookies:
     dependencies:
       cookie:


### PR DESCRIPTION
This PR simplifies css examples so it's easier to debug stylex and vanilla-extract. I don't think supporting both at the same time is practically important.