### PR TITLE
test: test css code split

### DIFF
--- a/e2e/fixtures/fs-router/src/pages/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/_layout.tsx
@@ -79,6 +79,9 @@ const HomeLayout = ({ children }: { children: ReactNode }) => (
       <li>
         <Link to="/page-with-slices">Page with Slices</Link>
       </li>
+      <li>
+        <Link to="/css-split">Css split</Link>
+      </li>
     </ul>
     {children}
   </div>

--- a/e2e/fixtures/fs-router/src/pages/css-split/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/css-split/_layout.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from 'react';
+import { Link } from 'waku';
+
+export default function Layout(props: PropsWithChildren) {
+  return (
+    <div>
+      <h4>Css code split test (page1: red, page2: blue)</h4>
+      <ul>
+        <li>
+          <Link to="/css-split/page1">Page 1</Link>
+        </li>
+        <li>
+          <Link to="/css-split/page1/nested">Page 1 Nested</Link>
+        </li>
+        <li>
+          <Link to="/css-split/page2">Page 2</Link>
+        </li>
+        <li>
+          <Link to="/css-split/page2/nested">Page 2 Nested</Link>
+        </li>
+      </ul>
+      <div>{props.children}</div>
+    </div>
+  );
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/css-split/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div className="test-css-split">css-split / index </div>;
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/page1/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/css-split/page1/_layout.tsx
@@ -1,0 +1,6 @@
+import './styles.css';
+import type { PropsWithChildren } from 'react';
+
+export default function Layout(props: PropsWithChildren) {
+  return props.children;
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/page1/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/css-split/page1/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div className="test-css-split">css-split / page1 / index</div>;
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/page1/nested/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/css-split/page1/nested/index.tsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return (
+    <div className="test-css-split">css-split / page1 / nested / index</div>
+  );
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/page1/styles.css
+++ b/e2e/fixtures/fs-router/src/pages/css-split/page1/styles.css
@@ -1,0 +1,3 @@
+.test-css-split {
+  color: red;
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/page2/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/css-split/page2/_layout.tsx
@@ -1,0 +1,6 @@
+import './styles.css';
+import type { PropsWithChildren } from 'react';
+
+export default function Layout(props: PropsWithChildren) {
+  return props.children;
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/page2/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/css-split/page2/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div className="test-css-split">css-split / page2 / index</div>;
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/page2/nested/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/css-split/page2/nested/index.tsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return (
+    <div className="test-css-split">css-split / page2 / nested / index</div>
+  );
+}

--- a/e2e/fixtures/fs-router/src/pages/css-split/page2/styles.css
+++ b/e2e/fixtures/fs-router/src/pages/css-split/page2/styles.css
@@ -1,0 +1,3 @@
+.test-css-split {
+  color: blue;
+}

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -180,28 +180,32 @@ test.describe(`fs-router`, async () => {
     await expect(page.getByTestId('slice002')).toHaveText('Slice 002');
   });
 
-  test("css split", async ({ page }) => {
-    // each ssr-ed page includes split css 
+  test('css split', async ({ page }) => {
+    // each ssr-ed page includes split css
     await page.goto(`http://localhost:${port}/css-split/page1`);
     await expect(page.getByText('css-split / page1 / index')).toHaveCSS(
       'color',
       'rgb(255, 0, 0)', // red
-    )
+    );
     await page.goto(`http://localhost:${port}/css-split/page1/nested`);
-    await expect(page.getByText('css-split / page1 / nested / index')).toHaveCSS(
+    await expect(
+      page.getByText('css-split / page1 / nested / index'),
+    ).toHaveCSS(
       'color',
       'rgb(255, 0, 0)', // red
-    )
+    );
     await page.goto(`http://localhost:${port}/css-split/page2`);
     await expect(page.getByText('css-split / page2 / index')).toHaveCSS(
       'color',
       'rgb(0, 0, 255)', // blue
-    )
+    );
     await page.goto(`http://localhost:${port}/css-split/page2/nested`);
-    await expect(page.getByText('css-split / page2 / nested / index')).toHaveCSS(
+    await expect(
+      page.getByText('css-split / page2 / nested / index'),
+    ).toHaveCSS(
       'color',
       'rgb(0, 0, 255)', // blue
-    )
+    );
 
     // client navigation cannot remove existing styles
     // page1 -> red
@@ -212,16 +216,16 @@ test.describe(`fs-router`, async () => {
     await expect(page.getByText('css-split / page1 / index')).toHaveCSS(
       'color',
       'rgb(255, 0, 0)', // red
-    )
+    );
     await page.click("a[href='/css-split/page2']");
     await expect(page.getByText('css-split / page2 / index')).toHaveCSS(
       'color',
       'rgb(0, 0, 255)', // blue
-    )
+    );
     await page.click("a[href='/css-split/page1']");
     await expect(page.getByText('css-split / page1 / index')).toHaveCSS(
       'color',
       'rgb(0, 0, 255)', // blue
-    )
-  })
+    );
+  });
 });

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -179,4 +179,49 @@ test.describe(`fs-router`, async () => {
     expect(sliceText?.startsWith('Slice 001')).toBeTruthy();
     await expect(page.getByTestId('slice002')).toHaveText('Slice 002');
   });
+
+  test("css split", async ({ page }) => {
+    // each ssr-ed page includes split css 
+    await page.goto(`http://localhost:${port}/css-split/page1`);
+    await expect(page.getByText('css-split / page1 / index')).toHaveCSS(
+      'color',
+      'rgb(255, 0, 0)', // red
+    )
+    await page.goto(`http://localhost:${port}/css-split/page1/nested`);
+    await expect(page.getByText('css-split / page1 / nested / index')).toHaveCSS(
+      'color',
+      'rgb(255, 0, 0)', // red
+    )
+    await page.goto(`http://localhost:${port}/css-split/page2`);
+    await expect(page.getByText('css-split / page2 / index')).toHaveCSS(
+      'color',
+      'rgb(0, 0, 255)', // blue
+    )
+    await page.goto(`http://localhost:${port}/css-split/page2/nested`);
+    await expect(page.getByText('css-split / page2 / nested / index')).toHaveCSS(
+      'color',
+      'rgb(0, 0, 255)', // blue
+    )
+
+    // client navigation cannot remove existing styles
+    // page1 -> red
+    // page2 -> blue
+    // page1 -> blue (last stylesheet wins)
+    await page.goto(`http://localhost:${port}/css-split/page1`);
+    await waitForHydration(page);
+    await expect(page.getByText('css-split / page1 / index')).toHaveCSS(
+      'color',
+      'rgb(255, 0, 0)', // red
+    )
+    await page.click("a[href='/css-split/page2']");
+    await expect(page.getByText('css-split / page2 / index')).toHaveCSS(
+      'color',
+      'rgb(0, 0, 255)', // blue
+    )
+    await page.click("a[href='/css-split/page1']");
+    await expect(page.getByText('css-split / page1 / index')).toHaveCSS(
+      'color',
+      'rgb(0, 0, 255)', // blue
+    )
+  })
 });


### PR DESCRIPTION
- Closes https://github.com/wakujs/waku/issues/752

This adds a test case for css code splitting in fs-router. The test verifies css is separately loaded initially depending on page structure, but as per React's "special rendering behavior", once loaded styles cannot be removed later on after route change. https://react.dev/reference/react-dom/components/style

> React may leave the style in the DOM even after the component that rendered it has been unmounted.

## demo

https://github.com/user-attachments/assets/8b48ddd7-cd7c-4b4d-bd0a-c9dba0b1015b

