### PR TITLE
fix(cli): top level await error

### DIFF
--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -55,7 +55,7 @@ const { values, positionals } = parseArgs({
 
 const cmd = positionals[0];
 
-async function run()  {
+async function run() {
   if (values.version) {
     const { version } = require('../package.json');
     console.log(version);


### PR DESCRIPTION
I'm not 100% on the full why of this ocurring. This works as a way to fix the error in #1724 though. My best guess is that it has something to do with the top level await being called inside a conditional statement, but this seems like an easy enough small fix to just make ¯\_(ツ)_/¯
    
fixes #1724