### PR TITLE
breaking(minimal): rename renderHtml option

### DIFF
--- a/e2e/fixtures/styled-components/src/server-html/ssr.ts
+++ b/e2e/fixtures/styled-components/src/server-html/ssr.ts
@@ -1,16 +1,10 @@
-import type { ReactNode } from 'react';
+import type { unstable_defineHandlers as defineHandlers } from 'waku/minimal/server';
 import { getServerInsertedHTML, serverInsertedHTMLStorage } from './context';
 import { createHeadInsertionTransformStream } from './stream';
 
-type RenderHtml = (
-  elementsStream: ReadableStream,
-  html: ReactNode,
-  options: {
-    rscPath: string;
-    actionResult?: unknown;
-    status?: number;
-  },
-) => Promise<Response>;
+type RenderHtml = Parameters<
+  ReturnType<typeof defineHandlers>['handleRequest']
+>[1]['renderHtml'];
 
 export function injectRenderHtml(renderHtml: RenderHtml): RenderHtml {
   if (!import.meta.env.SSR) {

--- a/examples/36_form/src/waku.server.tsx
+++ b/examples/36_form/src/waku.server.tsx
@@ -22,14 +22,13 @@ export default adapter({
       (input.type === 'action' || input.type === 'custom') &&
       input.pathname === '/'
     ) {
-      const actionResult =
-        input.type === 'action' ? await input.fn() : undefined;
+      const formState = input.type === 'action' ? await input.fn() : undefined;
       return renderHtml(
         await renderRsc({ App: <App name="Waku" /> }),
         <Slot id="App" />,
         {
           rscPath: '',
-          actionResult,
+          formState,
         },
       );
     }

--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -14,7 +14,7 @@ export type Unstable_ParseRsc = (
 export type Unstable_RenderHtml = (
   elementsStream: ReadableStream,
   html: ReactNode,
-  options: { rscPath: string; actionResult?: unknown; status?: number },
+  options: { rscPath: string; formState?: unknown; status?: number },
 ) => Promise<Response>;
 
 export type Unstable_EmitFile = (

--- a/packages/waku/src/lib/utils/render.ts
+++ b/packages/waku/src/lib/utils/render.ts
@@ -43,11 +43,7 @@ export function createRenderUtils(
         Record<string, unknown>
       >;
     },
-    async renderHtml(
-      elementsStream,
-      html,
-      options?: { rscPath?: string; actionResult?: any; status?: number },
-    ) {
+    async renderHtml(elementsStream, html, options) {
       const { INTERNAL_renderHtmlStream: renderHtmlStream } =
         await loadSsrEntryModule();
 
@@ -55,11 +51,12 @@ export function createRenderUtils(
         onError,
       });
       const htmlResult = await renderHtmlStream(elementsStream, rscHtmlStream, {
-        formState: options?.actionResult,
-        rscPath: options?.rscPath,
+        formState: options.formState as never,
+        rscPath: options.rscPath,
+        nonce: undefined,
       });
       return new Response(htmlResult.stream, {
-        status: htmlResult.status || options?.status || 200,
+        status: htmlResult.status || options.status || 200,
         headers: { 'content-type': 'text/html' },
       });
     },

--- a/packages/waku/src/lib/vite-rsc/ssr.tsx
+++ b/packages/waku/src/lib/vite-rsc/ssr.tsx
@@ -12,10 +12,10 @@ import { batchReadableStream } from '../utils/stream.js';
 type RenderHtmlStream = (
   rscStream: ReadableStream<Uint8Array>,
   rscHtmlStream: ReadableStream<Uint8Array>,
-  options?: {
-    rscPath?: string | undefined;
-    formState?: ReactFormState | undefined;
-    nonce?: string | undefined;
+  options: {
+    rscPath: string | undefined;
+    formState: ReactFormState | undefined;
+    nonce: string | undefined;
   },
 ) => Promise<{ stream: ReadableStream; status: number | undefined }>;
 
@@ -59,7 +59,7 @@ export const renderHtmlStream: RenderHtmlStream = async (
     htmlStream = await renderToReadableStream(<SsrRoot />, {
       bootstrapScriptContent:
         getBootstrapPreamble({
-          rscPath: options?.rscPath || '',
+          rscPath: options.rscPath || '',
           hydrate: true,
         }) + bootstrapScriptContent,
       onError: (e: unknown) => {
@@ -73,8 +73,8 @@ export const renderHtmlStream: RenderHtmlStream = async (
         }
         console.error('[SSR Error]', captureOwnerStack?.() || '', '\n', e);
       },
-      ...(options?.nonce ? { nonce: options.nonce } : {}),
-      ...(options?.formState ? { formState: options.formState } : {}),
+      ...(options.nonce ? { nonce: options.nonce } : {}),
+      ...(options.formState ? { formState: options.formState } : {}),
     });
   } catch (e) {
     const info = getErrorInfo(e);
@@ -92,17 +92,17 @@ export const renderHtmlStream: RenderHtmlStream = async (
     htmlStream = await renderToReadableStream(ssrErrorRoot, {
       bootstrapScriptContent:
         getBootstrapPreamble({
-          rscPath: options?.rscPath || '',
+          rscPath: options.rscPath || '',
           hydrate: false,
         }) + bootstrapScriptContent,
-      ...(options?.nonce ? { nonce: options.nonce } : {}),
+      ...(options.nonce ? { nonce: options.nonce } : {}),
     });
   }
   let responseStream: ReadableStream<Uint8Array> = htmlStream;
   responseStream = responseStream.pipeThrough(
     injectRSCPayload(
       batchReadableStream(stream2),
-      options?.nonce ? { nonce: options?.nonce } : {},
+      options.nonce ? { nonce: options.nonce } : {},
     ),
   );
 

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -531,11 +531,11 @@ export function unstable_defineRouter(fns: {
             httpstatus={httpstatus}
           />
         );
-        const actionResult =
+        const formState =
           input.type === 'action' ? await input.fn() : undefined;
         return renderHtml(await renderRsc(entries), html, {
           rscPath,
-          actionResult,
+          formState,
           status: httpstatus,
         });
       };


### PR DESCRIPTION
https://github.com/wakujs/waku/pull/1923#issuecomment-3793655838

`actionResult` 👉 `formState`.

This is a braking change in the minimal api, which is technically unstable.