### PR TITLE
test: skip github api test on ci

### DIFF
--- a/packages/create-waku/src/tests/cli-with-args.test.ts
+++ b/packages/create-waku/src/tests/cli-with-args.test.ts
@@ -127,9 +127,10 @@ describe('create-waku CLI with args', () => {
     expect(stdout).toContain('Setting up project...');
   }, 10000);
 
-  test(
+  // Github api call is not reliable on CI
+  test.skipIf(process.env.CI)(
     'accepts example option from command line',
-    { timeout: 30000, retry: process.env.CI ? 3 : 0 },
+    { timeout: 30000 },
     () => {
       const { stdout } = run(
         [


### PR DESCRIPTION
This is a last resort since retry doesn't seem to help probably because Github just rejects requests from the same machine https://github.com/wakujs/waku/actions/runs/16287396949/job/45989028513#step:8:61