### PR TITLE
ci: ensure latest rsc plugin canary/experimental package

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,19 +95,12 @@ jobs:
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
       - if: ${{ inputs.react_version }}
         run: pnpm -r update react@${{ inputs.react_version }} react-dom@${{ inputs.react_version }} react-server-dom-webpack@${{ inputs.react_version }}
-      - if: ${{ inputs.react_version == 'canary' }}
-        # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
+      # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
+      - if: ${{ inputs.react_version == 'canary' || inputs.react_version == 'experimental' }}
         run: |
           COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
-          pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-canary@$COMMIT_SHA"
+          pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-${{ inputs.react_version }}@$COMMIT_SHA"
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - if: ${{ inputs.react_version == 'experimental' }}
-        # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
-        run: |
-          COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
-          pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-experimental@$COMMIT_SHA"
         env:
           GH_TOKEN: ${{ github.token }}
       - run: pnpm install

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,8 +42,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: ''
-      - run: pnpm -r update react@canary react-dom@canary react-server-dom-webpack@canary
+          cache: ${{ !inputs.react_version && 'pnpm' || '' }}
+      - if: ${{ inputs.react_version }}
+        run: pnpm -r update react@${{ inputs.react_version }} react-dom@${{ inputs.react_version }} react-server-dom-webpack@${{ inputs.react_version }}
       - run: pnpm install
       - run: pnpm run compile
       - uses: actions/upload-artifact@v4
@@ -62,7 +63,7 @@ jobs:
           if-no-files-found: error
 
   e2e:
-    name: E2E on ${{ matrix.os }} (Node ${{ matrix.version }}) - (${{ matrix.shared }}/4) with react@canary
+    name: E2E on ${{ matrix.os }} (Node ${{ matrix.version }}) - (${{ matrix.shared }}/4)${{ inputs.react_version && format(' with react@{0}', inputs.react_version) || '' }}
     needs:
       - build
     strategy:
@@ -91,13 +92,22 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
-          cache: ''
-      - run: pnpm -r update react@canary react-dom@canary react-server-dom-webpack@canary
-      - # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
+          cache: ${{ !inputs.react_version && 'pnpm' || '' }}
+      - if: ${{ inputs.react_version }}
+        run: pnpm -r update react@${{ inputs.react_version }} react-dom@${{ inputs.react_version }} react-server-dom-webpack@${{ inputs.react_version }}
+      - if: ${{ inputs.react_version == 'canary' }}
+        # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
         run: |
           COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
           pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-canary@$COMMIT_SHA"
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - if: ${{ inputs.react_version == 'experimental' }}
+        # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
+        run: |
+          COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
+          pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-experimental@$COMMIT_SHA"
         env:
           GH_TOKEN: ${{ github.token }}
       - run: pnpm install

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,9 +42,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: ${{ !inputs.react_version && 'pnpm' || '' }}
-      - if: ${{ inputs.react_version }}
-        run: pnpm -r update react@${{ inputs.react_version }} react-dom@${{ inputs.react_version }} react-server-dom-webpack@${{ inputs.react_version }}
+          cache: ''
+      - run: pnpm -r update react@canary react-dom@canary react-server-dom-webpack@canary
       - run: pnpm install
       - run: pnpm run compile
       - uses: actions/upload-artifact@v4
@@ -63,7 +62,7 @@ jobs:
           if-no-files-found: error
 
   e2e:
-    name: E2E on ${{ matrix.os }} (Node ${{ matrix.version }}) - (${{ matrix.shared }}/4)${{ inputs.react_version && format(' with react@{0}', inputs.react_version) || '' }}
+    name: E2E on ${{ matrix.os }} (Node ${{ matrix.version }}) - (${{ matrix.shared }}/4) with react@canary
     needs:
       - build
     strategy:
@@ -92,21 +91,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
-          cache: ${{ !inputs.react_version && 'pnpm' || '' }}
-      - if: ${{ inputs.react_version }}
-        run: pnpm -r update react@${{ inputs.react_version }} react-dom@${{ inputs.react_version }} react-server-dom-webpack@${{ inputs.react_version }}
-      - if: ${{ inputs.react_version == 'canary' }}
-        # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
+          cache: ''
+      - run: pnpm -r update react@canary react-dom@canary react-server-dom-webpack@canary
+      - # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
         run: |
           COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
           pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-canary@$COMMIT_SHA"
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - if: ${{ inputs.react_version == 'experimental' }}
-        # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
-        run: |
-          COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
-          pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-experimental@$COMMIT_SHA"
         env:
           GH_TOKEN: ${{ github.token }}
       - run: pnpm install

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,6 +97,7 @@ jobs:
         run: |
           COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
           pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-canary@$COMMIT_SHA"
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
       - run: pnpm install

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,10 +97,18 @@ jobs:
         run: pnpm -r update react@${{ inputs.react_version }} react-dom@${{ inputs.react_version }} react-server-dom-webpack@${{ inputs.react_version }}
       - if: ${{ inputs.react_version == 'canary' }}
         # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
-        run: pnpm -r update @vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-canary@524
+        run: |
+          COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
+          pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-canary@$COMMIT_SHA"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - if: ${{ inputs.react_version == 'experimental' }}
         # overrides canary/experimental build from https://github.com/vitejs/vite-plugin-react/pull/524
-        run: pnpm -r update @vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-experimental@524
+        run: |
+          COMMIT_SHA=$(gh api repos/vitejs/vite-plugin-react/pulls/524 --jq '.head.sha')
+          pnpm -r update "@vitejs/plugin-rsc@https://pkg.pr.new/vitejs/vite-plugin-react/@vitejs/plugin-rsc-experimental@$COMMIT_SHA"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - run: pnpm install
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This may or may not related to the canary failure https://github.com/wakujs/waku/pull/1611, but I noticed pkg.pr.new is returning stale package when installing `@524` (it's possible that this is because of pnpm bug of local cache, so it might not happen on fresh CI). I updated ci job to specify by the latest commit to ensure latest build.