### PR TITLE
fix(router): restore cross-page hash scrolling after navigation

### DIFF
--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useTransition,
@@ -819,6 +820,24 @@ const InnerRouter = ({
     setRoute((prev) => (isSameRoute(prev, initialRoute) ? prev : initialRoute));
   }, [initialRoute]);
   const [err, setErr] = useState<unknown>(null);
+  const pendingScrollRef = useRef<{
+    behavior: ScrollBehavior;
+    route: RouteProps;
+    scrollTopForMissingHash: boolean;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    const pendingScroll = pendingScrollRef.current;
+    if (!pendingScroll || !isSameRoute(pendingScroll.route, route)) {
+      return;
+    }
+    pendingScrollRef.current = null;
+    scrollToRoute(
+      pendingScroll.route,
+      pendingScroll.behavior,
+      pendingScroll.scrollTopForMissingHash,
+    );
+  }, [route]);
 
   const [routeChangeEvents, emitRouteChangeEvent] =
     routeChangeListenersRef.current;
@@ -920,12 +939,16 @@ const InnerRouter = ({
           return;
         }
         writeHistoryIfNeeded(mode, urlToWrite);
+        pendingScrollRef.current = options.shouldScroll
+          ? {
+              route: nextRoute,
+              behavior: scrollBehavior,
+              scrollTopForMissingHash: pathChanged,
+            }
+          : null;
         routeRef.current = nextRoute;
         setRoute(nextRoute);
         routeChangeAbortRef.current = null;
-        if (options.shouldScroll) {
-          scrollToRoute(nextRoute, scrollBehavior, pathChanged);
-        }
         emitRouteChangeEvent('complete', nextRoute);
       });
     },

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1005,9 +1005,15 @@ describe('Router integration', () => {
   test('push to a new path with hash scrolls using destination hash after history write', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
+    const NextRoute = () => (
+      <>
+        <Probe />
+        <div id="target">target</div>
+      </>
+    );
     const elements = {
       [unstable_getRouteSlotId('/start')]: <Probe />,
-      [unstable_getRouteSlotId('/next')]: <Probe />,
+      [unstable_getRouteSlotId('/next')]: <NextRoute />,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
     };
@@ -1027,12 +1033,24 @@ describe('Router integration', () => {
       configurable: true,
       value: 100,
     });
-    const hashTarget = document.createElement('div');
-    hashTarget.id = 'target';
     const getBoundingClientRectSpy = vi
-      .spyOn(hashTarget, 'getBoundingClientRect')
-      .mockReturnValue({ top: 40 } as DOMRect);
-    document.body.append(hashTarget);
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.id === 'target') {
+          return { top: 40 } as DOMRect;
+        }
+        return {
+          bottom: 0,
+          height: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        } as DOMRect;
+      });
 
     const view = await renderRouter(
       {
@@ -1041,6 +1059,7 @@ describe('Router integration', () => {
       elements,
     );
     try {
+      document.body.append(view.container);
       if (!capture.router) {
         throw new Error('router not initialized');
       }
@@ -1048,6 +1067,7 @@ describe('Router integration', () => {
       await act(async () => {
         await capture.router!.push('/next#target');
       });
+      await flush();
 
       expect(scrollToSpy).toHaveBeenCalledWith({
         left: 0,
@@ -1063,7 +1083,6 @@ describe('Router integration', () => {
     } finally {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
-      hashTarget.remove();
       if (scrollYDescriptor) {
         Object.defineProperty(window, 'scrollY', scrollYDescriptor);
       } else {


### PR DESCRIPTION
- defer route hash scrolling until after the new route commits
- add a regression test that mounts the destination anchor in the next route instead of pre-appending it to document.body