### PR TITLE
test: enforce react version for npm monorepo

### DIFF
--- a/e2e/fixtures/monorepo/package.json
+++ b/e2e/fixtures/monorepo/package.json
@@ -3,5 +3,9 @@
   "private": true,
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,7 +200,14 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
-  e2e/fixtures/monorepo: {}
+  e2e/fixtures/monorepo:
+    dependencies:
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
 
   e2e/fixtures/partial-build:
     dependencies:


### PR DESCRIPTION
npm peer dep resolution is a bit silly and it's installing react 19.1.1 and react-dom 19.1.0, which breaks the test. 

https://github.com/wakujs/waku/actions/runs/16591870176

```
[Child Process Error: e2e/utils.ts#L0](https://github.com/wakujs/waku/pull/1564/files#annotation_37188527137)
stderr: Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
  - react:      19.1.1
  - react-dom:  19.1.0
Learn more: https://react.dev/warnings/version-mismatch
```

I don't think React version resolution is the point of this test case, but it's for monorepo client component package compatibility, so ensuring React version here seems fine to reduce the noise on new React release.