### PR TITLE
feat: export vite plugins (unstable)

### DIFF
--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -38,9 +38,9 @@
       "types": "./dist/internals.d.ts",
       "default": "./dist/internals.js"
     },
-    "./internals/*": {
-      "types": "./dist/internals/*.d.ts",
-      "default": "./dist/internals/*.js"
+    "./vite-plugins": {
+      "types": "./dist/vite-plugins.d.ts",
+      "default": "./dist/vite-plugins.js"
     },
     "./adapters/*": {
       "types": "./dist/adapters/*.d.ts",

--- a/packages/waku/src/internals/vite-plugins.ts
+++ b/packages/waku/src/internals/vite-plugins.ts
@@ -1,1 +1,0 @@
-export { rscPlugin as unstable_rscPlugin, type RscPluginOptions as unstable_RscPluginOptions } from '../lib/vite-rsc/plugin.js'

--- a/packages/waku/src/vite-plugins.ts
+++ b/packages/waku/src/vite-plugins.ts
@@ -1,0 +1,11 @@
+export { allowServerPlugin as unstable_allowServerPlugin } from './lib/vite-plugins/allow-server.js';
+export { buildMetadataPlugin as unstable_buildMetadataPlugin } from './lib/vite-plugins/build-metadata.js';
+export { defaultAdapterPlugin as unstable_defaultAdapterPlugin } from './lib/vite-plugins/default-adapter.js';
+export { fallbackHtmlPlugin as unstable_fallbackHtmlPlugin } from './lib/vite-plugins/fallback-html.js';
+export { fsRouterTypegenPlugin as unstable_fsRouterTypegenPlugin } from './lib/vite-plugins/fs-router-typegen.js';
+export { mainPlugin as unstable_mainPlugin } from './lib/vite-plugins/main.js';
+export { notFoundPlugin as unstable_notFoundPlugin } from './lib/vite-plugins/not-found.js';
+export { patchRsdwPlugin as unstable_patchRsdwPlugin } from './lib/vite-plugins/patch-rsdw.js';
+export { privateDirPlugin as unstable_privateDirPlugin } from './lib/vite-plugins/private-dir.js';
+export { userEntriesPlugin as unstable_userEntriesPlugin } from './lib/vite-plugins/user-entries.js';
+export { virtualConfigPlugin as unstable_virtualConfigPlugin } from './lib/vite-plugins/virtual-config.js';


### PR DESCRIPTION
This PR proposes to export `rscPlugin` via the internal entrypoint. I intentionally did not add it in `src/internals.ts` as it would conflict with the virtual modules exposed in `createServerEntryAdapter`.

Rationale: Exploring a new version of [Vocs](https://github.com/wevm/vocs) that will use Waku internally (in a Vite plugin). As such, it would be amazing to have access to the `rscPlugin`!

----

edit(daishi): export all internal plugins instead of `rscPlugin`.