### PR TITLE
fix: log server url in `waku start` 

### DIFF
--- a/packages/waku/src/lib/vite-rsc/cli.ts
+++ b/packages/waku/src/lib/vite-rsc/cli.ts
@@ -100,14 +100,10 @@ export async function cli(
             ...(host ? { hostname: host } : {}),
             port,
           },
-          (info) => {
-            if (host) {
-              console.log(
-                `ready: Listening on port ${info.port} (${info.family} host ${info.address})`,
-              );
-            } else {
-              console.log(`ready: Listening on http://localhost:${port}/`);
-            }
+          () => {
+            console.log(
+              `ready: Listening on http://${host || 'localhost'}:${port}/`,
+            );
             resolve();
           },
         );


### PR DESCRIPTION
This output was changed by https://github.com/wakujs/waku/pull/1695, but the previous output was more DX friendly 
<img width="569" height="105" alt="image" src="https://github.com/user-attachments/assets/a5c78b3b-b3bc-42c6-b8fe-fbefcd4d020d" />

~This PR uses non url output only when users explicitly specified `--host`:~ (No, we changed all the case)

<img width="569" height="101" alt="image" src="https://github.com/user-attachments/assets/e050f006-9c70-42de-8774-ab848b16a01e" />
