### PR TITLE
ci: skip monorepo test on ecosystem ci

### DIFF
--- a/e2e/monorepo.spec.ts
+++ b/e2e/monorepo.spec.ts
@@ -4,6 +4,9 @@ import { test, prepareStandaloneSetup } from './utils.js';
 
 const startApp = prepareStandaloneSetup('monorepo');
 
+// TODO: skip since ecosystem ci overrides setup tends to break package managers
+test.skip(!!process.env.ECOSYSTEM_CI);
+
 for (const packageManager of ['npm', 'pnpm', 'yarn'] as const) {
   test.describe(`${packageManager} monorepo`, () => {
     let port: number;


### PR DESCRIPTION
This has been failing on ecosystem CI. Since ecosystem ci itself involves many overrides, it might be tricky to make it work robustly especially for npm. Skipping this for now.