### PR TITLE
fix: rework adapter

### DIFF
--- a/packages/waku/src/lib/vite-rsc/plugin.ts
+++ b/packages/waku/src/lib/vite-rsc/plugin.ts
@@ -447,6 +447,7 @@ function createVirtualAdapterPlugin(config: Required<Config>) {
   const name = 'waku/adapters/default';
   return {
     name: `waku:virtual-${name}`,
+    enforce: 'pre',
     resolveId(source, _importer, _options) {
       return source === name ? this.resolve(config.adapter) : undefined;
     },


### PR DESCRIPTION
I'm finally catching up with new adapter feature. I think there is some pain points with current model. Let me think if I can find some improvements.

## notes

- adapter should be build only concept (for now)
  - during dev, it should be always node
  - we can switch build behavior by branched resolver of `waku/adapters/default` (i.e. it's essentially virtual)
- not sure `import.meta.__WAKU_ORIGINAL_PATH__` is the only way.
- `packages/website` doesn't run `pnpm start` since it hard-codes `waku/adapter/vercel`
- what to do with `{ static: true }` flag.
- ability to integrate nitro for packaging