### PR TITLE
fix(website): add `precedence` to font stylesheet link

### DIFF
--- a/packages/website/src/pages/_layout.tsx
+++ b/packages/website/src/pages/_layout.tsx
@@ -41,18 +41,22 @@ const Meta = () => {
       <link
         rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&display=block"
+        precedence='font'
       />
       <link
         rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&display=block"
+        precedence='font'
       />
       <link
         rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Inter&display=block"
+        precedence='font'
       />
       <link
         rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Fira+Code&display=block"
+        precedence='font'
       />
     </>
   );


### PR DESCRIPTION
- follow up to https://github.com/wakujs/waku/pull/1689

I just realized I forgot adding `precedence` for stylesheet links in https://github.com/wakujs/waku/pull/1689 and the links show up inside `body` and not `head`. This PR add `precedence` to fix it.

```
  <link rel="preconnect" href="https://fonts.googleapis.com/"/>
  ...
</head>
<body>
  <link rel="stylesheet" href="[https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&amp;display=block](https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&display=block)"/>
```