### PR TITLE
refactor: rename server build output to `dist/server` and `dist/server/ssr`

### DIFF
--- a/packages/waku/src/lib/vite-rsc/cli.ts
+++ b/packages/waku/src/lib/vite-rsc/cli.ts
@@ -79,7 +79,7 @@ export async function cli(
     const distDir = rscPluginOptions.config?.distDir ?? 'dist';
     const entry: typeof import('../vite-entries/entry.server.js') =
       await import(
-        pathToFileURL(path.resolve(distDir, 'rsc', 'index.js')).href
+        pathToFileURL(path.resolve(distDir, 'server', 'index.js')).href
       );
     await startServer(port);
     function startServer(port: number) {

--- a/packages/waku/src/lib/vite-rsc/deploy/aws-lambda/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/deploy/aws-lambda/plugin.ts
@@ -54,7 +54,7 @@ async function build({
 }) {
   writeFileSync(
     path.join(opts.distDir, SERVE_JS),
-    `export { handler } from './rsc/index.js';\n`,
+    `export { handler } from './server/index.js';\n`,
   );
   writeFileSync(
     path.join(opts.distDir, 'package.json'),

--- a/packages/waku/src/lib/vite-rsc/deploy/cloudflare/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/deploy/cloudflare/plugin.ts
@@ -84,7 +84,7 @@ async function build({
 
   writeFileSync(
     path.join(outDir, SERVE_JS),
-    `export { default } from './rsc/index.js';\n`,
+    `export { default } from './server/index.js';\n`,
   );
 
   separatePublicAssetsFromFunctions({

--- a/packages/waku/src/lib/vite-rsc/deploy/deno/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/deploy/deno/plugin.ts
@@ -47,5 +47,8 @@ async function build({
   config: ResolvedConfig;
   opts: Required<Config>;
 }) {
-  writeFileSync(path.join(opts.distDir, SERVE_JS), `import './rsc/deno.js';\n`);
+  writeFileSync(
+    path.join(opts.distDir, SERVE_JS),
+    `import './server/deno.js';\n`,
+  );
 }

--- a/packages/waku/src/lib/vite-rsc/deploy/netlify/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/deploy/netlify/plugin.ts
@@ -67,7 +67,7 @@ async function build({
       path.join(functionsDir, 'serve.js'),
       `\
 globalThis.__WAKU_NOT_FOUND_HTML__ = ${JSON.stringify(notFoundHtml)};
-export { default } from '../${opts.distDir}/rsc/index.js';
+export { default } from '../${opts.distDir}/server/index.js';
 export const config = {
   preferStatic: true,
   path: ['/', '/*'],

--- a/packages/waku/src/lib/vite-rsc/deploy/partykit/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/deploy/partykit/plugin.ts
@@ -70,7 +70,10 @@ async function build({
 }) {
   const rootDir = config.root;
 
-  writeFileSync(path.join(opts.distDir, SERVE_JS), `import './rsc/index.js';`);
+  writeFileSync(
+    path.join(opts.distDir, SERVE_JS),
+    `import './server/index.js';`,
+  );
 
   const partykitJsonFile = path.join(rootDir, 'partykit.json');
   if (!existsSync(partykitJsonFile)) {

--- a/packages/waku/src/lib/vite-rsc/deploy/vercel/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/deploy/vercel/plugin.ts
@@ -70,7 +70,7 @@ async function build({
     });
     writeFileSync(
       path.join(rootDir, opts.distDir, SERVE_JS),
-      `export { default } from './rsc/index.js';\n`,
+      `export { default } from './server/index.js';\n`,
     );
     cpSync(
       path.join(rootDir, opts.distDir),

--- a/packages/waku/src/lib/vite-rsc/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/plugin.ts
@@ -197,6 +197,9 @@ export function rscPlugin(rscPluginOptions?: RscPluginOptions): PluginOption {
 
         environmentConfig.build ??= {};
         environmentConfig.build.outDir = `${config.distDir}/${name}`;
+        if (name === 'ssr') {
+          environmentConfig.build.outDir = `${config.distDir}/rsc/ssr`;
+        }
         if (name === 'client') {
           environmentConfig.build.outDir = `${config.distDir}/${DIST_PUBLIC}`;
           if (flags['experimental-partial']) {

--- a/packages/waku/src/lib/vite-rsc/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/plugin.ts
@@ -197,8 +197,11 @@ export function rscPlugin(rscPluginOptions?: RscPluginOptions): PluginOption {
 
         environmentConfig.build ??= {};
         environmentConfig.build.outDir = `${config.distDir}/${name}`;
+        if (name === 'rsc') {
+          environmentConfig.build.outDir = `${config.distDir}/server`;
+        }
         if (name === 'ssr') {
-          environmentConfig.build.outDir = `${config.distDir}/rsc/ssr`;
+          environmentConfig.build.outDir = `${config.distDir}/server/ssr`;
         }
         if (name === 'client') {
           environmentConfig.build.outDir = `${config.distDir}/${DIST_PUBLIC}`;


### PR DESCRIPTION
Rsc plugin by default creates flat `dist/{name}`, but for normal use case, it looks cleaner to have only two directories for server and client. This is also a minor requirement for `@cloudflare/vite-plugin` https://github.com/wakujs/waku/pull/1655, so moving this change to here first.