### PR TITLE
fix(define-router): dynamic slices in static pages

### DIFF
--- a/e2e/define-router.spec.ts
+++ b/e2e/define-router.spec.ts
@@ -45,18 +45,18 @@ test.describe(`define-router`, () => {
   });
 
   test('bar2 (static page + dynamic slice)', async ({ page, mode }) => {
-    await page.goto(`http://localhost:${port}/`);
+    await page.goto(`http://localhost:${port}/bar2`);
     await waitForHydration(page);
-    await expect(page.getByTestId('home-title')).toHaveText('Home');
-    const sliceText = await page.getByTestId('slice002').textContent();
-    expect(sliceText?.startsWith('Slice 002')).toBeTruthy();
-    await page.click("a[href='/bar2']");
     await expect(page.getByTestId('bar2-title')).toHaveText('Bar2');
     const randomText = await page.getByTestId('bar2-random').textContent();
+    const sliceText = await page.getByTestId('slice002').textContent();
+    expect(sliceText?.startsWith('Slice 002')).toBeTruthy();
+    await page.click("a[href='/']");
+    await expect(page.getByTestId('home-title')).toHaveText('Home');
+    await page.click("a[href='/bar2']");
+    await expect(page.getByTestId('bar2-title')).toHaveText('Bar2');
     const sliceText2 = await page.getByTestId('slice002').textContent();
     expect(sliceText2 !== sliceText).toBeTruthy();
-    await page.reload();
-    await expect(page.getByTestId('bar2-title')).toHaveText('Bar2');
     if (mode === 'PRD') {
       const randomText2 = await page.getByTestId('bar2-random').textContent();
       expect(randomText === randomText2).toBeTruthy();
@@ -83,18 +83,18 @@ test.describe(`define-router`, () => {
   });
 
   test('baz2 (static page + lazy dynamic slice)', async ({ page, mode }) => {
-    await page.goto(`http://localhost:${port}/`);
+    await page.goto(`http://localhost:${port}/baz2`);
     await waitForHydration(page);
-    await expect(page.getByTestId('home-title')).toHaveText('Home');
-    const sliceText = await page.getByTestId('slice002').textContent();
-    expect(sliceText?.startsWith('Slice 002')).toBeTruthy();
-    await page.click("a[href='/baz2']");
     await expect(page.getByTestId('baz2-title')).toHaveText('Baz2');
     const randomText = await page.getByTestId('baz2-random').textContent();
+    const sliceText = await page.getByTestId('slice002').textContent();
+    expect(sliceText?.startsWith('Slice 002')).toBeTruthy();
+    await page.click("a[href='/']");
+    await expect(page.getByTestId('home-title')).toHaveText('Home');
+    await page.click("a[href='/baz2']");
+    await expect(page.getByTestId('baz2-title')).toHaveText('Baz2');
     const sliceText2 = await page.getByTestId('slice002').textContent();
     expect(sliceText2 !== sliceText).toBeTruthy();
-    await page.reload();
-    await expect(page.getByTestId('baz2-title')).toHaveText('Baz2');
     if (mode === 'PRD') {
       const randomText2 = await page.getByTestId('baz2-random').textContent();
       expect(randomText === randomText2).toBeTruthy();

--- a/e2e/define-router.spec.ts
+++ b/e2e/define-router.spec.ts
@@ -64,10 +64,6 @@ test.describe(`define-router`, () => {
   });
 
   test('baz1 (dynamic page + lazy static slice)', async ({ page, mode }) => {
-    await page.route(/.*\/RSC\/.*/, async (route) => {
-      await new Promise((r) => setTimeout(r, 100));
-      await route.continue();
-    });
     await page.goto(`http://localhost:${port}/`);
     await waitForHydration(page);
     await expect(page.getByTestId('home-title')).toHaveText('Home');
@@ -76,8 +72,6 @@ test.describe(`define-router`, () => {
     await page.click("a[href='/baz1']");
     await expect(page.getByTestId('baz1-title')).toHaveText('Baz1');
     const randomText = await page.getByTestId('baz1-random').textContent();
-    await expect(page.getByTestId('slice001-loading')).toBeVisible();
-    await expect(page.getByTestId('slice001')).toBeVisible();
     const sliceText2 = await page.getByTestId('slice001').textContent();
     expect(sliceText === sliceText2).toBeTruthy();
     await page.reload();
@@ -89,10 +83,6 @@ test.describe(`define-router`, () => {
   });
 
   test('baz2 (static page + lazy dynamic slice)', async ({ page, mode }) => {
-    await page.route(/.*\/RSC\/.*/, async (route) => {
-      await new Promise((r) => setTimeout(r, 100));
-      await route.continue();
-    });
     await page.goto(`http://localhost:${port}/`);
     await waitForHydration(page);
     await expect(page.getByTestId('home-title')).toHaveText('Home');
@@ -101,8 +91,6 @@ test.describe(`define-router`, () => {
     await page.click("a[href='/baz2']");
     await expect(page.getByTestId('baz2-title')).toHaveText('Baz2');
     const randomText = await page.getByTestId('baz2-random').textContent();
-    await expect(page.getByTestId('slice002-loading')).toBeVisible();
-    await expect(page.getByTestId('slice002')).toBeVisible();
     const sliceText2 = await page.getByTestId('slice002').textContent();
     expect(sliceText2 !== sliceText).toBeTruthy();
     await page.reload();
@@ -111,6 +99,32 @@ test.describe(`define-router`, () => {
       const randomText2 = await page.getByTestId('baz2-random').textContent();
       expect(randomText === randomText2).toBeTruthy();
     }
+  });
+
+  test('direct baz1 (static page + lazy dynamic slice)', async ({ page }) => {
+    await page.route(/.*\/RSC\/.*/, async (route) => {
+      await new Promise((r) => setTimeout(r, 100));
+      await route.continue();
+    });
+    await page.goto(`http://localhost:${port}/baz1`);
+    await expect(page.getByTestId('baz1-title')).toHaveText('Baz1');
+    await expect(page.getByTestId('slice001-loading')).toBeVisible();
+    await expect(page.getByTestId('slice001')).toBeVisible();
+    const sliceText = await page.getByTestId('slice001').textContent();
+    expect(sliceText?.startsWith('Slice 001')).toBeTruthy();
+  });
+
+  test('direct baz2 (static page + lazy dynamic slice)', async ({ page }) => {
+    await page.route(/.*\/RSC\/.*/, async (route) => {
+      await new Promise((r) => setTimeout(r, 100));
+      await route.continue();
+    });
+    await page.goto(`http://localhost:${port}/baz2`);
+    await expect(page.getByTestId('baz2-title')).toHaveText('Baz2');
+    await expect(page.getByTestId('slice002-loading')).toBeVisible();
+    await expect(page.getByTestId('slice002')).toBeVisible();
+    const sliceText = await page.getByTestId('slice002').textContent();
+    expect(sliceText?.startsWith('Slice 002')).toBeTruthy();
   });
 
   test('api hi', async () => {

--- a/e2e/define-router.spec.ts
+++ b/e2e/define-router.spec.ts
@@ -17,7 +17,7 @@ test.describe(`define-router`, () => {
   test('home', async ({ page }) => {
     await page.goto(`http://localhost:${port}/`);
     await expect(page.getByTestId('home-title')).toHaveText('Home');
-    await page.getByText('Foo').click();
+    await page.click("a[href='/foo']");
     await expect(page.getByTestId('foo-title')).toHaveText('Foo');
   });
 
@@ -26,33 +26,33 @@ test.describe(`define-router`, () => {
     await expect(page.getByTestId('foo-title')).toHaveText('Foo');
   });
 
-  test('bar (slice)', async ({ page }) => {
+  test('bar1 (dynamic page + static slice)', async ({ page }) => {
     await page.goto(`http://localhost:${port}/`);
     await waitForHydration(page);
     await expect(page.getByTestId('home-title')).toHaveText('Home');
     const sliceText = await page.getByTestId('slice001').textContent();
     expect(sliceText?.startsWith('Slice 001')).toBeTruthy();
-    await page.getByText('Bar').click();
-    await expect(page.getByTestId('bar-title')).toHaveText('Bar');
+    await page.click("a[href='/bar1']");
+    await expect(page.getByTestId('bar1-title')).toHaveText('Bar1');
     await expect(page.getByTestId('slice001')).toHaveText(sliceText!);
   });
 
-  test('baz (lazy slice)', async ({ page, mode }) => {
+  test('baz2 (static page + lazy dynamic slice)', async ({ page, mode }) => {
     await page.route(/.*\/RSC\/.*/, async (route) => {
       await new Promise((r) => setTimeout(r, 100));
       await route.continue();
     });
-    await page.goto(`http://localhost:${port}/baz`);
-    await expect(page.getByTestId('baz-title')).toHaveText('Baz');
-    const randomText = await page.getByTestId('baz-random').textContent();
+    await page.goto(`http://localhost:${port}/baz2`);
+    await expect(page.getByTestId('baz2-title')).toHaveText('Baz2');
+    const randomText = await page.getByTestId('baz2-random').textContent();
     await expect(page.getByTestId('slice002-loading')).toBeVisible();
     await expect(page.getByTestId('slice002')).toBeVisible();
     const sliceText = await page.getByTestId('slice002').textContent();
     expect(sliceText?.startsWith('Slice 002')).toBeTruthy();
     await page.reload();
-    await expect(page.getByTestId('baz-title')).toHaveText('Baz');
+    await expect(page.getByTestId('baz2-title')).toHaveText('Baz2');
     if (mode === 'PRD') {
-      await expect(page.getByTestId('baz-random')).toHaveText(randomText!);
+      await expect(page.getByTestId('baz2-random')).toHaveText(randomText!);
     }
     await expect(page.getByTestId('slice002-loading')).toBeVisible();
     await expect(page.getByTestId('slice002')).toBeVisible();

--- a/e2e/define-router.spec.ts
+++ b/e2e/define-router.spec.ts
@@ -34,13 +34,15 @@ test.describe(`define-router`, () => {
     expect(sliceText?.startsWith('Slice 001')).toBeTruthy();
     await page.click("a[href='/bar1']");
     await expect(page.getByTestId('bar1-title')).toHaveText('Bar1');
-    await expect(page.getByTestId('slice001')).toHaveText(sliceText!);
+    const sliceText2 = await page.getByTestId('slice001').textContent();
+    expect(sliceText2).toBe(sliceText);
     const randomText = await page.getByTestId('bar1-random').textContent();
     await page.reload();
     await expect(page.getByTestId('bar1-title')).toHaveText('Bar1');
     if (mode === 'PRD') {
-      const randomText2 = await page.getByTestId('bar1-random').textContent();
-      expect(randomText !== randomText2).toBeTruthy();
+      expect(await page.getByTestId('bar1-random').textContent()).not.toBe(
+        randomText,
+      );
     }
   });
 
@@ -56,10 +58,11 @@ test.describe(`define-router`, () => {
     await page.click("a[href='/bar2']");
     await expect(page.getByTestId('bar2-title')).toHaveText('Bar2');
     const sliceText2 = await page.getByTestId('slice002').textContent();
-    expect(sliceText2 !== sliceText).toBeTruthy();
+    expect(sliceText2).not.toBe(sliceText);
     if (mode === 'PRD') {
-      const randomText2 = await page.getByTestId('bar2-random').textContent();
-      expect(randomText === randomText2).toBeTruthy();
+      expect(await page.getByTestId('bar2-random').textContent()).toBe(
+        randomText,
+      );
     }
   });
 
@@ -73,12 +76,13 @@ test.describe(`define-router`, () => {
     await expect(page.getByTestId('baz1-title')).toHaveText('Baz1');
     const randomText = await page.getByTestId('baz1-random').textContent();
     const sliceText2 = await page.getByTestId('slice001').textContent();
-    expect(sliceText === sliceText2).toBeTruthy();
+    expect(sliceText2).toBe(sliceText);
     await page.reload();
     await expect(page.getByTestId('baz1-title')).toHaveText('Baz1');
     if (mode === 'PRD') {
-      const randomText2 = await page.getByTestId('baz1-random').textContent();
-      expect(randomText !== randomText2).toBeTruthy();
+      expect(await page.getByTestId('baz1-random').textContent()).not.toBe(
+        randomText,
+      );
     }
   });
 
@@ -94,10 +98,11 @@ test.describe(`define-router`, () => {
     await page.click("a[href='/baz2']");
     await expect(page.getByTestId('baz2-title')).toHaveText('Baz2');
     const sliceText2 = await page.getByTestId('slice002').textContent();
-    expect(sliceText2 !== sliceText).toBeTruthy();
+    expect(sliceText2).not.toBe(sliceText);
     if (mode === 'PRD') {
-      const randomText2 = await page.getByTestId('baz2-random').textContent();
-      expect(randomText === randomText2).toBeTruthy();
+      expect(await page.getByTestId('baz2-random').textContent()).toBe(
+        randomText,
+      );
     }
   });
 

--- a/e2e/fixtures/define-router/src/routes/bar1/page.tsx
+++ b/e2e/fixtures/define-router/src/routes/bar1/page.tsx
@@ -1,10 +1,10 @@
 import { Slice } from 'waku/router/client';
 
-const Bar = () => (
+const Bar1 = () => (
   <div>
-    <h2 data-testid="bar-title">Bar</h2>
+    <h2 data-testid="bar1-title">Bar1</h2>
     <Slice id="slice001" />
   </div>
 );
 
-export default Bar;
+export default Bar1;

--- a/e2e/fixtures/define-router/src/routes/bar1/page.tsx
+++ b/e2e/fixtures/define-router/src/routes/bar1/page.tsx
@@ -3,6 +3,7 @@ import { Slice } from 'waku/router/client';
 const Bar1 = () => (
   <div>
     <h2 data-testid="bar1-title">Bar1</h2>
+    <p data-testid="bar1-random">{Math.random()}</p>
     <Slice id="slice001" />
   </div>
 );

--- a/e2e/fixtures/define-router/src/routes/bar2/page.tsx
+++ b/e2e/fixtures/define-router/src/routes/bar2/page.tsx
@@ -1,0 +1,10 @@
+import { Slice } from 'waku/router/client';
+
+const Bar2 = () => (
+  <div>
+    <h2 data-testid="bar2-title">Bar2</h2>
+    <Slice id="slice002" />
+  </div>
+);
+
+export default Bar2;

--- a/e2e/fixtures/define-router/src/routes/bar2/page.tsx
+++ b/e2e/fixtures/define-router/src/routes/bar2/page.tsx
@@ -3,6 +3,7 @@ import { Slice } from 'waku/router/client';
 const Bar2 = () => (
   <div>
     <h2 data-testid="bar2-title">Bar2</h2>
+    <p data-testid="bar2-random">{Math.random()}</p>
     <Slice id="slice002" />
   </div>
 );

--- a/e2e/fixtures/define-router/src/routes/baz1/page.tsx
+++ b/e2e/fixtures/define-router/src/routes/baz1/page.tsx
@@ -1,0 +1,15 @@
+import { Slice } from 'waku/router/client';
+
+const Baz1 = () => (
+  <div>
+    <h2 data-testid="baz1-title">Baz1</h2>
+    <p data-testid="baz1-random">{Math.random()}</p>
+    <Slice
+      id="slice001"
+      lazy
+      fallback={<p data-testid="slice001-loading">Loading...</p>}
+    />
+  </div>
+);
+
+export default Baz1;

--- a/e2e/fixtures/define-router/src/routes/baz2/page.tsx
+++ b/e2e/fixtures/define-router/src/routes/baz2/page.tsx
@@ -1,9 +1,9 @@
 import { Slice } from 'waku/router/client';
 
-const Baz = () => (
+const Baz2 = () => (
   <div>
-    <h2 data-testid="baz-title">Baz</h2>
-    <p data-testid="baz-random">{Math.random()}</p>
+    <h2 data-testid="baz2-title">Baz2</h2>
+    <p data-testid="baz2-random">{Math.random()}</p>
     <Slice
       id="slice002"
       lazy
@@ -12,4 +12,4 @@ const Baz = () => (
   </div>
 );
 
-export default Baz;
+export default Baz2;

--- a/e2e/fixtures/define-router/src/routes/layout.tsx
+++ b/e2e/fixtures/define-router/src/routes/layout.tsx
@@ -53,6 +53,24 @@ const HomeLayout = ({ children }: { children: ReactNode }) => (
           Bar2
         </Link>
       </li>
+      <li>
+        <Link
+          to="/baz1"
+          unstable_pending={<Pending isPending />}
+          unstable_notPending={<Pending isPending={false} />}
+        >
+          Baz1
+        </Link>
+      </li>
+      <li>
+        <Link
+          to="/baz2"
+          unstable_pending={<Pending isPending />}
+          unstable_notPending={<Pending isPending={false} />}
+        >
+          Baz2
+        </Link>
+      </li>
     </ul>
     {children}
   </div>

--- a/e2e/fixtures/define-router/src/routes/layout.tsx
+++ b/e2e/fixtures/define-router/src/routes/layout.tsx
@@ -37,11 +37,20 @@ const HomeLayout = ({ children }: { children: ReactNode }) => (
       </li>
       <li>
         <Link
-          to="/bar"
+          to="/bar1"
           unstable_pending={<Pending isPending />}
           unstable_notPending={<Pending isPending={false} />}
         >
-          Bar
+          Bar1
+        </Link>
+      </li>
+      <li>
+        <Link
+          to="/bar2"
+          unstable_pending={<Pending isPending />}
+          unstable_notPending={<Pending isPending={false} />}
+        >
+          Bar2
         </Link>
       </li>
     </ul>

--- a/e2e/fixtures/define-router/src/routes/page.tsx
+++ b/e2e/fixtures/define-router/src/routes/page.tsx
@@ -5,7 +5,6 @@ const Home = () => (
     <h2 data-testid="home-title">Home</h2>
     <p>This is the home page.</p>
     <Slice id="slice001" />
-    <Slice id="slice002" />
   </div>
 );
 

--- a/e2e/fixtures/define-router/src/routes/page.tsx
+++ b/e2e/fixtures/define-router/src/routes/page.tsx
@@ -5,6 +5,7 @@ const Home = () => (
     <h2 data-testid="home-title">Home</h2>
     <p>This is the home page.</p>
     <Slice id="slice001" />
+    <Slice id="slice002" />
   </div>
 );
 

--- a/e2e/fixtures/define-router/src/server-entry.tsx
+++ b/e2e/fixtures/define-router/src/server-entry.tsx
@@ -6,8 +6,8 @@ import Layout from './routes/layout.js';
 import Page from './routes/page.js';
 import FooPage from './routes/foo/page.js';
 import Bar1Page from './routes/bar1/page.js';
-import Bar2Page from './routes/bar2/page.js';
-import Baz1Page from './routes/baz1/page.js';
+//import Bar2Page from './routes/bar2/page.js';
+//import Baz1Page from './routes/baz1/page.js';
 import Baz2Page from './routes/baz2/page.js';
 import { Slice001 } from './components/slice001.js';
 import { Slice002 } from './components/slice002.js';
@@ -17,8 +17,8 @@ const PATH_PAGE: Record<string, unknown> = {
   '/': <Page />,
   '/foo': <FooPage />,
   '/bar1': <Bar1Page />, // dynamic page + static slice
-  '/bar2': <Bar2Page />, // static page + dynamic slice
-  '/baz1': <Baz1Page />, // dynamic page + lazy static slice
+  //'/bar2': <Bar2Page />, // static page + dynamic slice
+  //'/baz1': <Baz1Page />, // dynamic page + lazy static slice
   '/baz2': <Baz2Page />, // static page + lazy dynamic slice
 };
 
@@ -94,7 +94,7 @@ const router: ReturnType<typeof defineRouter> = defineRouter({
         ),
         [`page:${path}`]: PATH_PAGE[path],
       },
-      ...(['/', '/bar'].includes(path) ? { slices: ['slice001'] } : {}),
+      ...(['/', '/bar1'].includes(path) ? { slices: ['slice001'] } : {}),
     };
   },
   handleApi: async (path, opt) => {

--- a/e2e/fixtures/define-router/src/server-entry.tsx
+++ b/e2e/fixtures/define-router/src/server-entry.tsx
@@ -5,17 +5,21 @@ import { Slot, Children } from 'waku/minimal/client';
 import Layout from './routes/layout.js';
 import Page from './routes/page.js';
 import FooPage from './routes/foo/page.js';
-import BarPage from './routes/bar/page.js';
-import BazPage from './routes/baz/page.js';
+import Bar1Page from './routes/bar1/page.js';
+import Bar2Page from './routes/bar2/page.js';
+import Baz1Page from './routes/baz1/page.js';
+import Baz2Page from './routes/baz2/page.js';
 import { Slice001 } from './components/slice001.js';
 import { Slice002 } from './components/slice002.js';
 
-const STATIC_PATHS = ['/', '/foo', '/baz'];
+const STATIC_PATHS = ['/', '/foo', '/bar2', '/baz2'];
 const PATH_PAGE: Record<string, unknown> = {
   '/': <Page />,
   '/foo': <FooPage />,
-  '/bar': <BarPage />,
-  '/baz': <BazPage />,
+  '/bar1': <Bar1Page />, // dynamic page + static slice
+  '/bar2': <Bar2Page />, // static page + dynamic slice
+  '/baz1': <Baz1Page />, // dynamic page + lazy static slice
+  '/baz2': <Baz2Page />, // static page + lazy dynamic slice
 };
 
 const router: ReturnType<typeof defineRouter> = defineRouter({
@@ -143,7 +147,7 @@ const router: ReturnType<typeof defineRouter> = defineRouter({
       return { isStatic: true };
     }
     if (sliceId === 'slice002') {
-      return {};
+      return {}; // dynamic slice
     }
     return null;
   },

--- a/e2e/fixtures/define-router/src/server-entry.tsx
+++ b/e2e/fixtures/define-router/src/server-entry.tsx
@@ -96,6 +96,7 @@ const router: ReturnType<typeof defineRouter> = defineRouter({
       },
       ...(path === '/' ? { slices: ['slice001', 'slice002'] } : {}),
       ...(path === '/bar1' ? { slices: ['slice001'] } : {}),
+      ...(path === '/bar2' ? { slices: ['slice002'] } : {}),
     };
   },
   handleApi: async (path, opt) => {
@@ -148,7 +149,7 @@ const router: ReturnType<typeof defineRouter> = defineRouter({
       return { isStatic: true };
     }
     if (sliceId === 'slice002') {
-      return {}; // dynamic slice
+      return { isStatic: false };
     }
     return null;
   },

--- a/e2e/fixtures/define-router/src/server-entry.tsx
+++ b/e2e/fixtures/define-router/src/server-entry.tsx
@@ -12,7 +12,8 @@ import Baz2Page from './routes/baz2/page.js';
 import { Slice001 } from './components/slice001.js';
 import { Slice002 } from './components/slice002.js';
 
-const STATIC_PATHS = ['/', '/foo', '/bar2', '/baz2'];
+const STATIC_PATHS = ['/', '/foo', '/baz2'];
+const STATIC_PAGES = ['/', '/foo', '/bar2', '/baz2'];
 const PATH_PAGE: Record<string, unknown> = {
   '/': <Page />,
   '/foo': <FooPage />,
@@ -25,7 +26,6 @@ const PATH_PAGE: Record<string, unknown> = {
 const router: ReturnType<typeof defineRouter> = defineRouter({
   getConfig: async () => [
     ...Object.keys(PATH_PAGE).map((path) => {
-      const isStatic = STATIC_PATHS.includes(path);
       return {
         type: 'route' as const,
         pattern: `^${path}$`,
@@ -33,11 +33,12 @@ const router: ReturnType<typeof defineRouter> = defineRouter({
           .split('/')
           .filter(Boolean)
           .map((name) => ({ type: 'literal', name }) as const),
-        rootElement: { isStatic },
-        routeElement: { isStatic },
+        isStatic: STATIC_PATHS.includes(path),
+        rootElement: { isStatic: true },
+        routeElement: { isStatic: true },
         elements: {
-          'layout:/': { isStatic },
-          [`page:${path}`]: { isStatic },
+          'layout:/': { isStatic: true },
+          [`page:${path}`]: { isStatic: STATIC_PAGES.includes(path) },
         },
       };
     }),

--- a/e2e/fixtures/define-router/src/server-entry.tsx
+++ b/e2e/fixtures/define-router/src/server-entry.tsx
@@ -6,8 +6,8 @@ import Layout from './routes/layout.js';
 import Page from './routes/page.js';
 import FooPage from './routes/foo/page.js';
 import Bar1Page from './routes/bar1/page.js';
-//import Bar2Page from './routes/bar2/page.js';
-//import Baz1Page from './routes/baz1/page.js';
+import Bar2Page from './routes/bar2/page.js';
+import Baz1Page from './routes/baz1/page.js';
 import Baz2Page from './routes/baz2/page.js';
 import { Slice001 } from './components/slice001.js';
 import { Slice002 } from './components/slice002.js';
@@ -17,8 +17,8 @@ const PATH_PAGE: Record<string, unknown> = {
   '/': <Page />,
   '/foo': <FooPage />,
   '/bar1': <Bar1Page />, // dynamic page + static slice
-  //'/bar2': <Bar2Page />, // static page + dynamic slice
-  //'/baz1': <Baz1Page />, // dynamic page + lazy static slice
+  '/bar2': <Bar2Page />, // static page + dynamic slice
+  '/baz1': <Baz1Page />, // dynamic page + lazy static slice
   '/baz2': <Baz2Page />, // static page + lazy dynamic slice
 };
 
@@ -94,7 +94,8 @@ const router: ReturnType<typeof defineRouter> = defineRouter({
         ),
         [`page:${path}`]: PATH_PAGE[path],
       },
-      ...(['/', '/bar1'].includes(path) ? { slices: ['slice001'] } : {}),
+      ...(path === '/' ? { slices: ['slice001', 'slice002'] } : {}),
+      ...(path === '/bar1' ? { slices: ['slice001'] } : {}),
     };
   },
   handleApi: async (path, opt) => {

--- a/e2e/fixtures/define-router/src/server-entry.tsx
+++ b/e2e/fixtures/define-router/src/server-entry.tsx
@@ -94,7 +94,7 @@ const router: ReturnType<typeof defineRouter> = defineRouter({
         ),
         [`page:${path}`]: PATH_PAGE[path],
       },
-      ...(path === '/' ? { slices: ['slice001', 'slice002'] } : {}),
+      ...(path === '/' ? { slices: ['slice001'] } : {}),
       ...(path === '/bar1' ? { slices: ['slice001'] } : {}),
       ...(path === '/bar2' ? { slices: ['slice002'] } : {}),
     };

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -129,7 +129,7 @@ export const prepareNormalSetup = (fixtureName: string) => {
   const startApp = async (mode: 'DEV' | 'PRD' | 'STATIC') => {
     if (mode !== 'DEV' && builtMode !== mode) {
       rmSync(`${fixtureDir}/dist`, { recursive: true, force: true });
-      execSync(`node ${waku} build`, { cwd: fixtureDir, stdio: 'inherit' });
+      execSync(`node ${waku} build`, { cwd: fixtureDir });
       builtMode = mode;
     }
     let cmd: string;

--- a/packages/waku/src/router/create-pages.ts
+++ b/packages/waku/src/router/create-pages.ts
@@ -428,6 +428,15 @@ export const createPages = <
     staticComponentMap.set(id, component);
   };
 
+  const isAllElementsStatic = (
+    elements: Record<string, { isStatic?: boolean }>,
+  ) => Object.values(elements).every((element) => element.isStatic);
+
+  const isAllSlicesStatic = (path: string) =>
+    (slicePathMap.get(path) || []).every(
+      (sliceId) => sliceIdMap.get(sliceId)?.isStatic,
+    );
+
   const createPage: CreatePage = (page) => {
     if (configured) {
       throw new Error('createPage no longer available');
@@ -730,6 +739,7 @@ export const createPages = <
       const routeConfigs: {
         type: 'route';
         path: PathSpec;
+        isStatic: boolean;
         pathPattern?: PathSpec;
         rootElement: { isStatic?: boolean };
         routeElement: { isStatic?: boolean };
@@ -758,11 +768,13 @@ export const createPages = <
         routeConfigs.push({
           type: 'route',
           path: literalSpec.filter((part) => !part.name?.startsWith('(')),
+          isStatic:
+            rootIsStatic &&
+            isAllElementsStatic(elements) &&
+            isAllSlicesStatic(path),
           ...(originalSpec && { pathPattern: originalSpec }),
           rootElement: { isStatic: rootIsStatic },
-          routeElement: {
-            isStatic: true,
-          },
+          routeElement: { isStatic: true },
           elements,
           noSsr,
         });
@@ -795,6 +807,10 @@ export const createPages = <
         }
         routeConfigs.push({
           type: 'route',
+          isStatic:
+            rootIsStatic &&
+            isAllElementsStatic(elements) &&
+            isAllSlicesStatic(path),
           path: pathSpec.filter((part) => !part.name?.startsWith('(')),
           rootElement: { isStatic: rootIsStatic },
           routeElement: { isStatic: true },
@@ -830,6 +846,10 @@ export const createPages = <
         }
         routeConfigs.push({
           type: 'route',
+          isStatic:
+            rootIsStatic &&
+            isAllElementsStatic(elements) &&
+            isAllSlicesStatic(path),
           path: pathSpec.filter((part) => !part.name?.startsWith('(')),
           rootElement: { isStatic: rootIsStatic },
           routeElement: { isStatic: true },

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -144,6 +144,7 @@ export function unstable_defineRouter(fns: {
       | {
           type: 'route';
           path: PathSpec;
+          isStatic: boolean;
           pathPattern?: PathSpec;
           rootElement: { isStatic?: boolean };
           routeElement: { isStatic?: boolean };
@@ -153,7 +154,7 @@ export function unstable_defineRouter(fns: {
       | {
           type: 'api';
           path: PathSpec;
-          isStatic?: boolean;
+          isStatic: boolean;
         }
     >
   >;
@@ -219,10 +220,6 @@ export function unstable_defineRouter(fns: {
               item.path.length === 1 &&
               item.path[0]!.type === 'literal' &&
               item.path[0]!.name === '404';
-            const isStatic =
-              !!item.rootElement.isStatic &&
-              !!item.routeElement.isStatic &&
-              Object.values(item.elements).every((x) => x.isStatic);
             if (
               Object.keys(item.elements).some(
                 (id) =>
@@ -248,7 +245,7 @@ export function unstable_defineRouter(fns: {
                 staticElementIds: Object.entries(item.elements).flatMap(
                   ([id, { isStatic }]) => (isStatic ? [id] : []),
                 ),
-                ...(isStatic ? { isStatic: true as const } : {}),
+                ...(item.isStatic ? { isStatic: true as const } : {}),
                 ...(is404 ? { is404: true as const } : {}),
                 ...(item.noSsr ? { noSsr: true as const } : {}),
               },

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -552,6 +552,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'test', type: 'literal' }],
+        isStatic: true,
       },
     ]);
 
@@ -584,6 +585,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'test', type: 'literal' }],
+        isStatic: false,
       },
     ]);
     const route = await handleRoute('/test', {
@@ -695,6 +697,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'test', type: 'literal' }],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test', {
@@ -734,6 +737,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'test', type: 'literal' }],
+        isStatic: false,
       },
     ]);
 
@@ -773,6 +777,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [],
+        isStatic: true,
       },
     ]);
     expect(await getSliceConfig('slice001')).toEqual({ isStatic: true });
@@ -805,6 +810,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [],
+        isStatic: false,
       },
     ]);
     expect(await getSliceConfig('slice001')).toEqual({ isStatic: true });
@@ -840,6 +846,7 @@ describe('createPages pages and layouts', () => {
           { name: 'test', type: 'literal' },
           { name: 'wildcard', type: 'wildcard' },
         ],
+        isStatic: false,
       },
     ]);
     expect(await getSliceConfig('slice001')).toEqual({ isStatic: true });
@@ -868,6 +875,7 @@ describe('createPages pages and layouts', () => {
           { name: 'test', type: 'literal' },
           { name: 'nested', type: 'literal' },
         ],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test/nested', {
@@ -908,6 +916,7 @@ describe('createPages pages and layouts', () => {
           { name: 'test', type: 'literal' },
           { name: 'nested', type: 'literal' },
         ],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test/nested', {
@@ -945,6 +954,7 @@ describe('createPages pages and layouts', () => {
           { name: 'test', type: 'literal' },
           { name: 'nested', type: 'literal' },
         ],
+        isStatic: false,
       },
     ]);
 
@@ -990,6 +1000,7 @@ describe('createPages pages and layouts', () => {
           { name: 'a', type: 'group' },
           { name: 'b', type: 'group' },
         ],
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1009,6 +1020,7 @@ describe('createPages pages and layouts', () => {
           { name: 'a', type: 'group' },
           { name: 'b', type: 'group' },
         ],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test/y/z', {
@@ -1044,6 +1056,7 @@ describe('createPages pages and layouts', () => {
           { name: 'a', type: 'group' },
           { name: 'b', type: 'group' },
         ],
+        isStatic: false,
       },
     ]);
     const route = await handleRoute('/test/w/x', {
@@ -1084,6 +1097,7 @@ describe('createPages pages and layouts', () => {
           { name: 'test', type: 'literal' },
           { name: 'path', type: 'wildcard' },
         ],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test/a/b', {
@@ -1118,6 +1132,7 @@ describe('createPages pages and layouts', () => {
           { name: 'test', type: 'literal' },
           { name: 'path', type: 'wildcard' },
         ],
+        isStatic: false,
       },
     ]);
     const route = await handleRoute('/test/a/b', {
@@ -1149,6 +1164,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'catchAll', type: 'wildcard' }],
+        isStatic: false,
       },
     ]);
 
@@ -1211,6 +1227,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: true,
         path: [{ name: 'static', type: 'literal' }],
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1221,6 +1238,7 @@ describe('createPages pages and layouts', () => {
         routeElement: { isStatic: true },
         noSsr: true,
         path: [{ name: 'dynamic', type: 'literal' }],
+        isStatic: false,
       },
     ]);
   });
@@ -1333,6 +1351,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1384,6 +1403,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1435,6 +1455,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1482,6 +1503,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1515,6 +1537,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: false,
       },
       {
         type: 'route',
@@ -1548,6 +1571,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: false,
       },
       {
         type: 'route',
@@ -1591,6 +1615,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1634,6 +1659,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1677,6 +1703,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1706,6 +1733,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: false,
       },
       {
         type: 'route',
@@ -1735,6 +1763,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: false,
       },
       {
         type: 'route',
@@ -1760,6 +1789,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: true,
       },
       {
         type: 'route',
@@ -1785,6 +1815,7 @@ describe('createPages pages and layouts', () => {
           },
         },
         noSsr: false,
+        isStatic: false,
       },
     ]);
     const route = await handleRoute('/server/two/a/b', {
@@ -1895,6 +1926,7 @@ describe('createPages - exactPath', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'test', type: 'literal' }],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test', {
@@ -1927,6 +1959,7 @@ describe('createPages - exactPath', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'test', type: 'literal' }],
+        isStatic: false,
       },
     ]);
     const route = await handleRoute('/test', {
@@ -1962,6 +1995,7 @@ describe('createPages - exactPath', () => {
           { name: 'test', type: 'literal' },
           { name: '[slug]', type: 'literal' },
         ],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test/[slug]', {
@@ -1997,6 +2031,7 @@ describe('createPages - exactPath', () => {
           { name: 'test', type: 'literal' },
           { name: '[...wildcard]', type: 'literal' },
         ],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test/[...wildcard]', {
@@ -2033,6 +2068,7 @@ describe('createPages - exactPath', () => {
           { name: '[...wildcard]', type: 'literal' },
           { name: '[slug]', type: 'literal' },
         ],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test/[...wildcard]/[slug]', {
@@ -2070,6 +2106,7 @@ describe('createPages - exactPath', () => {
           { name: 'test', type: 'literal' },
           { name: '[slug]', type: 'literal' },
         ],
+        isStatic: true,
       },
     ]);
     await expect(async () => {
@@ -2101,6 +2138,7 @@ describe('createPages - grouped paths', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'test', type: 'literal' }],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test', {
@@ -2135,6 +2173,7 @@ describe('createPages - grouped paths', () => {
           { name: 'test', type: 'literal' },
           { name: 'foo', type: 'literal' },
         ],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test/foo', {
@@ -2200,6 +2239,7 @@ describe('createPages - grouped paths', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [{ name: 'test', type: 'literal' }],
+        isStatic: true,
       },
       {
         type: 'route',
@@ -2212,6 +2252,7 @@ describe('createPages - grouped paths', () => {
         routeElement: { isStatic: true },
         noSsr: false,
         path: [],
+        isStatic: true,
       },
     ]);
     const route = await handleRoute('/test', {


### PR DESCRIPTION
There were some edge cases to fail. This PR adds comprehensive test cases and fix all by adding a new config entry in define-router.