### PR TITLE
chore: simplify cloudflare `getEnv` example

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ pnpm-lock.yaml
 pnpm-workspace.yaml
 dist
 worker-configuration.d.ts
+.wrangler

--- a/examples/07_cloudflare/src/pages/index.tsx
+++ b/examples/07_cloudflare/src/pages/index.tsx
@@ -2,7 +2,8 @@ import { Link } from 'waku';
 import { Suspense } from 'react';
 import { Counter } from '../components/counter';
 import { getHonoContext } from '../lib/hono';
-import { getEnv, isBuild } from '../lib/waku';
+import { isBuild } from '../lib/waku';
+import { getEnv } from 'waku/server';
 
 export default async function HomePage() {
   const data = await getData();

--- a/examples/07_cloudflare/waku.cloudflare-dev-server.ts
+++ b/examples/07_cloudflare/waku.cloudflare-dev-server.ts
@@ -1,10 +1,14 @@
 import type { Hono } from 'hono';
 import type { BlankEnv, BlankSchema } from 'hono/types';
+import { INTERNAL_setAllEnv } from 'waku/server';
 
 export const cloudflareDevServer = (cfOptions: any) => {
-  const wranglerPromise = import('wrangler').then(({ getPlatformProxy }) =>
-    getPlatformProxy({ ...(cfOptions || {}) }),
-  );
+  const wranglerPromise = import('wrangler')
+    .then(({ getPlatformProxy }) => getPlatformProxy({ ...(cfOptions || {}) }))
+    .then((proxy) => {
+      INTERNAL_setAllEnv(proxy.env as any);
+      return proxy;
+    });
   const miniflarePromise = import('miniflare').then(({ WebSocketPair }) => {
     Object.assign(globalThis, { WebSocketPair });
   });


### PR DESCRIPTION
Related https://github.com/wakujs/waku/pull/1493#discussion_r2227172901

Currently `examples/07_cloudflare` doesn't use Waku's `getEnv` and manually access it through `getHonoContext`. This is not necessary on production since Cloudflare deploy entry uses cloudflare `env` properly.

https://github.com/wakujs/waku/blob/ee3adba8dd97947b17776c6a7bdda41de61a0fc4/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts#L66

On development with `getPlatformProxy`, the same can be done if we expose `INTERNAL_setAllEnv` and set them manually.