### PR TITLE
fix: silence unknown rsc error

### DIFF
--- a/packages/waku/src/vite-rsc/lib/render.ts
+++ b/packages/waku/src/vite-rsc/lib/render.ts
@@ -1,5 +1,5 @@
 import { renderToReadableStream } from '@vitejs/plugin-rsc/rsc';
-import { captureOwnerStack, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import type { HandleRequest } from '../../lib/types.js';
 
 export type RscElementsPayload = Record<string, unknown>;
@@ -20,7 +20,6 @@ export function createRenderUtils({
     ) {
       return e.digest;
     }
-    console.error('[RSC Error]', captureOwnerStack?.() || '', '\n', e);
   };
 
   return {


### PR DESCRIPTION
I've had this logging for both rsc and ssr renders, but rsc error logging didn't exist before, so this PR removes it for alignment. This `console.error` shows up as error annotation on CI, such as https://github.com/wakujs/waku/actions/runs/16700445432.

> [Child Process Error: e2e/utils.ts#L0](https://github.com/wakujs/waku/commit/54a620f3d35b390a690d9202f72897e4085c02d4#annotation_37372093067)
> stderr: [RSC Error] Error: Something unexpected happened at ErrorRender (file:///Users/runner/work/_temp/create-pageszpPvf0/dist/rsc/index.js:17434:9)