### PR TITLE
test: use pnpm by default for `prepareStandaloneSetup`

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -198,7 +198,7 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
   const builtModeMap = new Map<'npm' | 'pnpm' | 'yarn', 'PRD' | 'STATIC'>();
   const startApp = async (
     mode: 'DEV' | 'PRD' | 'STATIC',
-    packageManager: 'npm' | 'pnpm' | 'yarn' = 'npm',
+    packageManager: 'npm' | 'pnpm' | 'yarn' = 'pnpm',
     packageDir = '',
   ) => {
     const wakuPackageDir = (): string => {


### PR DESCRIPTION
`pnpm` is faster and I think we should use this by default since the purpose is the isolation.
