### PR TITLE
feat: export `default { fetch }` from handler entry

### DIFF
--- a/packages/waku/src/lib/vite-entries/entry.server.tsx
+++ b/packages/waku/src/lib/vite-entries/entry.server.tsx
@@ -11,3 +11,8 @@ export async function INTERNAL_runFetch(
   INTERNAL_setAllEnv(env);
   return serverEntry.fetch(req, ...args);
 }
+
+// export "standard"-ish fetch handler entry point
+export default {
+  fetch: INTERNAL_runFetch,
+}


### PR DESCRIPTION
This makes downstream build output consumption to be easier even without "waku adapter" concept. This is extracted from https://github.com/wakujs/waku/pull/1785.