### PR TITLE
fix: silence `optimizeDeps.exclude` warning for `waku-jotai`

### DIFF
--- a/packages/waku/src/lib/vite-rsc/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/plugin.ts
@@ -213,7 +213,13 @@ export function rscPlugin(rscPluginOptions?: RscPluginOptions): PluginOption {
             noExternal: env.command === 'build' ? true : [PKG_NAME],
           },
           optimizeDeps: {
-            exclude: [PKG_NAME, 'waku/minimal/client', 'waku/router/client'],
+            exclude: [
+              PKG_NAME,
+              'waku/minimal/client',
+              'waku/router/client',
+              // https://github.com/vitejs/vite-plugin-react/issues/759
+              'waku-jotai',
+            ],
           },
         };
       },


### PR DESCRIPTION
This adds a workaround for https://github.com/vitejs/vite-plugin-react/issues/759. Without this, currently it shows (technically false-positive) warning

```js
$ pnpm -C e2e/fixtures/waku-jotai/ dev
...
ready: Listening on http://localhost:3000/
[vite] connected.
6:33:36 PM [vite] (rsc) warning: client component dependency is inconsistently optimized. It's recommended to add the dependency to 'optimizeDeps.exclude'.
  Plugin: rsc:use-client
  File: /home/hiroshi/code/others/waku/node_modules/.pnpm/waku-jotai@0.0.2_jotai@2.13.1_@babel+core@7.28.3_@babel+template@7.27.2_@types+react@19_387bcb10b53527d0eca5308a14cdc950/node_modules/waku-jotai/dist/minimal/client.js?v=0e246cca
6:33:36 PM [vite] (rsc) warning: client component dependency is inconsistently optimized. It's recommended to add the dependency to 'optimizeDeps.exclude'.
  Plugin: rsc:use-client
  File: /home/hiroshi/code/others/waku/node_modules/.pnpm/waku-jotai@0.0.2_jotai@2.13.1_@babel+core@7.28.3_@babel+template@7.27.2_@types+react@19_387bcb10b53527d0eca5308a14cdc950/node_modules/waku-jotai/dist/router/client.js?v=0e246cca
```