### PR TITLE
chore(deps): remove unused `vite-plugin-stylex-dev`

### DIFF
--- a/examples/37_css-stylex/package.json
+++ b/examples/37_css-stylex/package.json
@@ -23,7 +23,6 @@
     "@types/react-dom": "19.1.7",
     "@vitejs/plugin-react": "5.0.1",
     "vite": "7.1.3",
-    "vite-plugin-babel": "^1.3.2",
-    "vite-plugin-stylex-dev": "0.8.0"
+    "vite-plugin-babel": "^1.3.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1272,9 +1272,6 @@ importers:
       vite-plugin-babel:
         specifier: ^1.3.2
         version: 1.3.2(@babel/core@7.28.3)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.1))
-      vite-plugin-stylex-dev:
-        specifier: 0.8.0
-        version: 0.8.0(rollup@4.47.1)
 
   examples/37_css-vanilla-extract:
     dependencies:
@@ -3062,31 +3059,14 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
-  '@stylex-extend/babel-plugin@0.3.3':
-    resolution: {integrity: sha512-QoKK/1VwCvEtuFmmrZp9UKJ1/hFq0aMFRe4L4IsULNUmDWjLMBsQe3UXs/JhHjCo1EZ/rc88eCXjAAU0KWf1ZA==}
-
   '@stylexjs/babel-plugin@0.15.3':
     resolution: {integrity: sha512-xQEPjNaDL2ODbxBcNzf+U56IzKIcOy9F5WJZuHxqjGtIbcOqeHXkOjnpq8hRM3d8gtSWYmEoJj4+9KTdItfDkQ==}
-
-  '@stylexjs/babel-plugin@0.7.5':
-    resolution: {integrity: sha512-KirLQIaOVHpuSZT37qV19Pw8x4te5x6hZ90+2VsrJ4NzwyYFpovlMNsTeT+eE9mcdp84VksIi7QnrNpMvqBJMQ==}
 
   '@stylexjs/postcss-plugin@0.15.3':
     resolution: {integrity: sha512-XAR3TP9b9/Ux4c9nb2dCgy1jyCzyaTXUoM3Dl7mG+4Su1FKt6yeS8ILNuujB/GlUR37PhAwLhUOvEmZzvkqnzQ==}
 
-  '@stylexjs/shared@0.5.1':
-    resolution: {integrity: sha512-3kuvLfPr1P5lbLjvtEjXmJxyBOygudhH93DA8OtNnb0H3bQjDZJQqaR/Pde67tlsdbqU5pFuaeueKkZhnuurzA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@stylexjs/shared@0.7.5':
-    resolution: {integrity: sha512-B357xldr9Dh3tP646P0JKNnarxy5ei4mkZh1qQmuhgGewbaVcrD8jiEWH3WjEzRrBKfmJtcTxBC3xp507u7O4A==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   '@stylexjs/stylex@0.15.3':
     resolution: {integrity: sha512-lBYb7NnfwQ4nVSNOxfz0Znb+yIxMFJWQuaSozNtfLZFjRwlIAadquv1Xmu5DpjzPID1wOhLaz91fZQYg3ZWngA==}
-
-  '@stylexjs/stylex@0.7.5':
-    resolution: {integrity: sha512-e4bryU2AoKBeAlloea7sJZrYrjiqJYViw8AWL6eanTVdk7qJ0CduNoiRQxtCP1dOhqGAPG74kaWT7slLzZnqKg==}
 
   '@swc/cli@0.7.8':
     resolution: {integrity: sha512-27Ov4rm0s2C6LLX+NDXfDVB69LGs8K94sXtFhgeUyQ4DBywZuCgTBu2loCNHRr8JhT9DeQvJM5j9FAu/THbo4w==}
@@ -6821,14 +6801,8 @@ packages:
   style-to-object@1.0.9:
     resolution: {integrity: sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==}
 
-  styleq@0.1.3:
-    resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
-
   styleq@0.2.1:
     resolution: {integrity: sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==}
-
-  stylis@4.3.6:
-    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -7236,9 +7210,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
       vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-
-  vite-plugin-stylex-dev@0.8.0:
-    resolution: {integrity: sha512-Zcx3Yd85ZQeUHeUEX0GqO+/0mfDiK8VAmZjCFWbqiEa03/HToBZxGElCMSu7kV8Yz9+Vdjhzk55XFBGV8LL2Ew==}
 
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
@@ -8656,14 +8627,6 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@stylex-extend/babel-plugin@0.3.3':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@stylexjs/shared': 0.5.1
-      stylis: 4.3.6
-    transitivePeerDependencies:
-      - supports-color
-
   '@stylexjs/babel-plugin@0.15.3':
     dependencies:
       '@babel/core': 7.28.3
@@ -8673,17 +8636,6 @@ snapshots:
       '@dual-bundle/import-meta-resolve': 4.1.0
       '@stylexjs/stylex': 0.15.3
       postcss-value-parser: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stylexjs/babel-plugin@0.7.5':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
-      '@stylexjs/shared': 0.7.5
-      '@stylexjs/stylex': 0.7.5
     transitivePeerDependencies:
       - supports-color
 
@@ -8698,25 +8650,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@stylexjs/shared@0.5.1':
-    dependencies:
-      postcss-value-parser: 4.2.0
-
-  '@stylexjs/shared@0.7.5':
-    dependencies:
-      postcss-value-parser: 4.2.0
-
   '@stylexjs/stylex@0.15.3':
     dependencies:
       css-mediaquery: 0.1.2
       invariant: 2.2.4
       styleq: 0.2.1
-
-  '@stylexjs/stylex@0.7.5':
-    dependencies:
-      css-mediaquery: 0.1.2
-      invariant: 2.2.4
-      styleq: 0.1.3
 
   '@swc/cli@0.7.8(@swc/core@1.13.4(@swc/helpers@0.5.17))(chokidar@4.0.3)':
     dependencies:
@@ -13104,11 +13042,7 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styleq@0.1.3: {}
-
   styleq@0.2.1: {}
-
-  stylis@4.3.6: {}
 
   sucrase@3.35.0:
     dependencies:
@@ -13582,16 +13516,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.1)
-
-  vite-plugin-stylex-dev@0.8.0(rollup@4.47.1):
-    dependencies:
-      '@babel/core': 7.28.3
-      '@rollup/pluginutils': 5.2.0(rollup@4.47.1)
-      '@stylex-extend/babel-plugin': 0.3.3
-      '@stylexjs/babel-plugin': 0.7.5
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
 
   vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.1)):
     dependencies:


### PR DESCRIPTION
I noticed some deprecated dependencies coming from `vite-plugin-stylex-dev`, which is not used in the example since https://github.com/wakujs/waku/pull/1519.

```
$ pnpm i
Scope: all 57 workspace projects
 WARN  3 deprecated subdependencies found: @stylexjs/shared@0.5.1, @stylexjs/shared@0.7.5, source-map@0.8.0-beta.0
```