### PR TITLE
feat: add useServerInsertedHTML for CSS-in-JS support

### DIFF
--- a/examples/60_styled-components/package.json
+++ b/examples/60_styled-components/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "60_styled-components",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev",
+    "build": "waku build",
+    "start": "waku start"
+  },
+  "dependencies": {
+    "react": "~19.2.1",
+    "react-dom": "~19.2.1",
+    "react-server-dom-webpack": "~19.2.1",
+    "styled-components": "^6.1.19",
+    "waku": "0.27.3"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/60_styled-components/src/components/Counter.tsx
+++ b/examples/60_styled-components/src/components/Counter.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import styled from 'styled-components';
+
+const Button = styled.button`
+  border: 1px solid orange;
+  padding: 0.5rem 1rem;
+  background: transparent;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(255, 165, 0, 0.1);
+  }
+`;
+
+export const Counter = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <Button onClick={() => setCount((c) => c + 1)}>Count: {count}</Button>
+  );
+};

--- a/examples/60_styled-components/src/components/StyledComponentsRegistry.tsx
+++ b/examples/60_styled-components/src/components/StyledComponentsRegistry.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
+import { useServerInsertedHTML } from 'waku/server-html';
+
+/**
+ * Styled-components registry for Waku SSR.
+ *
+ * @see https://styled-components.com/docs/advanced#server-side-rendering
+ */
+export function StyledComponentsRegistry({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  // Only create stylesheet once with lazy initial state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
+
+  // On the client, just render children directly
+  if (typeof window !== 'undefined') {
+    return <>{children}</>;
+  }
+
+  // On the server, wrap with StyleSheetManager to collect styles
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      {children}
+    </StyleSheetManager>
+  );
+}

--- a/examples/60_styled-components/src/pages/_layout.tsx
+++ b/examples/60_styled-components/src/pages/_layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { StyledComponentsRegistry } from '../components/StyledComponentsRegistry';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return <StyledComponentsRegistry>{children}</StyledComponentsRegistry>;
+}

--- a/examples/60_styled-components/src/pages/index.tsx
+++ b/examples/60_styled-components/src/pages/index.tsx
@@ -1,0 +1,11 @@
+import { Counter } from '../components/Counter';
+
+export default function HomePage() {
+  return (
+    <div>
+      <title>Waku - styled-components</title>
+      <h1>styled-components Example</h1>
+      <Counter />
+    </div>
+  );
+}

--- a/examples/60_styled-components/tsconfig.json
+++ b/examples/60_styled-components/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/examples/61_emotion/package.json
+++ b/examples/61_emotion/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "61_emotion",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev",
+    "build": "waku build",
+    "start": "waku start"
+  },
+  "dependencies": {
+    "@emotion/cache": "^11.14.0",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
+    "react": "~19.2.1",
+    "react-dom": "~19.2.1",
+    "react-server-dom-webpack": "~19.2.1",
+    "waku": "0.27.3"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/61_emotion/src/components/Counter.tsx
+++ b/examples/61_emotion/src/components/Counter.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import styled from '@emotion/styled';
+
+const Button = styled.button`
+  border: 1px solid teal;
+  padding: 0.5rem 1rem;
+  background: transparent;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(0, 128, 128, 0.1);
+  }
+`;
+
+export const Counter = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <Button onClick={() => setCount((c) => c + 1)}>Count: {count}</Button>
+  );
+};

--- a/examples/61_emotion/src/components/EmotionRegistry.tsx
+++ b/examples/61_emotion/src/components/EmotionRegistry.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
+import { useServerInsertedHTML } from 'waku/server-html';
+
+/**
+ * Emotion registry for Waku SSR.
+ *
+ * @see https://emotion.sh/docs/ssr
+ */
+export function EmotionRegistry({ children }: { children: ReactNode }) {
+  const [cache] = useState(() => {
+    const cache = createCache({ key: 'css' });
+    cache.compat = true;
+    return cache;
+  });
+
+  useServerInsertedHTML(() => {
+    return (
+      <style
+        data-emotion={`${cache.key} ${Object.keys(cache.inserted).join(' ')}`}
+        dangerouslySetInnerHTML={{
+          __html: Object.values(cache.inserted).join(' '),
+        }}
+      />
+    );
+  });
+
+  return <CacheProvider value={cache}>{children}</CacheProvider>;
+}

--- a/examples/61_emotion/src/pages/_layout.tsx
+++ b/examples/61_emotion/src/pages/_layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { EmotionRegistry } from '../components/EmotionRegistry';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return <EmotionRegistry>{children}</EmotionRegistry>;
+}

--- a/examples/61_emotion/src/pages/index.tsx
+++ b/examples/61_emotion/src/pages/index.tsx
@@ -1,0 +1,11 @@
+import { Counter } from '../components/Counter';
+
+export default function HomePage() {
+  return (
+    <div>
+      <title>Waku - Emotion</title>
+      <h1>Emotion Example</h1>
+      <Counter />
+    </div>
+  );
+}

--- a/examples/61_emotion/tsconfig.json
+++ b/examples/61_emotion/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/react"
+  }
+}

--- a/examples/61_emotion/waku.config.ts
+++ b/examples/61_emotion/waku.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  vite: {
+    environments: {
+      rsc: {
+        resolve: {
+          // Prevent Emotion from being bundled in RSC (uses createContext)
+          external: ['@emotion/react', '@emotion/styled', '@emotion/cache'],
+        },
+      },
+    },
+  },
+});

--- a/examples/62_styled-jsx/package.json
+++ b/examples/62_styled-jsx/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "62_styled-jsx",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev",
+    "build": "waku build",
+    "start": "waku start"
+  },
+  "dependencies": {
+    "react": "~19.2.1",
+    "react-dom": "~19.2.1",
+    "react-server-dom-webpack": "~19.2.1",
+    "styled-jsx": "^5.1.6",
+    "waku": "0.27.3"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/62_styled-jsx/src/components/Counter.tsx
+++ b/examples/62_styled-jsx/src/components/Counter.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState } from 'react';
+
+export const Counter = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <>
+      <button onClick={() => setCount((c) => c + 1)}>Count: {count}</button>
+      { /* eslint-disable-next-line react/no-unknown-property */ }
+      <style jsx>{`
+        button {
+          border: 1px solid teal;
+          padding: 0.5rem 1rem;
+          background: transparent;
+          cursor: pointer;
+        }
+
+        button:hover {
+          background: rgba(0, 128, 128, 0.1);
+        }
+      `}</style>
+    </>
+  );
+};

--- a/examples/62_styled-jsx/src/components/StyledJsxRegistry.tsx
+++ b/examples/62_styled-jsx/src/components/StyledJsxRegistry.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { StyleRegistry, createStyleRegistry } from 'styled-jsx';
+import { useServerInsertedHTML } from 'waku/server-html';
+
+/**
+ * styled-jsx registry for Waku SSR.
+ *
+ * @see https://github.com/vercel/styled-jsx
+ */
+export function StyledJsxRegistry({ children }: { children: ReactNode }) {
+  const [jsxStyleRegistry] = useState(() => createStyleRegistry());
+
+  useServerInsertedHTML(() => {
+    const styles = jsxStyleRegistry.styles();
+    jsxStyleRegistry.flush();
+    return <>{styles}</>;
+  });
+
+  return <StyleRegistry registry={jsxStyleRegistry}>{children}</StyleRegistry>;
+}

--- a/examples/62_styled-jsx/src/pages/_layout.tsx
+++ b/examples/62_styled-jsx/src/pages/_layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { StyledJsxRegistry } from '../components/StyledJsxRegistry';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return <StyledJsxRegistry>{children}</StyledJsxRegistry>;
+}

--- a/examples/62_styled-jsx/src/pages/index.tsx
+++ b/examples/62_styled-jsx/src/pages/index.tsx
@@ -1,0 +1,11 @@
+import { Counter } from '../components/Counter';
+
+export default function HomePage() {
+  return (
+    <div>
+      <title>Waku - styled-jsx</title>
+      <h1>styled-jsx Example</h1>
+      <Counter />
+    </div>
+  );
+}

--- a/examples/62_styled-jsx/src/styled-jsx.d.ts
+++ b/examples/62_styled-jsx/src/styled-jsx.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="styled-jsx" />

--- a/examples/62_styled-jsx/tsconfig.json
+++ b/examples/62_styled-jsx/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/examples/62_styled-jsx/waku.config.ts
+++ b/examples/62_styled-jsx/waku.config.ts
@@ -1,0 +1,14 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  vite: {
+    plugins: [
+      react({
+        babel: {
+          plugins: ['styled-jsx/babel'],
+        },
+      }),
+    ],
+  },
+});

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -61,6 +61,10 @@
     "./router/server": {
       "types": "./dist/router/server.d.ts",
       "default": "./dist/router/server.js"
+    },
+    "./server-html": {
+      "types": "./dist/server-html/client.d.ts",
+      "default": "./dist/server-html/client.js"
     }
   },
   "bin": {

--- a/packages/waku/src/server-html/client.tsx
+++ b/packages/waku/src/server-html/client.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import * as React from 'react';
+import { ServerInsertedHTMLContext } from './server-inserted-html.js';
+
+export type ServerInsertedHTMLHook = (callback: () => ReactNode) => void;
+
+/**
+ * Hook to register HTML content to be inserted during server-side rendering.
+ * This is similar to Next.js's `useServerInsertedHTML` hook.
+ *
+ * The callback will be called during streaming and its result will be
+ * inserted into the HTML stream before the closing </head> tag.
+ *
+ * @example
+ * ```tsx
+ * 'use client';
+ *
+ * import { useState } from 'react';
+ * import { useServerInsertedHTML } from 'waku/server-html';
+ *
+ * export function StyleRegistry({ children }) {
+ *   const [styles, setStyles] = useState<string[]>([]);
+ *
+ *   useServerInsertedHTML(() => {
+ *     if (styles.length === 0) return null;
+ *     const html = styles.join('');
+ *     setStyles([]);
+ *     return <style dangerouslySetInnerHTML={{ __html: html }} />;
+ *   });
+ *
+ *   return <>{children}</>;
+ * }
+ * ```
+ */
+export function useServerInsertedHTML(callback: () => ReactNode): void {
+  const addInsertedServerHTMLCallback = React.useContext(
+    ServerInsertedHTMLContext,
+  );
+  // Should have no effects on client where there's no provider
+  if (addInsertedServerHTMLCallback) {
+    addInsertedServerHTMLCallback(callback);
+  }
+}

--- a/packages/waku/src/server-html/server-inserted-html.tsx
+++ b/packages/waku/src/server-html/server-inserted-html.tsx
@@ -1,0 +1,87 @@
+/**
+ * Internal SSR utilities for server-inserted HTML.
+ * This module provides the context and rendering utilities for collecting
+ * and injecting HTML content (like CSS-in-JS styles) during streaming SSR.
+ */
+
+import type { JSX, ReactNode } from 'react';
+import * as React from 'react';
+import { renderToReadableStream } from 'react-dom/server.edge';
+import { streamToString } from './stream-transforms.js';
+
+export type ServerInsertedHTMLHook = (callback: () => ReactNode) => void;
+
+/**
+ * Context for collecting server-inserted HTML callbacks.
+ * Used by CSS-in-JS libraries to inject styles during SSR.
+ *
+ * We use `React.createContext` to avoid errors from RSC checks because
+ * it can't be imported directly in Server Components.
+ */
+export const ServerInsertedHTMLContext =
+  React.createContext<ServerInsertedHTMLHook | null>(null);
+
+/**
+ * Creates the provider and render function for server-inserted HTML.
+ * This is used internally by Waku's SSR rendering pipeline.
+ */
+export function createServerInsertedHTML(): {
+  ServerInsertedHTMLProvider: ({
+    children,
+  }: {
+    children: JSX.Element;
+  }) => JSX.Element;
+  renderServerInsertedHTML: () => ReactNode;
+} {
+  const serverInsertedHTMLCallbacks: Array<() => ReactNode> = [];
+
+  const addInsertedHtml = (handler: () => ReactNode) => {
+    serverInsertedHTMLCallbacks.push(handler);
+  };
+
+  return {
+    ServerInsertedHTMLProvider({ children }: { children: JSX.Element }) {
+      return (
+        <ServerInsertedHTMLContext.Provider value={addInsertedHtml}>
+          {children}
+        </ServerInsertedHTMLContext.Provider>
+      );
+    },
+    renderServerInsertedHTML() {
+      return serverInsertedHTMLCallbacks.map((callback, index) => (
+        <React.Fragment key={'__waku_server_inserted__' + index}>
+          {callback()}
+        </React.Fragment>
+      ));
+    },
+  };
+}
+
+/**
+ * Creates a function that renders server-inserted HTML to a string.
+ * This is used to inject CSS-in-JS styles and other content during streaming.
+ */
+export function makeGetServerInsertedHTML(
+  renderServerInsertedHTML: () => ReactNode,
+): () => Promise<string> {
+  return async function getServerInsertedHTML(): Promise<string> {
+    const serverInsertedHTML = renderServerInsertedHTML();
+
+    // Skip rendering if there's nothing to insert
+    if (
+      serverInsertedHTML === null ||
+      serverInsertedHTML === undefined ||
+      (Array.isArray(serverInsertedHTML) && serverInsertedHTML.length === 0)
+    ) {
+      return '';
+    }
+
+    // Render the collected HTML to a stream and convert to string
+    const stream = await renderToReadableStream(<>{serverInsertedHTML}</>, {
+      // Larger chunk size since this isn't sent over the network
+      progressiveChunkSize: 1024 * 1024,
+    });
+
+    return streamToString(stream);
+  };
+}

--- a/packages/waku/src/server-html/stream-transforms.ts
+++ b/packages/waku/src/server-html/stream-transforms.ts
@@ -1,0 +1,147 @@
+/**
+ * Stream transform utilities for SSR streaming.
+ * These utilities enable injection of server-inserted HTML (like CSS-in-JS styles)
+ * into the HTML stream at the appropriate location.
+ */
+
+// Shared encoder instance (safe to share as TextEncoder is stateless)
+const encoder = new TextEncoder();
+
+// Encoded closing head tag for searching
+const ENCODED_CLOSING_HEAD = encoder.encode('</head>');
+
+/**
+ * Finds the index of a byte sequence within a Uint8Array.
+ */
+function indexOfUint8Array(
+  source: Uint8Array,
+  search: Uint8Array,
+  fromIndex = 0,
+): number {
+  const searchLength = search.length;
+  const sourceLength = source.length;
+
+  if (searchLength === 0) {
+    return fromIndex;
+  }
+  if (searchLength > sourceLength) {
+    return -1;
+  }
+
+  outer: for (let i = fromIndex; i <= sourceLength - searchLength; i++) {
+    for (let j = 0; j < searchLength; j++) {
+      if (source[i + j] !== search[j]) {
+        continue outer;
+      }
+    }
+    return i;
+  }
+
+  return -1;
+}
+
+/**
+ * Creates a transform stream that inserts HTML content before the closing </head> tag.
+ *
+ * This is used for injecting server-inserted HTML during streaming SSR,
+ * such as CSS-in-JS styles from libraries like styled-components or Emotion.
+ *
+ * The insertion function is called:
+ * - Before each chunk is enqueued (to collect newly registered content)
+ * - On flush (to handle any remaining content)
+ *
+ * @param insert - Async function that returns HTML string to insert
+ */
+export function createHeadInsertionTransformStream(
+  insert: () => Promise<string> | string,
+): TransformStream<Uint8Array, Uint8Array> {
+  let inserted = false;
+  // Track if we've seen any bytes - if not, we don't want to insert anything
+  let hasBytes = false;
+
+  return new TransformStream({
+    async transform(chunk, controller) {
+      hasBytes = true;
+
+      const insertion = await insert();
+
+      if (inserted) {
+        // Already found </head>, just pass through
+        if (insertion) {
+          controller.enqueue(encoder.encode(insertion));
+        }
+        controller.enqueue(chunk);
+        return;
+      }
+
+      // Look for </head> in this chunk
+      const index = indexOfUint8Array(chunk, ENCODED_CLOSING_HEAD);
+
+      if (index !== -1) {
+        // Found </head>
+        if (insertion) {
+          const encodedInsertion = encoder.encode(insertion);
+          // Create new array: [before </head>] + [insertion] + [</head> onwards]
+          const result = new Uint8Array(
+            chunk.length + encodedInsertion.length,
+          );
+          // Copy bytes before </head>
+          result.set(chunk.slice(0, index));
+          // Insert the server-inserted HTML
+          result.set(encodedInsertion, index);
+          // Copy </head> and everything after
+          result.set(chunk.slice(index), index + encodedInsertion.length);
+          controller.enqueue(result);
+        } else {
+          controller.enqueue(chunk);
+        }
+        inserted = true;
+      } else {
+        // No </head> found in this chunk
+        // This can happen with PPR or when the head is split across chunks
+        // In this case, we insert before the chunk and pass it through
+        if (insertion) {
+          controller.enqueue(encoder.encode(insertion));
+        }
+        controller.enqueue(chunk);
+        inserted = true;
+      }
+    },
+    async flush(controller) {
+      // Check if there's anything remaining to insert at the end
+      if (hasBytes) {
+        const insertion = await insert();
+        if (insertion) {
+          controller.enqueue(encoder.encode(insertion));
+        }
+      }
+    },
+  });
+}
+
+/**
+ * Converts a ReadableStream to a string.
+ * Useful for rendering React elements to string on the server.
+ */
+export async function streamToString(
+  stream: ReadableStream<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  let result = '';
+
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      result += decoder.decode(value, { stream: true });
+    }
+    result += decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+
+  return result;
+}

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -1,4 +1,5 @@
 import { getContext } from './lib/context.js';
+
 export {
   getContext as unstable_getContext,
   getContextData as unstable_getContextData,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1299,7 +1299,7 @@ importers:
     dependencies:
       '@vanilla-extract/css':
         specifier: ^1.17.5
-        version: 1.17.5
+        version: 1.17.5(babel-plugin-macros@3.1.0)
       react:
         specifier: ~19.2.1
         version: 19.2.1
@@ -1321,7 +1321,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vanilla-extract/vite-plugin':
         specifier: ^5.1.3
-        version: 5.1.3(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2))(yaml@2.8.2)
+        version: 5.1.3(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2))(yaml@2.8.2)
 
   examples/38_cookies:
     dependencies:
@@ -1612,6 +1612,99 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/60_styled-components:
+    dependencies:
+      react:
+        specifier: ~19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ~19.2.1
+        version: 19.2.1(react@19.2.1)
+      react-server-dom-webpack:
+        specifier: ~19.2.1
+        version: 19.2.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack@5.99.9)
+      styled-components:
+        specifier: ^6.1.19
+        version: 6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      waku:
+        specifier: 0.27.3
+        version: link:../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  examples/61_emotion:
+    dependencies:
+      '@emotion/cache':
+        specifier: ^11.14.0
+        version: 11.14.0
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@19.2.7)(react@19.2.1)
+      '@emotion/styled':
+        specifier: ^11.14.0
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react@19.2.1)
+      react:
+        specifier: ~19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ~19.2.1
+        version: 19.2.1(react@19.2.1)
+      react-server-dom-webpack:
+        specifier: ~19.2.1
+        version: 19.2.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack@5.99.9)
+      waku:
+        specifier: 0.27.3
+        version: link:../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  examples/62_styled-jsx:
+    dependencies:
+      react:
+        specifier: ~19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ~19.2.1
+        version: 19.2.1(react@19.2.1)
+      react-server-dom-webpack:
+        specifier: ~19.2.1
+        version: 19.2.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack@5.99.9)
+      styled-jsx:
+        specifier: ^5.1.6
+        version: 5.1.7(@babel/core@7.28.5)(react@19.2.1)
+      waku:
+        specifier: 0.27.3
+        version: link:../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.0
+        version: 5.1.0(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/create-waku:
     devDependencies:
       '@clack/prompts':
@@ -1710,7 +1803,7 @@ importers:
         version: 2.3.2
       framer-motion:
         specifier: ^12.23.25
-        version: 12.23.25(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 12.23.25(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       jotai:
         specifier: ^2.15.2
         version: 2.15.2(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.7)(react@19.2.1)
@@ -2041,8 +2134,68 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@emotion/babel-plugin@11.13.5':
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
+
+  '@emotion/cache@11.14.0':
+    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
+
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
+
+  '@emotion/is-prop-valid@1.2.2':
+    resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
+
+  '@emotion/is-prop-valid@1.4.0':
+    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
+
+  '@emotion/memoize@0.8.1':
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@emotion/react@11.14.0':
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/serialize@1.3.3':
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
+
+  '@emotion/sheet@1.4.0':
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+
+  '@emotion/styled@11.14.1':
+    resolution: {integrity: sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0-rc.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+
+  '@emotion/unitless@0.8.1':
+    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@emotion/utils@1.4.2':
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
+
+  '@emotion/weak-memoize@0.4.0':
+    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -3395,6 +3548,9 @@ packages:
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
+  '@types/parse-json@4.0.2':
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -3402,6 +3558,9 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+
+  '@types/stylis@4.2.5':
+    resolution: {integrity: sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==}
 
   '@types/tar@6.1.13':
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
@@ -3886,6 +4045,10 @@ packages:
       react-native-b4a:
         optional: true
 
+  babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
@@ -3999,6 +4162,9 @@ packages:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
 
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+
   caniuse-lite@1.0.30001757:
     resolution: {integrity: sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==}
 
@@ -4066,6 +4232,9 @@ packages:
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   clipboardy@3.0.0:
     resolution: {integrity: sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==}
@@ -4136,6 +4305,9 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -4149,12 +4321,23 @@ packages:
   core-js-compat@3.47.0:
     resolution: {integrity: sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==}
 
+  cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
   css-mediaquery@0.1.2:
     resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
@@ -4164,6 +4347,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -4288,6 +4474,9 @@ packages:
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -4623,6 +4812,9 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -4820,6 +5012,9 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   hono@4.10.0:
     resolution: {integrity: sha512-V/S2IyKL6fk5+bEjiQzg74r5BglqAwU20IX3WjdTUFgvmtSqAZjSxN/Zb5lr6/JXVmH0aqkqOq++3UgzOi9+4Q==}
     engines: {node: '>=16.9.0'}
@@ -4898,6 +5093,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
@@ -5639,6 +5837,10 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
@@ -5666,6 +5868,10 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -5739,6 +5945,10 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -6094,6 +6304,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
+
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -6162,6 +6375,10 @@ packages:
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -6277,8 +6494,34 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  styled-components@6.1.19:
+    resolution: {integrity: sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
+
+  styled-jsx@5.1.7:
+    resolution: {integrity: sha512-HPLmEIYprxCeWDMLYiaaAhsV3yGfIlCqzuVOybE6fjF3SUJmH67nCoMDO+nAvHNHo46OfvpCNu4Rcue82dMNFg==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
   styleq@0.2.1:
     resolution: {integrity: sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==}
+
+  stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+
+  stylis@4.3.2:
+    resolution: {integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -6424,6 +6667,9 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -6824,6 +7070,10 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
@@ -7186,7 +7436,96 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emotion/babel-plugin@11.13.5':
+    dependencies:
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/cache@11.14.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      stylis: 4.2.0
+
   '@emotion/hash@0.9.2': {}
+
+  '@emotion/is-prop-valid@1.2.2':
+    dependencies:
+      '@emotion/memoize': 0.8.1
+
+  '@emotion/is-prop-valid@1.4.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+
+  '@emotion/memoize@0.8.1': {}
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.1)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/serialize@1.3.3':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
+      csstype: 3.2.3
+
+  '@emotion/sheet@1.4.0': {}
+
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/is-prop-valid': 1.4.0
+      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.1)
+      '@emotion/utils': 1.4.2
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/unitless@0.10.0': {}
+
+  '@emotion/unitless@0.8.1': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+
+  '@emotion/utils@1.4.2': {}
+
+  '@emotion/weak-memoize@0.4.0': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -8245,6 +8584,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/parse-json@4.0.2': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
       '@types/react': 19.2.7
@@ -8252,6 +8593,8 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/stylis@4.2.5': {}
 
   '@types/tar@6.1.13':
     dependencies:
@@ -8421,10 +8764,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vanilla-extract/compiler@0.3.3(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2)':
+  '@vanilla-extract/compiler@0.3.3(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2)':
     dependencies:
-      '@vanilla-extract/css': 1.17.5
-      '@vanilla-extract/integration': 8.0.6
+      '@vanilla-extract/css': 1.17.5(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/integration': 8.0.6(babel-plugin-macros@3.1.0)
       vite: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2)
       vite-node: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -8442,14 +8785,14 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/css@1.17.5':
+  '@vanilla-extract/css@1.17.5(babel-plugin-macros@3.1.0)':
     dependencies:
       '@emotion/hash': 0.9.2
       '@vanilla-extract/private': 1.0.9
       css-what: 6.2.2
       cssesc: 3.0.0
       csstype: 3.2.3
-      dedent: 1.7.0
+      dedent: 1.7.0(babel-plugin-macros@3.1.0)
       deep-object-diff: 1.1.9
       deepmerge: 4.3.1
       lru-cache: 10.4.3
@@ -8459,13 +8802,13 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@vanilla-extract/integration@8.0.6':
+  '@vanilla-extract/integration@8.0.6(babel-plugin-macros@3.1.0)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
-      '@vanilla-extract/css': 1.17.5
-      dedent: 1.7.0
+      '@vanilla-extract/css': 1.17.5(babel-plugin-macros@3.1.0)
+      dedent: 1.7.0(babel-plugin-macros@3.1.0)
       esbuild: 0.27.0
       eval: 0.1.8
       find-up: 5.0.0
@@ -8477,10 +8820,10 @@ snapshots:
 
   '@vanilla-extract/private@1.0.9': {}
 
-  '@vanilla-extract/vite-plugin@5.1.3(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2))(yaml@2.8.2)':
+  '@vanilla-extract/vite-plugin@5.1.3(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2))(yaml@2.8.2)':
     dependencies:
-      '@vanilla-extract/compiler': 0.3.3(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2)
-      '@vanilla-extract/integration': 8.0.6
+      '@vanilla-extract/compiler': 0.3.3(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2)
+      '@vanilla-extract/integration': 8.0.6(babel-plugin-macros@3.1.0)
       vite: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
@@ -8903,6 +9246,12 @@ snapshots:
 
   b4a@1.7.3: {}
 
+  babel-plugin-macros@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      cosmiconfig: 7.1.0
+      resolve: 1.22.11
+
   babel-plugin-react-compiler@1.0.0:
     dependencies:
       '@babel/types': 7.28.5
@@ -9017,6 +9366,8 @@ snapshots:
 
   camelcase@7.0.1: {}
 
+  camelize@1.0.1: {}
+
   caniuse-lite@1.0.30001757: {}
 
   ccount@2.0.1: {}
@@ -9065,6 +9416,8 @@ snapshots:
       escape-string-regexp: 5.0.0
 
   cli-boxes@3.0.0: {}
+
+  client-only@0.0.1: {}
 
   clipboardy@3.0.0:
     dependencies:
@@ -9130,6 +9483,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  convert-source-map@1.9.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@2.0.0: {}
@@ -9140,17 +9495,35 @@ snapshots:
     dependencies:
       browserslist: 4.28.0
 
+  cosmiconfig@7.1.0:
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-color-keywords@1.0.0: {}
+
   css-mediaquery@0.1.2: {}
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   css-what@6.2.2: {}
 
   cssesc@3.0.0: {}
+
+  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -9192,7 +9565,9 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  dedent@1.7.0: {}
+  dedent@1.7.0(babel-plugin-macros@3.1.0):
+    optionalDependencies:
+      babel-plugin-macros: 3.1.0
 
   deep-extend@0.6.0: {}
 
@@ -9250,6 +9625,10 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   error-stack-parser-es@1.0.5: {}
 
@@ -9838,6 +10217,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-root@1.1.0: {}
+
   find-up-simple@1.0.1: {}
 
   find-up@5.0.0:
@@ -9877,12 +10258,13 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
-  framer-motion@12.23.25(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  framer-motion@12.23.25(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       motion-dom: 12.23.23
       motion-utils: 12.23.6
       tslib: 2.8.1
     optionalDependencies:
+      '@emotion/is-prop-valid': 1.4.0
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
@@ -10084,6 +10466,10 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
   hono@4.10.0: {}
 
   html-void-elements@3.0.0: {}
@@ -10148,6 +10534,8 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-arrayish@0.3.4: {}
 
@@ -11030,6 +11418,13 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   parse-ms@4.0.0: {}
 
   path-exists@4.0.0: {}
@@ -11045,6 +11440,8 @@ snapshots:
   path-to-regexp@3.3.0: {}
 
   path-to-regexp@6.3.0: {}
+
+  path-type@4.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -11100,6 +11497,12 @@ snapshots:
       yaml: 2.8.2
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.49:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.6:
     dependencies:
@@ -11489,6 +11892,8 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
+  shallowequal@1.1.0: {}
+
   sharp@0.33.5:
     dependencies:
       color: 4.2.3
@@ -11594,6 +11999,8 @@ snapshots:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+
+  source-map@0.5.7: {}
 
   source-map@0.6.1: {}
 
@@ -11727,7 +12134,32 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@emotion/is-prop-valid': 1.2.2
+      '@emotion/unitless': 0.8.1
+      '@types/stylis': 4.2.5
+      css-to-react-native: 3.2.0
+      csstype: 3.1.3
+      postcss: 8.4.49
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      shallowequal: 1.1.0
+      stylis: 4.3.2
+      tslib: 2.6.2
+
+  styled-jsx@5.1.7(@babel/core@7.28.5)(react@19.2.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.1
+    optionalDependencies:
+      '@babel/core': 7.28.5
+
   styleq@0.2.1: {}
+
+  stylis@4.2.0: {}
+
+  stylis@4.3.2: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -11876,6 +12308,8 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@2.6.2: {}
 
   tslib@2.8.1: {}
 
@@ -12405,6 +12839,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yaml@1.10.2: {}
 
   yaml@2.8.2: {}
 


### PR DESCRIPTION
Attempt to address https://github.com/wakujs/waku/discussions/1211

I know CSS-in-JS is dead, but we have tons of old projects still using it and can't be migrated quickly, this PR followed NextJS's take on `useServerInsertedHTML` to add streaming SSR support to CSS-in-JS libs

I've explored different approaches before submitting this PR, like exposing SSR hooks with wrapElement and transformHtml, it's simple and works great with SSG but doesn't support steaming

Happy to discuss about the API design, like should we prefix with `unstable_` and should we just expose it from `waku`

