### PR TITLE
chore(e2e): expect timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,9 @@ import type { TestOptions } from './e2e/utils.js';
 const config = defineConfig<TestOptions>({
   testDir: './e2e',
   timeout: process.env.CI ? 120_000 : 30_000,
+  expect: {
+    timeout: process.env.CI ? 10_000 : 5_000,
+  },
   use: {
     viewport: { width: 1440, height: 800 },
     locale: 'en-US',


### PR DESCRIPTION
I removed it in #1486, assuming it would work, and it works for most cases, but it seems necessary in some occasions.