### PR TITLE
test: React.use server promise on client

### DIFF
--- a/examples/36_form/src/components/Form.tsx
+++ b/examples/36_form/src/components/Form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import { useFormStatus } from 'react-dom';
 
 const SubmitButton = () => {
@@ -14,19 +15,41 @@ const SubmitButton = () => {
   );
 };
 
+// export const Form = ({
+//   message,
+//   greet,
+// }: {
+//   message: Promise<string>;
+//   greet: (formData: FormData) => Promise<void>;
+// }) => (
+//   <div style={{ border: '3px blue dashed', margin: '1em', padding: '1em' }}>
+//     <p>{String(React.use(message))}</p>
+//     {/* <p>{message}</p> */}
+//     <form action={greet}>
+//       Name: <input name="name" />
+//       <SubmitButton />
+//     </form>
+//     <h3>This is a client component.</h3>
+//   </div>
+// );
+
 export const Form = ({
   message,
   greet,
 }: {
   message: Promise<string>;
   greet: (formData: FormData) => Promise<void>;
-}) => (
-  <div style={{ border: '3px blue dashed', margin: '1em', padding: '1em' }}>
-    <p>{message}</p>
+}) => {
+  const inner = React.use(message);
+  console.log({ inner })
+  return <div style={{ border: '3px blue dashed', margin: '1em', padding: '1em' }}>
+    <p>{inner}</p>
+    {/* <p>{String(React.use(message))}</p> */}
+    {/* <p>{message}</p> */}
     <form action={greet}>
       Name: <input name="name" />
       <SubmitButton />
     </form>
     <h3>This is a client component.</h3>
   </div>
-);
+}


### PR DESCRIPTION
I found something interesting while investigating failures on https://github.com/wakujs/waku/pull/1493. The same issue exists on current Waku. To be explained later...

---

When logging `React.use(message)`,

```js
export const Form = ({
  message,
  greet,
}: {
  message: Promise<string>;
  greet: (formData: FormData) => Promise<void>;
}) => {
  const inner = React.use(message);
  console.log({ inner })  // 👈👈
```

this shows two logs:

```js
// 1st log on ssr, which causes "not valid as a React child" error
{
  inner: {
    App: {
      '$$typeof': Symbol(react.transitional.element),
      type: 'html',
      key: null,
      props: [Object],
      _owner: [Object],
      _store: {}
    }
  }
}
// 2nd log on ssr
{ inner: '' }
```

The first render causes a following error but it's saved by `hackToIgnoreFirstTwoErrors` on current Waku. I didn't add this hack yet on https://github.com/wakujs/waku/pull/1493, so `examples/36_form` is currently failing there. 

```
Error: Objects are not valid as a React child (found: object with keys {App}). ...
```

It's possible that this is a bug of react. Waku uses `renderToReadableStream` twice on SSR, but React might be somehow mixing up multiple promises during RSC serialization/deserialization.