### PR TITLE
test: use `prepareNormalSetup` except hot-reload and monorepo tests

### DIFF
--- a/e2e/broken-links.spec.ts
+++ b/e2e/broken-links.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 
-import { test, prepareStandaloneSetup, waitForHydration } from './utils.js';
+import { test, waitForHydration, prepareNormalSetup } from './utils.js';
 
-const startApp = prepareStandaloneSetup('broken-links');
+const startApp = prepareNormalSetup('broken-links');
 
 test.describe(`broken-links: normal server`, async () => {
   let port: number;

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -4,10 +4,10 @@ import {
   test,
   FETCH_ERROR_MESSAGES,
   waitForHydration,
-  prepareStandaloneSetup,
+  prepareNormalSetup,
 } from './utils.js';
 
-const startApp = prepareStandaloneSetup('create-pages');
+const startApp = prepareNormalSetup('create-pages');
 
 test.describe(`create-pages`, () => {
   let port: number;

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 
-import { test, prepareStandaloneSetup, waitForHydration } from './utils.js';
+import { test, waitForHydration, prepareNormalSetup } from './utils.js';
 
-const startApp = prepareStandaloneSetup('fs-router');
+const startApp = prepareNormalSetup('fs-router');
 
 test.describe(`fs-router`, async () => {
   let port: number;

--- a/e2e/ssg-performance.spec.ts
+++ b/e2e/ssg-performance.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 
-import { test, prepareStandaloneSetup } from './utils.js';
+import { test, prepareNormalSetup } from './utils.js';
 
-const startApp = prepareStandaloneSetup('ssg-performance');
+const startApp = prepareNormalSetup('ssg-performance');
 
 test.skip(
   ({ browserName }) => browserName !== 'chromium',

--- a/e2e/ssg-wildcard.spec.ts
+++ b/e2e/ssg-wildcard.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 
-import { test, prepareStandaloneSetup } from './utils.js';
+import { test, prepareNormalSetup } from './utils.js';
 
-const startApp = prepareStandaloneSetup('ssg-wildcard');
+const startApp = prepareNormalSetup('ssg-wildcard');
 
 test.describe(`ssg wildcard`, async () => {
   let port: number;

--- a/e2e/ssr-catch-error.spec.ts
+++ b/e2e/ssr-catch-error.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 
-import { test, prepareStandaloneSetup, waitForHydration } from './utils.js';
+import { test, waitForHydration, prepareNormalSetup } from './utils.js';
 
-const startApp = prepareStandaloneSetup('ssr-catch-error');
+const startApp = prepareNormalSetup('ssr-catch-error');
 
 test.describe(`ssr-catch-error`, () => {
   let port: number;

--- a/e2e/use-router.spec.ts
+++ b/e2e/use-router.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 
-import { test, waitForHydration, prepareStandaloneSetup } from './utils.js';
+import { test, waitForHydration, prepareNormalSetup } from './utils.js';
 
-const startApp = prepareStandaloneSetup('use-router');
+const startApp = prepareNormalSetup('use-router');
 
 test.describe(`useRouter`, async () => {
   let port: number;

--- a/e2e/wildcard-api-routes.spec.ts
+++ b/e2e/wildcard-api-routes.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 
-import { test, prepareStandaloneSetup } from './utils.js';
+import { test, prepareNormalSetup } from './utils.js';
 
-const startApp = prepareStandaloneSetup('wildcard-api-routes');
+const startApp = prepareNormalSetup('wildcard-api-routes');
 
 test.describe(`wildcard api routes`, async () => {
   let port: number;


### PR DESCRIPTION
This has been discussed before. For normal Waku feature testing, `prepareNormalSetup` is preferred over `prepareStandaloneSetup` since `prepareStandaloneSetup` is slower as it ensures clean install for proper isolation.