### PR TITLE
fix(cmd): use correct variable in ready log message

### DIFF
--- a/packages/waku/src/lib/vite-rsc/cmd-start.ts
+++ b/packages/waku/src/lib/vite-rsc/cmd-start.ts
@@ -19,7 +19,7 @@ export async function runStart(flags: { host?: string; port?: string }) {
   }
   process.env.PORT = String(port);
   await import(serveFileUrl);
-  console.log(`ready: Listening on http://${host || 'localhost'}:${port}/`);
+  console.log(`ready: Listening on http://${process.env.HOST || 'localhost'}:${port}/`);
 }
 
 async function getFreePort(startPort: number): Promise<number> {


### PR DESCRIPTION
Right now when setting hostname via HOST env (which seems to be supported, but not documented), the console output is:
`ready: Listening on http://localhost:8080/`
The correct output should be (if HOST env is 0.0.0.0):
`ready: Listening on http://0.0.0.0:8080/`

This pr changes output when host flag is NOT set and HOST env variable IS set
This pr doesn't change the program's behaviour