### PR TITLE
refactor: remove unused `configurePreviewServer`

### DIFF
--- a/packages/waku/src/lib/vite-rsc/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/plugin.ts
@@ -238,13 +238,6 @@ export function rscPlugin(rscPluginOptions?: RscPluginOptions): PluginOption {
           });
         };
       },
-      async configurePreviewServer(server) {
-        const { getRequestListener } = await import('@hono/node-server');
-        const module = await import(
-          pathToFileURL(path.resolve('./dist/rsc/index.js')).href
-        );
-        server.middlewares.use(getRequestListener(module.default));
-      },
     },
     {
       name: 'rsc:waku:user-entries',


### PR DESCRIPTION
This should've been removed together during https://github.com/wakujs/waku/pull/1645.