### PR TITLE
fix(router): slice with children

### DIFF
--- a/e2e/fixtures/fs-router/src/pages/_slices/two.tsx
+++ b/e2e/fixtures/fs-router/src/pages/_slices/two.tsx
@@ -1,5 +1,7 @@
-export default function Slice002() {
-  return <h4 data-testid="slice002">Slice 002</h4>;
+import type { ReactNode } from 'react';
+
+export default function Slice002({ children }: { children?: ReactNode }) {
+  return <h4 data-testid="slice002">Slice 002: {children}</h4>;
 }
 
 export const getConfig = () => {

--- a/e2e/fixtures/fs-router/src/pages/page-with-slices/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/page-with-slices/index.tsx
@@ -7,7 +7,7 @@ export default function Slices() {
     <>
       <h2>Slices</h2>
       <Slice id={slices[0]} />
-      <Slice id={slices[1]} />
+      <Slice id={slices[1]}>Hello from page with slices</Slice>
       <Slice
         id="dynamic/test123"
         lazy

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -263,7 +263,9 @@ test.describe('fs-router', () => {
     await waitForHydration(page);
     const sliceText = await page.getByTestId('slice001').textContent();
     expect(sliceText?.startsWith('Slice 001')).toBeTruthy();
-    await expect(page.getByTestId('slice002')).toHaveText('Slice 002');
+    await expect(page.getByTestId('slice002')).toHaveText(
+      'Slice 002: Hello from page with slices',
+    );
   });
 
   test('slug slices', async ({ page }) => {

--- a/examples/11_fs-router/src/pages/_slices/two.tsx
+++ b/examples/11_fs-router/src/pages/_slices/two.tsx
@@ -1,9 +1,12 @@
-export default function SliceTwo() {
+import type { ReactNode } from 'react';
+
+export default function SliceTwo({ children }: { children: ReactNode }) {
   return (
     <div>
       <h2 className="text-2xl font-bold">
         Slice Two {new Date().toLocaleString()}
       </h2>
+      <p>Children={children}</p>
     </div>
   );
 }

--- a/examples/11_fs-router/src/pages/slice-page.tsx
+++ b/examples/11_fs-router/src/pages/slice-page.tsx
@@ -5,7 +5,7 @@ export default function SlicePage() {
     <div>
       <h2>Slice Page</h2>
       <Slice id="one" />
-      <Slice id="two" />
+      <Slice id="two">Hello from SlicePage</Slice>
     </div>
   );
 }

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -916,7 +916,7 @@ export const createPages = <
             if (!slice) {
               throw new Error('Slice not found: ' + id);
             }
-            return <slice.component {...params} />;
+            return createElement(slice.component, params, <Children />);
           },
         };
       });

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -4,6 +4,7 @@ import type { TypeEqual } from 'ts-expect';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MockedFunction } from 'vitest';
 import { parsePathWithSlug } from '../src/lib/utils/path.js';
+import { Children } from '../src/minimal/client.js';
 import type { PathsForPages } from '../src/router/base-types.js';
 import type { GetSlugs } from '../src/router/create-pages-utils/inferred-path-types.js';
 import {
@@ -972,7 +973,7 @@ describe('createPages pages and layouts', () => {
     });
   });
 
-  it('slug slice renderer passes params as props', async () => {
+  it('slug slice renderer passes params and children placeholder as props', async () => {
     const TestPage = () => null;
     const TestSlice = (_props: { id: string }) => null;
     createPages(async ({ createSlice, createPage }) => [
@@ -994,7 +995,8 @@ describe('createPages pages and layouts', () => {
     ) as any;
     const element = await sliceConfig.renderer({ id: '123' });
     expect(element).toBeDefined();
-    expect(element.props).toEqual({ id: '123' });
+    expect(element.props.id).toBe('123');
+    expect(element.props.children.type).toBe(Children);
   });
 
   it('static slice without slug has no pathSpec', async () => {


### PR DESCRIPTION
I just noticed `<Slice id="...">...</Slice>` is not supported/implemented, which I thought we did.