### PR TITLE
refactor: remove `node:async_hooks` fallback

### DIFF
--- a/packages/waku/src/lib/vite-rsc/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/plugin.ts
@@ -203,10 +203,6 @@ export function rscPlugin(rscPluginOptions?: RscPluginOptions): PluginOption {
             environmentConfig.build.emptyOutDir = false;
           }
         }
-        // top-level-await in packages/waku/src/lib/middleware/context.ts
-        if (name !== 'client') {
-          environmentConfig.build.target ??= 'esnext';
-        }
 
         return {
           resolve: {


### PR DESCRIPTION
Since `node:async_hooks` is essential for React features and all server platform should implements this already, I'd suggest removing this fallback. Rsc plugin actually already assumes this and haven't provided option to disable it.