### PR TITLE
test: retry dev async redirection test

### DIFF
--- a/e2e/ssr-redirect.spec.ts
+++ b/e2e/ssr-redirect.spec.ts
@@ -21,6 +21,7 @@ test.describe(`ssr-redirect`, () => {
 
   test('access async page directly', async ({ page, mode }) => {
     // TODO: async redirection on dev is flaky, so wrap with retry for now
+    // https://github.com/wakujs/waku/pull/1586
     if (mode === 'DEV') {
       await expect(async () => {
         await page.goto(`http://localhost:${port}/async`);

--- a/e2e/ssr-redirect.spec.ts
+++ b/e2e/ssr-redirect.spec.ts
@@ -19,7 +19,15 @@ test.describe(`ssr-redirect`, () => {
     await expect(page.getByRole('heading')).toHaveText('Destination Page');
   });
 
-  test('access async page directly', async ({ page }) => {
+  test('access async page directly', async ({ page, mode }) => {
+    // TODO: async redirection on dev is flaky, so wrap with retry for now
+    if (mode === 'DEV') {
+      await expect(async () => {
+        await page.goto(`http://localhost:${port}/async`);
+        await expect(page.getByRole('heading')).toHaveText('Destination Page');
+      }).toPass();
+      return;
+    }
     await page.goto(`http://localhost:${port}/async`);
     await expect(page.getByRole('heading')).toHaveText('Destination Page');
   });


### PR DESCRIPTION
This is flaky and I can reproduce it locally either via `pnpm e2e-dev e2e/ssr-redirect.spec.ts -g 'access async page directly'` or just manually `pnpm -C e2e/fixtures/ssr-redirect dev` and accessing http://localhost:3000/async. It's likely due to after `@vitejs/plugin-rsc` migration, initial js waterfall makes hydration slower on dev. This PR fixes flakiness by retrying only this assertion though eventually we should figure out the actual cause.