### PR TITLE
test: fix monorepo yarn to use local build

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -179,12 +179,6 @@ const PACKAGE_INSTALL = {
   yarn: `yarn install`,
 } as const;
 
-const PACKAGE_ADD = {
-  npm: `npm add --force`,
-  pnpm: `pnpm add`,
-  yarn: `yarn add -W`,
-} as const;
-
 export const makeTempDir = (prefix: string): string => {
   // GitHub Action on Windows doesn't support mkdtemp on global temp dir,
   // Which will cause files in `src` folder to be empty. I don't know why
@@ -281,18 +275,6 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
         cwd: standaloneDir,
         stdio: 'inherit',
       });
-      // if (packageManager === 'yarn') {
-      //   // For yarn workspaces, we need to run yarn add -W from the root to add waku to workspace dependencies
-      //   execSync(`${PACKAGE_ADD[packageManager]} ${wakuPackageTgz}`, {
-      //     cwd: standaloneDir,
-      //     stdio: 'inherit',
-      //   });
-      // } else {
-      //   execSync(`${PACKAGE_ADD[packageManager]} ${wakuPackageTgz}`, {
-      //     cwd: wakuPackageDir(),
-      //     stdio: 'inherit',
-      //   });
-      // }
     }
     if (mode !== 'DEV' && builtModeMap.get(packageManager) !== mode) {
       rmSync(`${join(standaloneDir, packageDir, 'dist')}`, {

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -211,7 +211,7 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
       if (!standaloneDir) {
         throw new Error('standaloneDir is not set');
       }
-      return packageManager === 'npm'
+      return packageManager !== 'pnpm'
         ? standaloneDir
         : join(standaloneDir, packageDir);
     };
@@ -239,6 +239,7 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
       const pnpmOverrides = {
         ...rootPkg.pnpm?.overrides,
         ...rootPkg.pnpmOverrides, // Do we need this?
+        waku: `file:${wakuPackageTgz}`,
       };
       for (const file of readdirSync(standaloneDir, {
         encoding: 'utf8',
@@ -280,10 +281,18 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
         cwd: standaloneDir,
         stdio: 'inherit',
       });
-      execSync(`${PACKAGE_ADD[packageManager]} ${wakuPackageTgz}`, {
-        cwd: wakuPackageDir(),
-        stdio: 'inherit',
-      });
+      // if (packageManager === 'yarn') {
+      //   // For yarn workspaces, we need to run yarn add -W from the root to add waku to workspace dependencies
+      //   execSync(`${PACKAGE_ADD[packageManager]} ${wakuPackageTgz}`, {
+      //     cwd: standaloneDir,
+      //     stdio: 'inherit',
+      //   });
+      // } else {
+      //   execSync(`${PACKAGE_ADD[packageManager]} ${wakuPackageTgz}`, {
+      //     cwd: wakuPackageDir(),
+      //     stdio: 'inherit',
+      //   });
+      // }
     }
     if (mode !== 'DEV' && builtModeMap.get(packageManager) !== mode) {
       rmSync(`${join(standaloneDir, packageDir, 'dist')}`, {


### PR DESCRIPTION
I found that monorepo yarn case is using the package just downloaded from npm and not the one build locally. This PR changes `prepareStandaloneSetup` to rely on `overrides/resolutions` instead of `add xxx.tar.gz` command to enforce locally built package.