### PR TITLE
test: minimal repro of client promise bug

### DIFF
--- a/examples/36_form-repro/package.json
+++ b/examples/36_form-repro/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "36_form-repro",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev",
+    "build": "waku build",
+    "start": "waku start"
+  },
+  "dependencies": {
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "react-server-dom-webpack": "19.1.0",
+    "waku": "0.23.4"
+  },
+  "devDependencies": {
+    "@types/react": "19.1.8",
+    "@types/react-dom": "19.1.6",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/36_form-repro/src/client-entry.tsx
+++ b/examples/36_form-repro/src/client-entry.tsx
@@ -1,0 +1,17 @@
+import { StrictMode } from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import { Root, Slot } from 'waku/minimal/client';
+
+const rootElement = (
+  <StrictMode>
+    <Root>
+      <Slot id="App" />
+    </Root>
+  </StrictMode>
+);
+
+if ((globalThis as any).__WAKU_HYDRATE__) {
+  hydrateRoot(document, rootElement);
+} else {
+  createRoot(document as any).render(rootElement);
+}

--- a/examples/36_form-repro/src/components/App.tsx
+++ b/examples/36_form-repro/src/components/App.tsx
@@ -1,0 +1,18 @@
+import { TestClient } from "./client";
+
+const App = () => {
+  return (
+    <html>
+      <head>
+        <title>Waku</title>
+      </head>
+      <body>
+        <div>
+          <TestClient serverPromise={Promise.resolve("test")}/>
+        </div>
+      </body>
+    </html>
+  );
+};
+
+export default App;

--- a/examples/36_form-repro/src/components/client.tsx
+++ b/examples/36_form-repro/src/components/client.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import React from "react"
+
+export function TestClient(props: { serverPromise: Promise<string>} ) {
+  const data = React.use(props.serverPromise);
+  console.log("[React.use(props.serverPromise)]", data);
+  return <div>[React.use(props.serverPromise): {data}]</div>
+}

--- a/examples/36_form-repro/src/server-entry.tsx
+++ b/examples/36_form-repro/src/server-entry.tsx
@@ -1,0 +1,18 @@
+import { unstable_defineEntries as defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
+
+import App from './components/App';
+
+export default defineEntries({
+  handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App /> });
+    }
+    if (input.type === 'custom') {
+      return renderHtml({ App: <App /> }, <Slot id="App" />, {
+        rscPath: '',
+      });
+    }
+  },
+  handleBuild: () => null,
+});

--- a/examples/36_form-repro/tsconfig.json
+++ b/examples/36_form-repro/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"],
+    "jsx": "react-jsx"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1146,6 +1146,31 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/36_form-repro:
+    dependencies:
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      react-server-dom-webpack:
+        specifier: 19.1.0
+        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.99.9)
+      waku:
+        specifier: 0.23.4
+        version: link:../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: 19.1.8
+        version: 19.1.8
+      '@types/react-dom':
+        specifier: 19.1.6
+        version: 19.1.6(@types/react@19.1.8)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/37_css:
     dependencies:
       classnames:


### PR DESCRIPTION
Related 
- https://github.com/wakujs/waku/issues/1496
- https://github.com/wakujs/waku/pull/1534

This example is a minimal version of https://github.com/wakujs/waku/pull/1534. This appears working but it's due to `hackToIgnoreFirstTwoErrors`. On initial SSR, it shows following logs

```sh
$ pnpm -C examples/36_form-repro/ dev
...
// initial ssr fails by "Objects are not valid as a React child"
[React.use(props.serverPromise)] {
  App: {
    '$$typeof': Symbol(react.transitional.element),
    type: 'html',
    key: null,
    props: { children: [Array] },
   ...
}

// works after retry of hackToIgnoreFirstTwoErrors
[React.use(props.serverPromise)] test
```