### PR TITLE
feat(fs-router): slice support for managed mode

### DIFF
--- a/e2e/fixtures/fs-router/src/pages/_components/_slice-one.tsx
+++ b/e2e/fixtures/fs-router/src/pages/_components/_slice-one.tsx
@@ -1,0 +1,10 @@
+export default function Slice001() {
+  return <h4 data-testid="slice001">Slice 001 ({Math.random()})</h4>;
+}
+
+export const getConfig = () => {
+  return {
+    render: 'dynamic',
+    id: 'slice001',
+  };
+};

--- a/e2e/fixtures/fs-router/src/pages/_components/_slice-two.tsx
+++ b/e2e/fixtures/fs-router/src/pages/_components/_slice-two.tsx
@@ -1,0 +1,10 @@
+export default function Slice002() {
+  return <h4 data-testid="slice002">Slice 002</h4>;
+}
+
+export const getConfig = () => {
+  return {
+    render: 'static',
+    id: 'slice002',
+  };
+};

--- a/e2e/fixtures/fs-router/src/pages/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/_layout.tsx
@@ -76,6 +76,9 @@ const HomeLayout = ({ children }: { children: ReactNode }) => (
       <li>
         <Link to="/page-parts">Page Parts</Link>
       </li>
+      <li>
+        <Link to="/slices">Slices</Link>
+      </li>
     </ul>
     {children}
   </div>

--- a/e2e/fixtures/fs-router/src/pages/slices/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/slices/index.tsx
@@ -1,0 +1,17 @@
+import { Slice } from 'waku/router/client';
+
+export default function Slices() {
+  return (
+    <>
+      <h2>Slices</h2>
+      <Slice id="slice001" />
+      <Slice id="slice002" />
+    </>
+  );
+}
+
+export const getConfig = () => {
+  return {
+    slices: ['slice001', 'slice002'],
+  };
+};

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -171,4 +171,16 @@ test.describe(`fs-router`, async () => {
       page.getByRole('heading', { name: 'Nested / encoded%20path' }),
     ).toBeVisible();
   });
+
+  test('slices', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/slices`);
+    await waitForHydration(page);
+    await expect(
+      page
+        .getByTestId('slice001')
+        .textContent.toString()
+        .startsWith('Slice 001'),
+    ).toBeTruthy();
+    await expect(page.getByTestId('slice002')).toHaveText('Slice 002');
+  });
 });

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -32,6 +32,7 @@ export function unstable_fsRouter(
       createRoot,
       createApi,
       createPagePart,
+      createSlice,
     }) => {
       let files = await unstable_getPlatformData<string[]>('fsRouterFiles');
       if (!files) {
@@ -93,6 +94,17 @@ export function unstable_fsRouter(
           .replace(/\.\w+$/, '')
           .split('/')
           .filter(Boolean);
+        // must come before isIgnoredPath check to include slices from inside _components
+        if (pathItems.at(-1)?.startsWith('_slice')) {
+          createSlice({
+            component: mod.default,
+            render: 'dynamic',
+            // Q: should we default to using the file name as the id?
+            // id: pathItems.at(-1)!.slice('_slice'.length),
+            ...config,
+          });
+          continue;
+        }
         if (isIgnoredPath(pathItems)) {
           continue;
         }


### PR DESCRIPTION
currently trying to overcome this error

```
Error: Invalid element: slice:slice001
    at Slot (file:///Users/tyler/gitspace/waku/packages/waku/dist/minimal/client.js:221:15)
```

it's confusing because `handleSlice` is not being called. And from checking logs both `createSlice` and `createPage` are called in the same way as the create-pages spec.

I'm probably missing something obvious so if someone sees the issue that'd be very helpful 🙌 