### PR TITLE
chore: bump typescript

### DIFF
--- a/e2e/fixtures/broken-links/package.json
+++ b/e2e/fixtures/broken-links/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/create-pages/package.json
+++ b/e2e/fixtures/create-pages/package.json
@@ -19,6 +19,6 @@
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "server-only": "^0.0.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/define-router/package.json
+++ b/e2e/fixtures/define-router/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/fs-router/package.json
+++ b/e2e/fixtures/fs-router/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/hot-reload/package.json
+++ b/e2e/fixtures/hot-reload/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/partial-build/package.json
+++ b/e2e/fixtures/partial-build/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/render-type/package.json
+++ b/e2e/fixtures/render-type/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/rsc-asset/package.json
+++ b/e2e/fixtures/rsc-asset/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vite": "7.0.5"
   }
 }

--- a/e2e/fixtures/rsc-basic/package.json
+++ b/e2e/fixtures/rsc-basic/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/rsc-css-modules/package.json
+++ b/e2e/fixtures/rsc-css-modules/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/ssg-performance/package.json
+++ b/e2e/fixtures/ssg-performance/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/ssg-wildcard/package.json
+++ b/e2e/fixtures/ssg-wildcard/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/ssr-basic/package.json
+++ b/e2e/fixtures/ssr-basic/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vite": "7.0.5"
   }
 }

--- a/e2e/fixtures/ssr-catch-error/package.json
+++ b/e2e/fixtures/ssr-catch-error/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/ssr-context-provider/package.json
+++ b/e2e/fixtures/ssr-context-provider/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/ssr-redirect/package.json
+++ b/e2e/fixtures/ssr-redirect/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/ssr-swr/package.json
+++ b/e2e/fixtures/ssr-swr/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/ssr-target-bundle/package.json
+++ b/e2e/fixtures/ssr-target-bundle/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vite": "7.0.5"
   }
 }

--- a/e2e/fixtures/use-router/package.json
+++ b/e2e/fixtures/use-router/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/waku-jotai/package.json
+++ b/e2e/fixtures/waku-jotai/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/e2e/fixtures/wildcard-api-routes/package.json
+++ b/e2e/fixtures/wildcard-api-routes/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/examples/01_template/package.json
+++ b/examples/01_template/package.json
@@ -20,6 +20,6 @@
     "@types/react-dom": "19.1.7",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.11",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/03_demo/package.json
+++ b/examples/03_demo/package.json
@@ -20,6 +20,6 @@
     "@types/react-dom": "19.1.7",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.11",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/04_cssmodules/package.json
+++ b/examples/04_cssmodules/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/05_compiler/package.json
+++ b/examples/05_compiler/package.json
@@ -22,7 +22,7 @@
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.11",
-    "typescript": "5.8.3",
+    "typescript": "5.9.2",
     "vite": "7.0.5"
   }
 }

--- a/examples/06_form-demo/package.json
+++ b/examples/06_form-demo/package.json
@@ -20,6 +20,6 @@
     "@types/react-dom": "19.1.7",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.11",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/07_cloudflare/package.json
+++ b/examples/07_cloudflare/package.json
@@ -25,7 +25,7 @@
     "miniflare": "4.20250726.0",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.11",
-    "typescript": "5.8.3",
+    "typescript": "5.9.2",
     "vite": "7.0.5"
   }
 }

--- a/examples/08_jotai-demo/package.json
+++ b/examples/08_jotai-demo/package.json
@@ -22,6 +22,6 @@
     "@types/react-dom": "19.1.7",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.11",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/11_fs-router/package.json
+++ b/examples/11_fs-router/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3",
+    "typescript": "5.9.2",
     "vite": "7.0.5"
   }
 }

--- a/examples/12_nossr/package.json
+++ b/examples/12_nossr/package.json
@@ -21,7 +21,7 @@
     "postcss": "8.5.6",
     "rollup": "4.46.2",
     "tailwindcss": "4.1.11",
-    "typescript": "5.8.3",
+    "typescript": "5.9.2",
     "vite": "7.0.5"
   }
 }

--- a/examples/21_create-pages/package.json
+++ b/examples/21_create-pages/package.json
@@ -18,6 +18,6 @@
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
     "server-only": "0.0.1",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/22_define-router/package.json
+++ b/examples/22_define-router/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/31_minimal/package.json
+++ b/examples/31_minimal/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/33_promise/package.json
+++ b/examples/33_promise/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/34_functions/package.json
+++ b/examples/34_functions/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/35_nesting/package.json
+++ b/examples/35_nesting/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/36_form/package.json
+++ b/examples/36_form/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/38_cookies/package.json
+++ b/examples/38_cookies/package.json
@@ -21,6 +21,6 @@
     "@types/node": "24.1.0",
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/39_api/package.json
+++ b/examples/39_api/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/41_path-alias/package.json
+++ b/examples/41_path-alias/package.json
@@ -18,7 +18,7 @@
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
     "rollup": "4.46.2",
-    "typescript": "5.8.3",
+    "typescript": "5.9.2",
     "vite": "7.0.5",
     "vite-tsconfig-paths": "5.1.4"
   }

--- a/examples/42_react-tweet/package.json
+++ b/examples/42_react-tweet/package.json
@@ -21,6 +21,6 @@
     "@types/react-dom": "19.1.7",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.11",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/43_weave-render/package.json
+++ b/examples/43_weave-render/package.json
@@ -18,6 +18,6 @@
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
     "server-only": "0.0.1",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/45_view-transitions/package.json
+++ b/examples/45_view-transitions/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/51_spa/package.json
+++ b/examples/51_spa/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/52_tanstack-router/package.json
+++ b/examples/52_tanstack-router/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/53_islands/package.json
+++ b/examples/53_islands/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/examples/54_jotai/package.json
+++ b/examples/54_jotai/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "terminate": "^2.8.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "typescript-eslint": "^8.38.0",
     "waku": "workspace:*"
   }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -29,7 +29,7 @@
     "prettier-plugin-tailwindcss": "^0.6.14",
     "shiki": "^3.8.1",
     "tailwindcss": "4.1.11",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vite": "7.0.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.32.0(jiti@2.5.1))
@@ -57,11 +57,11 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       typescript-eslint:
         specifier: ^8.38.0
-        version: 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+        version: 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       waku:
         specifier: workspace:*
         version: link:packages/waku
@@ -91,8 +91,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/create-pages:
     dependencies:
@@ -122,8 +122,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/define-router:
     dependencies:
@@ -147,8 +147,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/fs-router:
     dependencies:
@@ -172,8 +172,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/hot-reload:
     dependencies:
@@ -197,8 +197,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/monorepo:
     dependencies:
@@ -234,8 +234,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/render-type:
     dependencies:
@@ -262,8 +262,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/rsc-asset:
     dependencies:
@@ -287,8 +287,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -318,8 +318,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/rsc-css-modules:
     dependencies:
@@ -343,8 +343,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/ssg-performance:
     dependencies:
@@ -368,8 +368,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/ssg-wildcard:
     dependencies:
@@ -393,8 +393,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/ssr-basic:
     dependencies:
@@ -421,8 +421,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -452,8 +452,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/ssr-context-provider:
     dependencies:
@@ -477,8 +477,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/ssr-redirect:
     dependencies:
@@ -502,8 +502,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/ssr-swr:
     dependencies:
@@ -530,8 +530,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/ssr-target-bundle:
     dependencies:
@@ -558,8 +558,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -586,8 +586,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/waku-jotai:
     dependencies:
@@ -617,8 +617,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/fixtures/wildcard-api-routes:
     dependencies:
@@ -642,8 +642,8 @@ importers:
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   examples/01_template:
     dependencies:
@@ -676,8 +676,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/02_template_js:
     dependencies:
@@ -735,8 +735,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/04_cssmodules:
     dependencies:
@@ -760,8 +760,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/05_compiler:
     dependencies:
@@ -800,8 +800,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -837,8 +837,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/07_cloudflare:
     dependencies:
@@ -883,8 +883,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -926,8 +926,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/11_fs-router:
     dependencies:
@@ -951,8 +951,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -991,8 +991,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -1022,8 +1022,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/22_define-router:
     dependencies:
@@ -1047,8 +1047,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/31_minimal:
     dependencies:
@@ -1072,8 +1072,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/32_minimal_js:
     dependencies:
@@ -1112,8 +1112,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/34_functions:
     dependencies:
@@ -1140,8 +1140,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/35_nesting:
     dependencies:
@@ -1165,8 +1165,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/36_form:
     dependencies:
@@ -1190,8 +1190,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/37_css:
     dependencies:
@@ -1332,8 +1332,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/39_api:
     dependencies:
@@ -1357,8 +1357,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/41_path-alias:
     dependencies:
@@ -1385,14 +1385,14 @@ importers:
         specifier: 4.46.2
         version: 4.46.2
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
       vite-tsconfig-paths:
         specifier: 5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0))
+        version: 5.1.4(typescript@5.9.2)(vite@7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0))
 
   examples/42_react-tweet:
     dependencies:
@@ -1428,8 +1428,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/43_weave-render:
     dependencies:
@@ -1456,8 +1456,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/45_view-transitions:
     dependencies:
@@ -1481,8 +1481,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/51_spa:
     dependencies:
@@ -1506,8 +1506,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/52_tanstack-router:
     dependencies:
@@ -1537,8 +1537,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/53_islands:
     dependencies:
@@ -1562,8 +1562,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   examples/54_jotai:
     dependencies:
@@ -1593,8 +1593,8 @@ importers:
         specifier: 19.1.7
         version: 19.1.7(@types/react@19.1.9)
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
 
   packages/create-waku:
     devDependencies:
@@ -1621,7 +1621,7 @@ importers:
         version: 7.4.3
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@swc/core@1.13.3(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.0)
+        version: 8.5.0(@swc/core@1.13.3(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.19.4)(typescript@5.9.2)(yaml@2.8.0)
       update-check:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1736,8 +1736,8 @@ importers:
         specifier: 4.1.11
         version: 4.1.11
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.5
         version: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
@@ -7179,8 +7179,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -9245,41 +9245,41 @@ snapshots:
       '@types/node': 24.1.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.38.0
       eslint: 9.32.0(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.38.0
       '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.38.0
       debug: 4.4.1
       eslint: 9.32.0(jiti@2.5.1)
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.38.0(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.38.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.38.0
       debug: 4.4.1
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9288,28 +9288,28 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/visitor-keys': 8.38.0
 
-  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.8.3)':
+  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.9.2)':
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       debug: 4.4.1
       eslint: 9.32.0(jiti@2.5.1)
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.38.0': {}
 
-  '@typescript-eslint/typescript-estree@8.38.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.38.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.38.0(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/project-service': 8.38.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/visitor-keys': 8.38.0
       debug: 4.4.1
@@ -9317,19 +9317,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
       '@typescript-eslint/scope-manager': 8.38.0
       '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
       eslint: 9.32.0(jiti@2.5.1)
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10416,16 +10416,16 @@ snapshots:
 
   detective-stylus@5.0.1: {}
 
-  detective-typescript@14.0.0(typescript@5.8.3):
+  detective-typescript@14.0.0(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
       ast-module-types: 6.0.1
       node-source-walk: 7.0.1
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  detective-vue2@2.2.0(typescript@5.8.3):
+  detective-vue2@2.2.0(typescript@5.9.2):
     dependencies:
       '@dependents/detective-less': 5.0.1
       '@vue/compiler-sfc': 3.5.18
@@ -10433,8 +10433,8 @@ snapshots:
       detective-sass: 6.0.1
       detective-scss: 5.0.1
       detective-stylus: 5.0.1
-      detective-typescript: 14.0.0(typescript@5.8.3)
-      typescript: 5.8.3
+      detective-typescript: 14.0.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10756,22 +10756,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10782,7 +10782,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10794,7 +10794,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -12594,12 +12594,12 @@ snapshots:
       detective-sass: 6.0.1
       detective-scss: 5.0.1
       detective-stylus: 5.0.1
-      detective-typescript: 14.0.0(typescript@5.8.3)
-      detective-vue2: 2.2.0(typescript@5.8.3)
+      detective-typescript: 14.0.0(typescript@5.9.2)
+      detective-vue2: 2.2.0(typescript@5.9.2)
       module-definition: 6.0.1
       node-source-walk: 7.0.1
       postcss: 8.5.6
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13494,17 +13494,17 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.1.0(typescript@5.8.3):
+  ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   ts-expect@1.3.0: {}
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.6(typescript@5.8.3):
+  tsconfck@3.1.6(typescript@5.9.2):
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -13515,7 +13515,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(@swc/core@1.13.3(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.0):
+  tsup@8.5.0(@swc/core@1.13.3(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.19.4)(typescript@5.9.2)(yaml@2.8.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.8)
       cac: 6.7.14
@@ -13537,7 +13537,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.13.3(@swc/helpers@0.5.17)
       postcss: 8.5.6
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -13595,18 +13595,18 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3):
+  typescript-eslint@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.32.0(jiti@2.5.1)
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.8.3: {}
+  typescript@5.9.2: {}
 
   ufo@1.6.1: {}
 
@@ -13830,11 +13830,11 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.8.3)
+      tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
       vite: 7.0.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:


### PR DESCRIPTION
changelog: https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/

I guess import defer could be an awesome feature we might use that (maybe)?