### PR TITLE
feat: add `emitBuildMetadata` API to `handleBuild`

### DIFF
--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -43,6 +43,7 @@ export type Unstable_HandleBuild = (utils: {
     body: Promise<ReadableStream | string>,
   ) => Promise<void>;
   generateDefaultHtml: (pathname: string) => Promise<void>;
+  emitBuildMetadata: (key: string, value: any) => void;
 }) => Promise<void>;
 
 export type Unstable_CreateAppArgs = {

--- a/packages/waku/src/lib/vite-rsc/build.ts
+++ b/packages/waku/src/lib/vite-rsc/build.ts
@@ -15,6 +15,7 @@ export async function processBuild(
     filePath: string,
     bodyPromise: Promise<ReadableStream | string>,
   ) => void,
+  emitBuildMetadata: (key: string, value: any) => void,
 ) {
   const renderUtils = createRenderUtils(
     undefined,
@@ -63,6 +64,7 @@ export async function processBuild(
       );
       emitFileInTask(viteConfig.root, filePath, getFallbackHtml());
     },
+    emitBuildMetadata,
   });
 }
 

--- a/packages/waku/src/lib/vite-rsc/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/plugin.ts
@@ -329,6 +329,11 @@ if (import.meta.hot) {
               '__waku_set_platform_data.js',
             ),
           );
+          this.emitFile({
+            type: 'asset',
+            fileName: '__waku_set_platform_data.js',
+            source: `export const buildMetadata = {};\n`,
+          })
           return code.replaceAll(
             'virtual:vite-rsc-waku/set-platform-data',
             () => replacement,
@@ -351,11 +356,15 @@ if (import.meta.hot) {
           // run `handleBuild`
           INTERNAL_setAllEnv(process.env as any);
           unstable_getBuildOptions().unstable_phase = 'emitStaticFiles';
-          await entry.processBuild(viteConfig, config, emitFileInTask);
+          const buildMetadata: Record<string, any> = {};
+          function emitBuildMetadata(key: string, value: any) {
+            buildMetadata[key] = value;
+          }
+          await entry.processBuild(viteConfig, config, emitFileInTask, emitBuildMetadata);
           await waitForTasks();
 
           // save platform data
-          const platformDataCode = `globalThis.__WAKU_SERVER_PLATFORM_DATA__ = ${JSON.stringify((globalThis as any).__WAKU_SERVER_PLATFORM_DATA__ ?? {}, null, 2)}\n`;
+          const platformDataCode = `export const buildMetadata = ${JSON.stringify(buildMetadata, null, 2)};`;
           const platformDataFile = path.join(
             builder.config.environments.rsc!.build.outDir,
             '__waku_set_platform_data.js',

--- a/packages/waku/src/lib/vite-types.d.ts
+++ b/packages/waku/src/lib/vite-types.d.ts
@@ -8,7 +8,9 @@ declare module 'virtual:vite-rsc-waku/server-entry' {
 
 declare module 'virtual:vite-rsc-waku/client-entry' {}
 
-declare module 'virtual:vite-rsc-waku/set-platform-data' {}
+declare module 'virtual:vite-rsc-waku/set-platform-data' {
+  export const buildMetadata: Record<string, any>;
+}
 
 declare module 'virtual:vite-rsc-waku/config' {
   export const flags: import('./vite-rsc/plugin.ts').Flags;

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -21,6 +21,7 @@ import {
   encodeRoutePath,
   encodeSliceId,
 } from './common.js';
+import { buildMetadata } from 'virtual:vite-rsc-waku/set-platform-data'
 
 const isStringArray = (x: unknown): x is string[] =>
   Array.isArray(x) && x.every((y) => typeof y === 'string');
@@ -212,7 +213,8 @@ export function unstable_defineRouter(fns: {
   )[];
   let cachedMyConfig: MyConfig | undefined;
   const getMyConfig = async (): Promise<MyConfig> => {
-    const myConfig = await unstable_getPlatformData('defineRouterMyConfig');
+    // const myConfig = await unstable_getPlatformData('defineRouterMyConfig');
+    const myConfig = buildMetadata['defineRouterMyConfig'];
     if (myConfig) {
       return myConfig as MyConfig;
     }
@@ -533,6 +535,7 @@ export function unstable_defineRouter(fns: {
     rscPath2pathname,
     generateFile,
     generateDefaultHtml,
+    emitBuildMetadata,
   }) => {
     const myConfig = await getMyConfig();
 
@@ -629,7 +632,8 @@ export function unstable_defineRouter(fns: {
       }),
     );
 
-    await unstable_setPlatformData('defineRouterMyConfig', myConfig, true);
+    // await unstable_setPlatformData('defineRouterMyConfig', myConfig, true);
+    emitBuildMetadata('defineRouterMyConfig', myConfig);
   };
 
   return defineServer({ handleRequest, handleBuild });


### PR DESCRIPTION
This is one idea for https://github.com/wakujs/waku/pull/1688#pullrequestreview-3222971392

`emitBuildMetadata` is provided as `handleBuild(utils)` utility and it can be used to persist data for production runtime e.g.

```js
handleBuild({ emitBuildMetadata }) {
  emitBuildMetadata("key", "value");
}
```

This can be accessed on runtime by:

```js
import { buildMetadata } from "...virtual..."
buildMetadata["key"]
```

---

As seen in https://github.com/wakujs/waku/tree/main/e2e/fixtures/render-type/src/build, previously `unstable_set/getPlatformData` allowed to be called from anywhere, but this API is restricted to only "settable" via `handleBuild` implementation.