### PR TITLE
test: avoid redundant build for PRD and STATIC

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -125,12 +125,12 @@ export const prepareNormalSetup = (fixtureName: string) => {
   const fixtureDir = fileURLToPath(
     new URL('./fixtures/' + fixtureName, import.meta.url),
   );
-  let builtMode: undefined | 'PRD' | 'STATIC';
+  let built = false
   const startApp = async (mode: 'DEV' | 'PRD' | 'STATIC') => {
-    if (mode !== 'DEV' && builtMode !== mode) {
+    if (mode !== 'DEV' && !built) {
       rmSync(`${fixtureDir}/dist`, { recursive: true, force: true });
       execSync(`node ${waku} build`, { cwd: fixtureDir });
-      builtMode = mode;
+      built = true;
     }
     let cmd: string;
     switch (mode) {
@@ -148,7 +148,6 @@ export const prepareNormalSetup = (fixtureName: string) => {
     debugChildProcess(cp, fileURLToPath(import.meta.url));
     const port = await findWakuPort(cp);
     const stopApp = async () => {
-      builtMode = undefined;
       await terminate(cp.pid!);
     };
     return { port, stopApp, fixtureDir };


### PR DESCRIPTION
Currently it runs exact same command `node ${waku} build` when spec file includes both `startApp("PRD")` and `startApp("STATIC")`, which seems redundant. This PR removes this redundancy.