### PR TITLE
test: fix flaky github api calls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,4 @@ jobs:
       - run: pnpm test
         env:
           VITE_EXPERIMENTAL_WAKU_ROUTER: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/create-waku/src/tests/cli-with-args.test.ts
+++ b/packages/create-waku/src/tests/cli-with-args.test.ts
@@ -127,7 +127,23 @@ describe('create-waku CLI with args', () => {
     expect(stdout).toContain('Setting up project...');
   }, 10000);
 
-  test('accepts example option from command line', () => {
+  test('accepts example option from command line', (ctx) => {
+    if (process.env.CI) {
+      if (process.env.GITHUB_TOKEN) {
+        const oldFetch = fetch;
+        globalThis.fetch = (input, init) => {
+          const headers = new Headers(init?.headers);
+          headers.set('Authorization', `Bearer ${process.env.GITHUB_TOKEN}`);
+          return oldFetch(input, { ...init, headers });
+        };
+        ctx.onTestFinished(() => {
+          globalThis.fetch = oldFetch;
+        });
+      } else {
+        ctx.skip('requires GITHUB_TOKEN on CI');
+      }
+    }
+
     const { stdout } = run(
       [
         '--project-name',


### PR DESCRIPTION
Follow up to https://github.com/wakujs/waku/pull/1513#issuecomment-3059989816

The issue is likely flaky github api calls on CI. I added `GITHUB_TOKEN` on Waku's CI, so this should become more reliable. On Vite ecosystem CI, this will be skipped since it would require on their side to set up the token.