### PR TITLE
fix monorepo with pnpm and yarn

### DIFF
--- a/e2e/fixtures/monorepo/pnpm-workspace.yaml
+++ b/e2e/fixtures/monorepo/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'packages/*'
+linkWorkspacePackages: true

--- a/e2e/multi-platform.spec.ts
+++ b/e2e/multi-platform.spec.ts
@@ -64,7 +64,7 @@ const cleanListAfterBuild = new Set(
   ),
 );
 
-test.describe(`multi platform builds`, () => {
+test.describe.serial(`multi platform builds`, () => {
   for (const { cwd, project } of dryRunList) {
     for (const { platform, clearDirOrFile } of buildPlatformTarget) {
       test(`build ${project} with ${platform} should not throw error`, async ({

--- a/e2e/partial-build.spec.ts
+++ b/e2e/partial-build.spec.ts
@@ -11,7 +11,7 @@ const waku = fileURLToPath(
   new URL('../packages/waku/dist/cli.js', import.meta.url),
 );
 
-test.describe(`partial builds`, () => {
+test.describe.serial(`partial builds`, () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
     'Browsers are not relevant for this test. One is enough.',

--- a/e2e/render-type.spec.ts
+++ b/e2e/render-type.spec.ts
@@ -4,7 +4,7 @@ import { test, prepareNormalSetup } from './utils.js';
 
 const startApp = prepareNormalSetup('render-type');
 
-test.describe('render type', () => {
+test.describe.serial('render type', () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
     'Browsers are not relevant for this test. One is enough.',

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -171,13 +171,13 @@ export const prepareNormalSetup = (fixtureName: string) => {
 
 const PACKAGE_INSTALL = {
   npm: `npm install --force`,
-  pnpm: `pnpm install --link-workspace-packages=true`,
+  pnpm: `pnpm install`,
   yarn: `yarn install`,
 } as const;
 
 const PACKAGE_ADD = {
   npm: `npm add --force`,
-  pnpm: `pnpm add --link-workspace-packages=true`,
+  pnpm: `pnpm add`,
   yarn: `yarn add -W`,
 } as const;
 

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -259,9 +259,13 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
           writeFileSync(f, JSON.stringify(pkg, null, 2), 'utf8');
         }
       }
-      execSync(PACKAGE_INSTALL[packageManager], { cwd: standaloneDir });
+      execSync(PACKAGE_INSTALL[packageManager], {
+        cwd: standaloneDir,
+        stdio: 'inherit',
+      });
       execSync(`${PACKAGE_ADD[packageManager]} ${wakuPackageTgz}`, {
         cwd: standaloneDir,
+        stdio: 'inherit',
       });
     }
     if (mode !== 'DEV' && !built) {

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -171,13 +171,13 @@ export const prepareNormalSetup = (fixtureName: string) => {
 
 const PACKAGE_INSTALL = {
   npm: `npm install --force`,
-  pnpm: `pnpm install`,
+  pnpm: `pnpm install --link-workspace-packages=true`,
   yarn: `yarn install`,
 } as const;
 
 const PACKAGE_ADD = {
   npm: `npm add --force`,
-  pnpm: `pnpm add`,
+  pnpm: `pnpm add --link-workspace-packages=true`,
   yarn: `yarn add -W`,
 } as const;
 

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -199,6 +199,14 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
     packageManager: 'npm' | 'pnpm' | 'yarn' = 'npm',
     packageDir = '',
   ) => {
+    const wakuPackageDir = (): string => {
+      if (!standaloneDir) {
+        throw new Error('standaloneDir is not set');
+      }
+      return packageManager === 'npm'
+        ? standaloneDir
+        : join(standaloneDir, packageDir);
+    };
     let standaloneDir = standaloneDirMap.get(packageManager);
     if (!standaloneDir) {
       standaloneDir = mkdtempSync(join(tmpDir, fixtureName));
@@ -264,7 +272,7 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
         stdio: 'inherit',
       });
       execSync(`${PACKAGE_ADD[packageManager]} ${wakuPackageTgz}`, {
-        cwd: standaloneDir,
+        cwd: wakuPackageDir(),
         stdio: 'inherit',
       });
     }
@@ -274,7 +282,7 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
         force: true,
       });
       execSync(
-        `node ${join(standaloneDir, './node_modules/waku/dist/cli.js')} build`,
+        `node ${join(wakuPackageDir(), './node_modules/waku/dist/cli.js')} build`,
         { cwd: join(standaloneDir, packageDir) },
       );
       built = true;
@@ -282,10 +290,10 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
     let cmd: string;
     switch (mode) {
       case 'DEV':
-        cmd = `node ${join(standaloneDir, './node_modules/waku/dist/cli.js')} dev`;
+        cmd = `node ${join(wakuPackageDir(), './node_modules/waku/dist/cli.js')} dev`;
         break;
       case 'PRD':
-        cmd = `node ${join(standaloneDir, './node_modules/waku/dist/cli.js')} start`;
+        cmd = `node ${join(wakuPackageDir(), './node_modules/waku/dist/cli.js')} start`;
         break;
       case 'STATIC':
         cmd = `node ${join(standaloneDir, './node_modules/serve/build/main.js')} dist/public`;

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -139,7 +139,7 @@ export const prepareNormalSetup = (fixtureName: string) => {
   const fixtureDir = fileURLToPath(
     new URL('./fixtures/' + fixtureName, import.meta.url),
   );
-  let builtMode: false | 'PRD' | 'STATIC' = false;
+  let builtMode: undefined | 'PRD' | 'STATIC';
   const startApp = async (mode: 'DEV' | 'PRD' | 'STATIC') => {
     if (mode !== 'DEV' && builtMode !== mode) {
       rmSync(`${fixtureDir}/dist`, { recursive: true, force: true });
@@ -162,7 +162,7 @@ export const prepareNormalSetup = (fixtureName: string) => {
     debugChildProcess(cp, fileURLToPath(import.meta.url));
     const port = await findWakuPort(cp);
     const stopApp = async () => {
-      builtMode = false;
+      builtMode = undefined;
       await terminate(cp.pid!);
     };
     return { port, stopApp, fixtureDir };
@@ -305,6 +305,7 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
     debugChildProcess(cp, fileURLToPath(import.meta.url));
     const port = await findWakuPort(cp);
     const stopApp = async () => {
+      builtModeMap.delete(packageManager);
       await terminate(cp.pid!);
     };
     return { port, stopApp, standaloneDir };

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -143,7 +143,7 @@ export const prepareNormalSetup = (fixtureName: string) => {
   const startApp = async (mode: 'DEV' | 'PRD' | 'STATIC') => {
     if (mode !== 'DEV' && !built) {
       rmSync(`${fixtureDir}/dist`, { recursive: true, force: true });
-      execSync(`node ${waku} build`, { cwd: fixtureDir });
+      execSync(`node ${waku} build`, { cwd: fixtureDir, stdio: 'inherit' });
       built = true;
     }
     let cmd: string;
@@ -219,6 +219,7 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
       });
       execSync(`pnpm pack --pack-destination ${standaloneDir}`, {
         cwd: wakuDir,
+        stdio: 'inherit',
       });
       const wakuPackageTgz = join(standaloneDir, `waku-${version}.tgz`);
       const rootPkg = JSON.parse(
@@ -283,7 +284,7 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
       });
       execSync(
         `node ${join(wakuPackageDir(), './node_modules/waku/dist/cli.js')} build`,
-        { cwd: join(standaloneDir, packageDir) },
+        { cwd: join(standaloneDir, packageDir), stdio: 'inherit' },
       );
       built = true;
     }

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -33,6 +33,7 @@ import {
   CLIENT_PREFIX,
 } from '../middleware/handler.js';
 import { rscRsdwPlugin } from '../plugins/vite-plugin-rsc-rsdw.js';
+import { rscResolveRsdwPlugin } from '../plugins/vite-plugin-rsc-resolve-rsdw.js';
 import { rscIndexPlugin } from '../plugins/vite-plugin-rsc-index.js';
 import { rscAnalyzePlugin } from '../plugins/vite-plugin-rsc-analyze.js';
 import { nonjsResolvePlugin } from '../plugins/vite-plugin-nonjs-resolve.js';
@@ -107,6 +108,7 @@ const analyzeEntries = async (rootDir: string, config: ConfigDev) => {
       {
         mode: 'production',
         plugins: [
+          rscResolveRsdwPlugin(),
           rscAnalyzePlugin({ isClient: false, clientFileMap, serverFileMap }),
           rscManagedPlugin({ ...config, addEntriesToInput: true }),
           ...deployPlugins(config),
@@ -236,6 +238,7 @@ const buildServerBundle = async (
             clientEntryFiles,
             serverEntryFiles,
           }),
+          rscResolveRsdwPlugin(),
           rscRsdwPlugin(),
           rscEnvPlugin({ isDev: false, env, config }),
           rscPrivatePlugin(config),

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-resolve-rsdw.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-resolve-rsdw.ts
@@ -5,7 +5,6 @@ export function rscResolveRsdwPlugin(): Plugin {
     name: 'rsc-resolve-rsdw-plugin',
     enforce: 'pre',
     async resolveId(id) {
-      console.error('Resolving ID:', id);
       if (id === 'react-server-dom-webpack/server.edge') {
         const resolved = await this.resolve(id);
         return resolved?.id;

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-resolve-rsdw.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-resolve-rsdw.ts
@@ -1,0 +1,15 @@
+import type { Plugin } from 'vite';
+
+export function rscResolveRsdwPlugin(): Plugin {
+  return {
+    name: 'rsc-resolve-rsdw-plugin',
+    enforce: 'pre',
+    async resolveId(id) {
+      console.error('Resolving ID:', id);
+      if (id === 'react-server-dom-webpack/server.edge') {
+        const resolved = await this.resolve(id);
+        return resolved?.id;
+      }
+    },
+  };
+}


### PR DESCRIPTION
Problem: monorepo spec doesn't pass locally. It looks like, when it seems to work, it reuses `standaloneDir` wrongly.