### PR TITLE
refactor: simplify managed fs-router internal

### DIFF
--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -1,21 +1,20 @@
-// import {
-//   unstable_getPlatformData,
-//   unstable_setPlatformData,
-//   unstable_getBuildOptions,
-// } from '../server.js';
+import {
+  unstable_getPlatformData,
+  unstable_setPlatformData,
+  unstable_getBuildOptions,
+} from '../server.js';
 import { createPages, METHODS } from './create-pages.js';
 import type { Method } from './create-pages.js';
 
-// import { EXTENSIONS } from '../lib/builder/constants.js';
+import { EXTENSIONS } from '../lib/builder/constants.js';
 import { isIgnoredPath } from '../lib/utils/fs-router.js';
-import * as virtualFsRouter from 'virtual:vite-rsc-waku/fs-router';
 
-// const DO_NOT_BUNDLE = '';
+const DO_NOT_BUNDLE = '';
 
 export function unstable_fsRouter(
-  _importMetaUrl: string,
-  _loadPage: (file: string) => Promise<any> | undefined,
-  _options: {
+  importMetaUrl: string,
+  loadPage: (file: string) => Promise<any> | undefined,
+  options: {
     /** e.g. `"pages"` will detect pages in `src/pages`. */
     pagesDir: string;
     /**
@@ -23,9 +22,10 @@ export function unstable_fsRouter(
      * is `"foo"`, then it will detect pages in `src/foo/api`.
      */
     apiDir: string;
+    files?: string[];
   },
 ) {
-  // const buildOptions = unstable_getBuildOptions();
+  const buildOptions = unstable_getBuildOptions();
   return createPages(
     async ({
       createPage,
@@ -35,63 +35,62 @@ export function unstable_fsRouter(
       createPagePart,
       createSlice,
     }) => {
-      // let files = await unstable_getPlatformData<string[]>('fsRouterFiles');
-      // if (!files) {
-      //   // dev and build only
-      //   if (
-      //     import.meta.env &&
-      //     import.meta.env.MODE === 'production' &&
-      //     !buildOptions.unstable_phase
-      //   ) {
-      //     throw new Error('files must be set in production.');
-      //   }
-      //   const [
-      //     { readdir },
-      //     { join, dirname, extname, sep },
-      //     { fileURLToPath },
-      //   ] = await Promise.all([
-      //     import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:fs/promises'),
-      //     import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:path'),
-      //     import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:url'),
-      //   ]);
-      //   const pagesDir = join(
-      //     dirname(fileURLToPath(importMetaUrl)),
-      //     options.pagesDir,
-      //   );
-      //   files = await readdir(pagesDir, {
-      //     encoding: 'utf8',
-      //     recursive: true,
-      //   });
-      //   files = files!.flatMap((file) => {
-      //     const myExt = extname(file);
-      //     const myExtIndex = EXTENSIONS.indexOf(myExt);
-      //     if (myExtIndex === -1) {
-      //       return [];
-      //     }
-      //     // HACK: replace "_slug_" to "[slug]" for build
-      //     file = file.replace(/(?<=^|\/|\\)_([^/]+)_(?=\/|\\|\.)/g, '[$1]');
-      //     // For Windows
-      //     file = sep === '/' ? file : file.replace(/\\/g, '/');
-      //     // HACK: resolve different extensions for build
-      //     const exts = [myExt, ...EXTENSIONS];
-      //     exts.splice(myExtIndex + 1, 1); // remove the second myExt
-      //     for (const ext of exts) {
-      //       const f = file.slice(0, -myExt.length) + ext;
-      //       if (loadPage(f)) {
-      //         return [f];
-      //       }
-      //     }
-      //     throw new Error('Failed to resolve ' + file);
-      //   });
-      // }
-      const files = virtualFsRouter.files;
+      let files = options.files;
+      files ??= await unstable_getPlatformData<string[]>('fsRouterFiles');
+      if (!files) {
+        // dev and build only
+        if (
+          import.meta.env &&
+          import.meta.env.MODE === 'production' &&
+          !buildOptions.unstable_phase
+        ) {
+          throw new Error('files must be set in production.');
+        }
+        const [
+          { readdir },
+          { join, dirname, extname, sep },
+          { fileURLToPath },
+        ] = await Promise.all([
+          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:fs/promises'),
+          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:path'),
+          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:url'),
+        ]);
+        const pagesDir = join(
+          dirname(fileURLToPath(importMetaUrl)),
+          options.pagesDir,
+        );
+        files = await readdir(pagesDir, {
+          encoding: 'utf8',
+          recursive: true,
+        });
+        files = files!.flatMap((file) => {
+          const myExt = extname(file);
+          const myExtIndex = EXTENSIONS.indexOf(myExt);
+          if (myExtIndex === -1) {
+            return [];
+          }
+          // HACK: replace "_slug_" to "[slug]" for build
+          file = file.replace(/(?<=^|\/|\\)_([^/]+)_(?=\/|\\|\.)/g, '[$1]');
+          // For Windows
+          file = sep === '/' ? file : file.replace(/\\/g, '/');
+          // HACK: resolve different extensions for build
+          const exts = [myExt, ...EXTENSIONS];
+          exts.splice(myExtIndex + 1, 1); // remove the second myExt
+          for (const ext of exts) {
+            const f = file.slice(0, -myExt.length) + ext;
+            if (loadPage(f)) {
+              return [f];
+            }
+          }
+          throw new Error('Failed to resolve ' + file);
+        });
+      }
       // build only - skip in dev
-      // if (buildOptions.unstable_phase) {
-      //   await unstable_setPlatformData('fsRouterFiles', files, true);
-      // }
+      if (buildOptions.unstable_phase) {
+        await unstable_setPlatformData('fsRouterFiles', files, true);
+      }
       for (const file of files) {
-        // const mod = await loadPage(file);
-        const mod = await virtualFsRouter.loadPage(file);
+        const mod = await loadPage(file);
         const config = await mod.getConfig?.();
         const pathItems = file
           .replace(/\.\w+$/, '')
@@ -121,7 +120,7 @@ export function unstable_fsRouter(
           throw new Error(
             'Page file cannot be named [path]. This will conflict with the path prop of the page component.',
           );
-        } else if (pathItems.at(0) === virtualFsRouter.apiDir) {
+        } else if (pathItems.at(0) === options.apiDir) {
           if (config?.render === 'static') {
             if (Object.keys(mod).length !== 2 || !mod.GET) {
               console.warn(

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -1,21 +1,21 @@
-import {
-  unstable_getPlatformData,
-  unstable_setPlatformData,
-  unstable_getBuildOptions,
-} from '../server.js';
+// import {
+//   unstable_getPlatformData,
+//   unstable_setPlatformData,
+//   unstable_getBuildOptions,
+// } from '../server.js';
 import { createPages, METHODS } from './create-pages.js';
 import type { Method } from './create-pages.js';
 
-import { EXTENSIONS } from '../lib/builder/constants.js';
+// import { EXTENSIONS } from '../lib/builder/constants.js';
 import { isIgnoredPath } from '../lib/utils/fs-router.js';
 import * as virtualFsRouter from 'virtual:vite-rsc-waku/fs-router';
 
-const DO_NOT_BUNDLE = '';
+// const DO_NOT_BUNDLE = '';
 
 export function unstable_fsRouter(
-  importMetaUrl: string,
-  loadPage: (file: string) => Promise<any> | undefined,
-  options: {
+  _importMetaUrl: string,
+  _loadPage: (file: string) => Promise<any> | undefined,
+  _options: {
     /** e.g. `"pages"` will detect pages in `src/pages`. */
     pagesDir: string;
     /**
@@ -25,7 +25,7 @@ export function unstable_fsRouter(
     apiDir: string;
   },
 ) {
-  const buildOptions = unstable_getBuildOptions();
+  // const buildOptions = unstable_getBuildOptions();
   return createPages(
     async ({
       createPage,

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -8,6 +8,7 @@ import type { Method } from './create-pages.js';
 
 import { EXTENSIONS } from '../lib/builder/constants.js';
 import { isIgnoredPath } from '../lib/utils/fs-router.js';
+import * as virtualFsRouter from 'virtual:vite-rsc-waku/fs-router';
 
 const DO_NOT_BUNDLE = '';
 
@@ -34,61 +35,63 @@ export function unstable_fsRouter(
       createPagePart,
       createSlice,
     }) => {
-      let files = await unstable_getPlatformData<string[]>('fsRouterFiles');
-      if (!files) {
-        // dev and build only
-        if (
-          import.meta.env &&
-          import.meta.env.MODE === 'production' &&
-          !buildOptions.unstable_phase
-        ) {
-          throw new Error('files must be set in production.');
-        }
-        const [
-          { readdir },
-          { join, dirname, extname, sep },
-          { fileURLToPath },
-        ] = await Promise.all([
-          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:fs/promises'),
-          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:path'),
-          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:url'),
-        ]);
-        const pagesDir = join(
-          dirname(fileURLToPath(importMetaUrl)),
-          options.pagesDir,
-        );
-        files = await readdir(pagesDir, {
-          encoding: 'utf8',
-          recursive: true,
-        });
-        files = files!.flatMap((file) => {
-          const myExt = extname(file);
-          const myExtIndex = EXTENSIONS.indexOf(myExt);
-          if (myExtIndex === -1) {
-            return [];
-          }
-          // HACK: replace "_slug_" to "[slug]" for build
-          file = file.replace(/(?<=^|\/|\\)_([^/]+)_(?=\/|\\|\.)/g, '[$1]');
-          // For Windows
-          file = sep === '/' ? file : file.replace(/\\/g, '/');
-          // HACK: resolve different extensions for build
-          const exts = [myExt, ...EXTENSIONS];
-          exts.splice(myExtIndex + 1, 1); // remove the second myExt
-          for (const ext of exts) {
-            const f = file.slice(0, -myExt.length) + ext;
-            if (loadPage(f)) {
-              return [f];
-            }
-          }
-          throw new Error('Failed to resolve ' + file);
-        });
-      }
+      // let files = await unstable_getPlatformData<string[]>('fsRouterFiles');
+      // if (!files) {
+      //   // dev and build only
+      //   if (
+      //     import.meta.env &&
+      //     import.meta.env.MODE === 'production' &&
+      //     !buildOptions.unstable_phase
+      //   ) {
+      //     throw new Error('files must be set in production.');
+      //   }
+      //   const [
+      //     { readdir },
+      //     { join, dirname, extname, sep },
+      //     { fileURLToPath },
+      //   ] = await Promise.all([
+      //     import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:fs/promises'),
+      //     import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:path'),
+      //     import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:url'),
+      //   ]);
+      //   const pagesDir = join(
+      //     dirname(fileURLToPath(importMetaUrl)),
+      //     options.pagesDir,
+      //   );
+      //   files = await readdir(pagesDir, {
+      //     encoding: 'utf8',
+      //     recursive: true,
+      //   });
+      //   files = files!.flatMap((file) => {
+      //     const myExt = extname(file);
+      //     const myExtIndex = EXTENSIONS.indexOf(myExt);
+      //     if (myExtIndex === -1) {
+      //       return [];
+      //     }
+      //     // HACK: replace "_slug_" to "[slug]" for build
+      //     file = file.replace(/(?<=^|\/|\\)_([^/]+)_(?=\/|\\|\.)/g, '[$1]');
+      //     // For Windows
+      //     file = sep === '/' ? file : file.replace(/\\/g, '/');
+      //     // HACK: resolve different extensions for build
+      //     const exts = [myExt, ...EXTENSIONS];
+      //     exts.splice(myExtIndex + 1, 1); // remove the second myExt
+      //     for (const ext of exts) {
+      //       const f = file.slice(0, -myExt.length) + ext;
+      //       if (loadPage(f)) {
+      //         return [f];
+      //       }
+      //     }
+      //     throw new Error('Failed to resolve ' + file);
+      //   });
+      // }
+      const files = virtualFsRouter.files;
       // build only - skip in dev
-      if (buildOptions.unstable_phase) {
-        await unstable_setPlatformData('fsRouterFiles', files, true);
-      }
+      // if (buildOptions.unstable_phase) {
+      //   await unstable_setPlatformData('fsRouterFiles', files, true);
+      // }
       for (const file of files) {
-        const mod = await loadPage(file);
+        // const mod = await loadPage(file);
+        const mod = await virtualFsRouter.loadPage(file);
         const config = await mod.getConfig?.();
         const pathItems = file
           .replace(/\.\w+$/, '')
@@ -118,7 +121,7 @@ export function unstable_fsRouter(
           throw new Error(
             'Page file cannot be named [path]. This will conflict with the path prop of the page component.',
           );
-        } else if (pathItems.at(0) === options.apiDir) {
+        } else if (pathItems.at(0) === virtualFsRouter.apiDir) {
           if (config?.render === 'static') {
             if (Object.keys(mod).length !== 2 || !mod.GET) {
               console.warn(

--- a/packages/waku/src/vite-rsc/plugin.ts
+++ b/packages/waku/src/vite-rsc/plugin.ts
@@ -563,7 +563,6 @@ export default fsRouter('', loadPage, { pagesDir, apiDir, files });
       },
     },
     rscIndexPlugin(),
-    fsRouterPlugin({ config }),
     fsRouterTypegenPlugin({ srcDir: config.srcDir }),
     !!(
       flags['with-vercel'] ||
@@ -591,28 +590,6 @@ export default fsRouter('', loadPage, { pagesDir, apiDir, files });
         config,
         streaming: process.env.DEPLOY_AWS_LAMBDA_STREAMING === 'true',
       }),
-  ];
-}
-
-function fsRouterPlugin({ config }: { config: Required<Config> }): Plugin[] {
-  return [
-    createVirtualPlugin('vite-rsc-waku/fs-router', async function () {
-      const globBase = `/${config.srcDir}/${config.pagesDir}/`;
-      const globPattern = `${globBase}**/*.{${EXTENSIONS.map((ext) => ext.slice(1)).join(',')}}`;
-      const output = `\
-const glob = import.meta.glob(${JSON.stringify(globPattern)});
-const globBase = ${JSON.stringify(globBase)};
-const files = Object.keys(glob).map(file => file.slice(globBase.length));
-const loadPage = (file) => glob[globBase + file]();
-const apiDir = ${JSON.stringify(config.apiDir)};
-export {
-  files,
-  loadPage,
-  apiDir,
-};
-`;
-      return output;
-    }),
   ];
 }
 

--- a/packages/waku/src/vite-rsc/plugin.ts
+++ b/packages/waku/src/vite-rsc/plugin.ts
@@ -16,10 +16,7 @@ import fs from 'node:fs';
 import type { Config } from '../config.js';
 import { INTERNAL_setAllEnv, unstable_getBuildOptions } from '../server.js';
 import { emitStaticFile, waitForTasks } from '../lib/builder/build.js';
-import {
-  getManagedEntries,
-  getManagedMain,
-} from '../lib/plugins/vite-plugin-rsc-managed.js';
+import { getManagedMain } from '../lib/plugins/vite-plugin-rsc-managed.js';
 import { deployVercelPlugin } from './deploy/vercel/plugin.js';
 import { allowServerPlugin } from './plugins/allow-server.js';
 import {
@@ -290,17 +287,18 @@ if (import.meta.hot) {
 `;
         }
         if (id === '\0virtual:vite-rsc-waku/server-entry-inner') {
-          return getManagedEntries(
-            joinPath(
-              this.environment.config.root,
-              `${config.srcDir}/server-entry.js`,
-            ),
-            'src',
-            {
-              pagesDir: config.pagesDir,
-              apiDir: config.apiDir,
-            },
-          );
+          const globBase = `/${config.srcDir}/${config.pagesDir}/`;
+          const globPattern = `${globBase}**/*.{${EXTENSIONS.map((ext) => ext.slice(1)).join(',')}}`;
+          return `
+import { unstable_fsRouter as fsRouter } from 'waku/router/server';
+const glob = import.meta.glob(${JSON.stringify(globPattern)});
+const globBase = ${JSON.stringify(globBase)};
+const files = Object.keys(glob).map(file => file.slice(globBase.length));
+const loadPage = (file) => glob[globBase + file]();
+const apiDir = ${JSON.stringify(config.apiDir)};
+const pagesDir = ${JSON.stringify(config.pagesDir)};
+export default fsRouter('', loadPage, { pagesDir, apiDir, files });
+`;
         }
         if (id === '\0virtual:vite-rsc-waku/client-entry') {
           return getManagedMain();

--- a/packages/waku/src/vite-rsc/types.d.ts
+++ b/packages/waku/src/vite-rsc/types.d.ts
@@ -32,3 +32,18 @@ declare module 'virtual:vite-rsc-waku/fallback-html' {
   const default_: string;
   export default default_;
 }
+
+declare module 'virtual:vite-rsc-waku/fs-router' {
+  // const default_: string;
+  // export default default_;
+  export const files: string[];
+  export const loadPage: (file: string) => Promise<any>;
+  // export const loadPage: (file: string) => Promise<{
+  //   default: import("react").FC,
+  //   getConfig?: () => Promise<{
+  //     render?: 'dynamic' | 'static',
+  //   }>,
+  //   GET: (request: Request) => Promise<Response>,
+  // }>;
+  export const apiDir: string;
+}

--- a/packages/waku/src/vite-rsc/types.d.ts
+++ b/packages/waku/src/vite-rsc/types.d.ts
@@ -32,18 +32,3 @@ declare module 'virtual:vite-rsc-waku/fallback-html' {
   const default_: string;
   export default default_;
 }
-
-declare module 'virtual:vite-rsc-waku/fs-router' {
-  // const default_: string;
-  // export default default_;
-  export const files: string[];
-  export const loadPage: (file: string) => Promise<any>;
-  // export const loadPage: (file: string) => Promise<{
-  //   default: import("react").FC,
-  //   getConfig?: () => Promise<{
-  //     render?: 'dynamic' | 'static',
-  //   }>,
-  //   GET: (request: Request) => Promise<Response>,
-  // }>;
-  export const apiDir: string;
-}


### PR DESCRIPTION
This PR moves file crawling logic from runtime (dev and handleBuild) to plugin side main process. This is one necessary step for adopting cloudflare runtime https://github.com/wakujs/waku/issues/1596.