### PR TITLE
chore(ci): downgrade windows 2022 for e2e (temporary)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,16 +71,16 @@ jobs:
       matrix:
         shared: [1, 2, 3, 4]
         shardTotal: [4]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
         version: [24.0.0, 22.12.0, 20.19.0]
         exclude:
           - os: macos-latest
             version: 20.19.0
-          - os: windows-latest
+          - os: windows-2022
             version: 20.19.0
           - os: macos-latest
             version: 22.12.0
-          - os: windows-latest
+          - os: windows-2022
             version: 22.12.0
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Until #1696 will be solved.