### PR TITLE
e2e: recover smoke tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,7 +109,7 @@ jobs:
         id: install-playwright
         uses: ./.github/actions/playwright
       - run: pnpm exec playwright test --shard=${{ matrix.shared }}/${{ matrix.shardTotal }}
-        timeout-minutes: 30
+        timeout-minutes: 15
         env:
           TEMP_DIR: ${{ runner.temp }}
           VITE_EXPERIMENTAL_WAKU_ROUTER: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,7 +109,7 @@ jobs:
         id: install-playwright
         uses: ./.github/actions/playwright
       - run: pnpm exec playwright test --shard=${{ matrix.shared }}/${{ matrix.shardTotal }}
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           TEMP_DIR: ${{ runner.temp }}
           VITE_EXPERIMENTAL_WAKU_ROUTER: true

--- a/e2e/examples-smoke.spec.ts
+++ b/e2e/examples-smoke.spec.ts
@@ -11,6 +11,7 @@ import { readdir, rm } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { findWakuPort, terminate, test } from './utils.js';
 import { error, info } from '@actions/core';
+import os from 'node:os';
 
 const examplesDir = fileURLToPath(new URL('../examples', import.meta.url));
 
@@ -51,6 +52,10 @@ for (const cwd of examples) {
     ? commandsCloudflare
     : commands;
   for (const { build, command } of exampleCommands) {
+    if (command === 'npx wrangler dev' && os.platform() === 'win32') {
+      // FIXME npx wrangler dev doesn't work on Windows and we don't know why.
+      continue;
+    }
     test.describe(`smoke test on ${basename(cwd)}: ${command}`, () => {
       test.skip(({ mode }) => mode !== (build ? 'PRD' : 'DEV'));
       let cp: ChildProcess | undefined;

--- a/e2e/examples-smoke.spec.ts
+++ b/e2e/examples-smoke.spec.ts
@@ -52,6 +52,7 @@ for (const cwd of examples) {
     : commands;
   for (const { build, command } of exampleCommands) {
     test.describe(`smoke test on ${basename(cwd)}: ${command}`, () => {
+      test.skip(({ mode }) => mode !== (build ? 'PRD' : 'DEV'));
       let cp: ChildProcess | undefined;
       let port: number;
       test.beforeAll('remove cache', async () => {

--- a/examples/37_css-stylex/src/pages/index.tsx
+++ b/examples/37_css-stylex/src/pages/index.tsx
@@ -15,6 +15,7 @@ const styles = stylex.create({
 export default async function HomePage() {
   return (
     <div>
+      <title>Waku</title>
       <div {...stylex.props(styles.server)}>Server Style (green)</div>
       <div>
         <Counter />

--- a/examples/37_css-vanilla-extract/src/pages/index.tsx
+++ b/examples/37_css-vanilla-extract/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { serverStyle } from '../server.css';
 export default async function HomePage() {
   return (
     <div>
+      <title>Waku</title>
       <div className={serverStyle}>Server Style (green)</div>
       <div>
         <Counter />

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,6 @@ const config = defineConfig<TestOptions>({
     {
       ...item,
       name: `${item.name}-dev`,
-      testIgnore: ['examples-smoke.spec.ts'],
       use: {
         ...item.use,
         mode: 'DEV',
@@ -45,7 +44,6 @@ const config = defineConfig<TestOptions>({
     {
       ...item,
       name: `${item.name}-prd`,
-      testIgnore: ['examples-smoke.spec.ts'],
       use: {
         ...item.use,
         mode: 'PRD',


### PR DESCRIPTION
smoke tests has been ignored since #1463.

I'm not sure if it's a leftover or an intentional change by @himself65 , but this reverts it.