### PR TITLE
chore: use `viteRsc.loadModule` in styled-components demo

### DIFF
--- a/e2e/fixtures/styled-components/waku.config.ts
+++ b/e2e/fixtures/styled-components/waku.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "waku/config"
+
+export default defineConfig({
+  vite: {
+    environments: {
+      ssr: {
+        build: {
+          rollupOptions: {
+            input: {
+              __server_html: "./src/server-html/ssr.ts",
+            }
+          }
+        }
+      }
+    }
+  }
+})


### PR DESCRIPTION
- Related https://github.com/wakujs/waku/discussions/1211#discussioncomment-15277402

I'm not sure this approach has been brought up. This isn't clean either, but just sharing that importing "ssr" environment module is possible in this way.