### PR TITLE
fix: remove `order: 'post'` from ssg `buildApp` hook

### DIFF
--- a/packages/waku/src/vite-rsc/plugin.ts
+++ b/packages/waku/src/vite-rsc/plugin.ts
@@ -98,6 +98,7 @@ export function mainPlugin(
       serverHandler: false,
       keepUseCientProxy: true,
       ignoredPackageWarnings: [/.*/],
+      useBuildAppHook: true,
     }),
     {
       name: 'rsc:waku',
@@ -436,7 +437,6 @@ if (import.meta.hot) {
       },
       // cf. packages/waku/src/lib/builder/build.ts
       buildApp: {
-        order: 'post',
         async handler(builder) {
           // import server entry
           const viteConfig = builder.config;


### PR DESCRIPTION
I'm looking into integrating Nitro as plugin https://github.com/hi-ogawa/vite-plugins/tree/main/packages/nitro but I realized it's not possible to run nitro plugin's `buildApp` hook after Waku's ssg because of `order: 'post'`. This PR removes it so that user land `buildApp` (including nitro plugin) can run after Waku ssg.

```js
import { defineConfig } from "waku/config"
import nitro from "@hiogawa/vite-plugin-nitro";

export default defineConfig({
  vite: {
    plugins: [
      nitro({
        server: {
          environmentName: "rsc",
        },
      }),
    ],
  }
})
```