### PR TITLE
ci: use overrides for canary ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
       - if: ${{ inputs.react_version }}
         run: |
-          sed -i "0,/overrides:/s//overrides:\n  react: '${{ inputs.react_version }}'\n  react-dom: '${{ inputs.react_version }}'\n  react-server-dom-webpack: '${{ inputs.react_version }}'/" pnpm-workspace.yaml
+          yq eval -i '.overrides |= (.react = "${{ inputs.react_version }}" | .["react-dom"] = "${{ inputs.react_version }}" | .["react-server-dom-webpack"] = "${{ inputs.react_version }}")' pnpm-workspace.yaml
           pnpm install --no-frozen-lockfile
       - run: pnpm install
       - run: pnpm run compile
@@ -100,9 +100,11 @@ jobs:
         with:
           node-version: ${{ matrix.version }}
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
+      - if: runner.os == 'Windows'
+        run: choco install yq -y
       - if: ${{ inputs.react_version }}
         run: |
-          sed -i "0,/overrides:/s//overrides:\n  react: '${{ inputs.react_version }}'\n  react-dom: '${{ inputs.react_version }}'\n  react-server-dom-webpack: '${{ inputs.react_version }}'/" pnpm-workspace.yaml
+          yq eval -i '.overrides |= (.react = "${{ inputs.react_version }}" | .["react-dom"] = "${{ inputs.react_version }}" | .["react-server-dom-webpack"] = "${{ inputs.react_version }}")' pnpm-workspace.yaml
           pnpm install --no-frozen-lockfile
       - run: pnpm install
       - uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
       - if: ${{ inputs.react_version }}
         run: |
-          sed -i "0,/overrides:/s//overrides:\n  react: '${{ inputs.react_version }}'\n  react-dom: '${{ inputs.react_version }}'\n  react-server-dom-webpack: '${{ inputs.react_version }}'/" pnpm-workspace.yaml
+          yq eval -i '.overrides |= (.react = "${{ inputs.react_version }}" | .["react-dom"] = "${{ inputs.react_version }}" | .["react-server-dom-webpack"] = "${{ inputs.react_version }}")' pnpm-workspace.yaml
           pnpm install --no-frozen-lockfile
       - run: pnpm install
       - run: pnpm run compile

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,3 @@ linkWorkspacePackages: true
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@hiogawa/node-loader-cloudflare'
-overrides:


### PR DESCRIPTION
Addresses https://github.com/wakujs/waku/pull/1767#issuecomment-3525794158

While `pnpm -r update` tends to bump unrelated packages in current lockfile, `overrides` should generally avoid this by targeting packages to bump. This is the approach used in Vite repository, for example https://github.com/vitejs/vite-plugin-react/blob/a06940b10c3d7c19236f1f176fc0a1748b9f62e7/.github/workflows/ci-rsc.yml#L68-L76