### PR TITLE
fix: workaround `React.use` SSR bug by wrapping extra component

### DIFF
--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -205,7 +205,6 @@ export async function renderHtml(
     injected.allReady = readable.allReady;
     return injected as never;
   } catch (e) {
-    console.error('[renderHTML] Error in renderToReadableStream:', e);
     if (hackToIgnoreFirstTwoErrors) {
       hackToIgnoreFirstTwoErrors--;
       return renderHtml(

--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -4,7 +4,6 @@ import type {
   ReactNode,
   FunctionComponent,
   ComponentProps,
-  PropsWithChildren,
 } from 'react';
 import type * as RDServerType from 'react-dom/server.edge';
 import type { default as RSDWClientType } from 'react-server-dom-webpack/client.edge';
@@ -89,9 +88,6 @@ globalThis.__WAKU_HYDRATE__ = true;
   return { headCode, headModules, headElements };
 };
 
-// FIXME Why does it error on the first and second time?
-let hackToIgnoreFirstTwoErrors = 0;
-
 export async function renderHtml(
   config: ConfigDev | ConfigPrd,
   ctx: Pick<HandlerContext, 'unstable_modules' | 'unstable_devServer'>,
@@ -162,62 +158,45 @@ export async function renderHtml(
       ? `${config.basePath}${(config as ConfigDev).srcDir}/${SRC_CLIENT_ENTRY}`
       : '',
   );
-  // isolate `React.use` in its own component
-  // https://github.com/facebook/react/issues/33937#issuecomment-3091349011
-  function UseWrapper(props: { value: Promise<ReactNode> }) {
-    const resolved = INTERNAL_use(props.value);
-    return createElement(UseWrapperInner, null, resolved);
-  }
-  function UseWrapperInner(props: PropsWithChildren) {
-    return props.children;
-  }
-  try {
-    const readable = await renderToReadableStream(
-      createElement(
-        INTERNAL_ServerRoot as FunctionComponent<
-          Omit<ComponentProps<typeof INTERNAL_ServerRoot>, 'children'>
-        >,
-        { elementsPromise },
-        createElement(UseWrapper, { value: htmlNode }),
-        ...headElements,
-      ),
-      {
-        bootstrapScriptContent: headCode,
-        bootstrapModules: headModules,
-        formState:
-          actionResult === undefined
-            ? null
-            : await getExtractFormState(ctx)(actionResult),
-        onError(err) {
-          if (hackToIgnoreFirstTwoErrors) {
-            return;
-          }
-          console.error(err);
-          onError.forEach((fn) => fn(err, ctx as HandlerContext, 'html'));
-          if (typeof (err as any)?.digest === 'string') {
-            return (err as { digest: string }).digest;
-          }
-        },
+  const readable = await renderToReadableStream(
+    createElement(
+      INTERNAL_ServerRoot as FunctionComponent<
+        Omit<ComponentProps<typeof INTERNAL_ServerRoot>, 'children'>
+      >,
+      { elementsPromise },
+      // See: https://github.com/wakujs/waku/pull/1545
+      // isolate `React.use` in its own component
+      // https://github.com/facebook/react/issues/33937#issuecomment-3091349011
+      createElement(() => {
+        const resolvedHtmlNode = INTERNAL_use(htmlNode);
+        return createElement(HtmlNodeWrapper, null, resolvedHtmlNode);
+      }),
+      ...headElements,
+    ),
+    {
+      bootstrapScriptContent: headCode,
+      bootstrapModules: headModules,
+      formState:
+        actionResult === undefined
+          ? null
+          : await getExtractFormState(ctx)(actionResult),
+      onError(err) {
+        console.error(err);
+        onError.forEach((fn) => fn(err, ctx as HandlerContext, 'html'));
+        if (typeof (err as any)?.digest === 'string') {
+          return (err as { digest: string }).digest;
+        }
       },
-    );
-    const injected: ReadableStream & { allReady?: Promise<void> } =
-      readable.pipeThrough(injectRSCPayload(stream2));
-    injected.allReady = readable.allReady;
-    return injected as never;
-  } catch (e) {
-    if (hackToIgnoreFirstTwoErrors) {
-      hackToIgnoreFirstTwoErrors--;
-      return renderHtml(
-        config,
-        ctx,
-        htmlHead,
-        elements,
-        onError,
-        html,
-        rscPath,
-        actionResult,
-      );
-    }
-    throw e;
-  }
+    },
+  );
+  const injected: ReadableStream & { allReady?: Promise<void> } =
+    readable.pipeThrough(injectRSCPayload(stream2));
+  injected.allReady = readable.allReady;
+  return injected as never;
+}
+
+// HACK: This is only for a workaround.
+// https://github.com/facebook/react/issues/33937
+function HtmlNodeWrapper(props: { children: ReactNode }) {
+  return props.children;
 }

--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -1,4 +1,4 @@
-import { use, createElement } from 'react';
+import { createElement } from 'react';
 import type {
   ReactElement,
   ReactNode,
@@ -111,7 +111,7 @@ export async function renderHtml(
   const {
     default: { createFromReadableStream },
   } = modules.rsdwClient as { default: typeof RSDWClientType };
-  const { INTERNAL_ServerRoot } =
+  const { INTERNAL_ServerRoot, INTERNAL_use } =
     modules.wakuMinimalClient as typeof WakuMinimalClientType;
 
   const stream = await renderRsc(config, ctx, elements, onError);
@@ -170,10 +170,9 @@ export async function renderHtml(
         { elementsPromise },
         // isolate `React.use` in its own component
         // to workaround https://github.com/facebook/react/issues/33937
-        createElement(function Wrapper() {
-          return use(htmlNode);
+        createElement(function HtmlNodeWrapper() {
+          return INTERNAL_use(htmlNode);
         }),
-        // htmlNode as any,
         ...headElements,
       ),
       {

--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -165,8 +165,8 @@ export async function renderHtml(
   // isolate `React.use` in its own component
   // https://github.com/facebook/react/issues/33937#issuecomment-3091349011
   function UseWrapper(props: { value: Promise<ReactNode> }) {
-    const used = INTERNAL_use(props.value);
-    return createElement(UseWrapperInner, null, used);
+    const resolved = INTERNAL_use(props.value);
+    return createElement(UseWrapperInner, null, resolved);
   }
   function UseWrapperInner(props: PropsWithChildren) {
     return props.children;

--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -108,7 +108,7 @@ export async function renderHtml(
   const {
     default: { createFromReadableStream },
   } = modules.rsdwClient as { default: typeof RSDWClientType };
-  const { INTERNAL_ServerRoot, INTERNAL_use } =
+  const { INTERNAL_ServerRoot } =
     modules.wakuMinimalClient as typeof WakuMinimalClientType;
 
   const stream = await renderRsc(config, ctx, elements, onError);
@@ -167,8 +167,8 @@ export async function renderHtml(
       // See: https://github.com/wakujs/waku/pull/1545
       // isolate `React.use` in its own component
       // https://github.com/facebook/react/issues/33937#issuecomment-3091349011
-      createElement(() => {
-        const resolvedHtmlNode = INTERNAL_use(htmlNode);
+      createElement(async () => {
+        const resolvedHtmlNode = await htmlNode;
         return createElement(HtmlNodeWrapper, null, resolvedHtmlNode);
       }),
       ...headElements,

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -361,13 +361,6 @@ export const Slot = ({
 const SlotElementWrapper = (props: { children: ReactNode }) => props.children;
 
 /**
- * re-export `use` for renderes/html
- * HACK: This is only for a workaround.
- * https://github.com/facebook/react/issues/33937
- */
-export const INTERNAL_use = use;
-
-/**
  * ServerRoot for SSR
  * This is not a public API.
  */

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -329,35 +329,6 @@ export const useElementsPromise_UNSTABLE = () => {
  *   <Root><Slot id="foo" /><Slot id="bar" /></Root>
  * ```
  */
-// export const Slot = ({
-//   id,
-//   children,
-// }: {
-//   id: string;
-//   children?: ReactNode;
-// }) => {
-//   const elementsPromise = useElementsPromise_UNSTABLE();
-//   const elements = use(elementsPromise);
-//   console.log('Slot:use(elementsPromise)', id, elements);
-//   if (id in elements && elements[id] === undefined) {
-//     throw new Error('Element cannot be undefined, use null instead: ' + id);
-//   }
-//   const element = elements[id];
-//   const isValidElement = element !== undefined;
-//   if (!isValidElement) {
-//     throw new Error('Invalid element: ' + id);
-//   }
-//   return createElement(
-//     ChildrenContextProvider,
-//     { value: children },
-//     // FIXME is there `isReactNode` type checker?
-//     element as ReactNode,
-//   );
-// };
-
-/** re-export use for renderes/html */
-export const INTERNAL_use = use;
-
 export const Slot = ({
   id,
   children,
@@ -387,6 +358,9 @@ export const Slot = ({
 const SlotElementWrapper: FC<PropsWithChildren> = (props) => {
   return props.children;
 };
+
+/** re-export use for renderes/html */
+export const INTERNAL_use = use;
 
 /**
  * ServerRoot for SSR

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -11,7 +11,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import type { FC, PropsWithChildren, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import RSDWClient from 'react-server-dom-webpack/client';
 
 import { createCustomError } from '../lib/utils/custom-errors.js';
@@ -349,17 +349,22 @@ export const Slot = ({
   return createElement(
     ChildrenContextProvider,
     { value: children },
+    // See: https://github.com/wakujs/waku/pull/1545
     // isolate potential `lazy + React.use` usage inside `element` in its own component
     // https://github.com/facebook/react/issues/33937#issuecomment-3091349011
     createElement(SlotElementWrapper, null, element as ReactNode),
   );
 };
 
-const SlotElementWrapper: FC<PropsWithChildren> = (props) => {
-  return props.children;
-};
+// HACK: This is only for a workaround.
+// https://github.com/facebook/react/issues/33937
+const SlotElementWrapper = (props: { children: ReactNode}) =>  props.children;
 
-/** re-export use for renderes/html */
+/**
+ * re-export `use` for renderes/html
+ * HACK: This is only for a workaround.
+ * https://github.com/facebook/react/issues/33937
+ */
 export const INTERNAL_use = use;
 
 /**

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -358,15 +358,12 @@ export const useElementsPromise_UNSTABLE = () => {
 /** re-export use for renderes/html */
 export const INTERNAL_use = use;
 
-// isolate `React.use` in its own component
-// to workaround https://github.com/facebook/react/issues/33937
-export const Slot: typeof SlotUseWrapper = (props) => {
-  return createElement(SlotUseWrapper, props);
-};
-
-const SlotUseWrapper: FC<{ id: string; children?: ReactNode }> = ({
+export const Slot = ({
   id,
   children,
+}: {
+  id: string;
+  children?: ReactNode;
 }) => {
   const elementsPromise = useElementsPromise_UNSTABLE();
   const elements = use(elementsPromise);
@@ -381,11 +378,9 @@ const SlotUseWrapper: FC<{ id: string; children?: ReactNode }> = ({
   return createElement(
     ChildrenContextProvider,
     { value: children },
-    // isolate potential `React.use` usage in its own component
-    // https://github.com/facebook/react/issues/33937
+    // isolate potential `lazy + React.use` usage inside `element` in its own component
+    // https://github.com/facebook/react/issues/33937#issuecomment-3091349011
     createElement(SlotElementWrapper, null, element as ReactNode),
-    // FIXME is there `isReactNode` type checker?
-    // element as ReactNode,
   );
 };
 

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -355,13 +355,16 @@ export const useElementsPromise_UNSTABLE = () => {
 //   );
 // };
 
+/** re-export use for renderes/html */
+export const INTERNAL_use = use;
+
 // isolate `React.use` in its own component
 // to workaround https://github.com/facebook/react/issues/33937
-export const Slot: typeof SlotInner = (props) => {
-  return createElement(SlotInner, props);
+export const Slot: typeof SlotUseWrapper = (props) => {
+  return createElement(SlotUseWrapper, props);
 };
 
-const SlotInner: FC<{ id: string; children?: ReactNode }> = ({
+const SlotUseWrapper: FC<{ id: string; children?: ReactNode }> = ({
   id,
   children,
 }) => {
@@ -380,13 +383,13 @@ const SlotInner: FC<{ id: string; children?: ReactNode }> = ({
     { value: children },
     // isolate potential `React.use` usage in its own component
     // https://github.com/facebook/react/issues/33937
-    createElement(Wrapper, null, element as ReactNode),
+    createElement(SlotElementWrapper, null, element as ReactNode),
     // FIXME is there `isReactNode` type checker?
     // element as ReactNode,
   );
 };
 
-const Wrapper: FC<PropsWithChildren> = (props) => {
+const SlotElementWrapper: FC<PropsWithChildren> = (props) => {
   return props.children;
 };
 

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -358,7 +358,7 @@ export const Slot = ({
 
 // HACK: This is only for a workaround.
 // https://github.com/facebook/react/issues/33937
-const SlotElementWrapper = (props: { children: ReactNode}) =>  props.children;
+const SlotElementWrapper = (props: { children: ReactNode }) => props.children;
 
 /**
  * re-export `use` for renderes/html


### PR DESCRIPTION
- Closes https://github.com/wakujs/waku/issues/1496

To understand better the nature of the React SSR bug https://github.com/facebook/react/issues/33937, this is an alternative approach of https://github.com/wakujs/waku/pull/1542.

See here https://github.com/facebook/react/issues/33937#issuecomment-3091349011 for how two approach differs.

I might like this approach better than adding DIY `use` since this way React SSR bug condition is better manifested by using only React API.