### PR TITLE
feat(router): layout slug props [breaking behavior]

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -502,7 +502,11 @@ test.describe(`create-pages`, () => {
   }) => {
     await page.goto(`http://localhost:${port}/layout-props/dynamic/en/post-1`);
     await expect(
-      page.getByRole('heading', { name: 'Dynamic Parent Layout' }),
+      page.getByRole('heading', {
+        name: 'Dynamic Parent Layout',
+        exact: true,
+        level: 2,
+      }),
     ).toBeVisible();
     await expect(page.getByTestId('dynamic-layout-props-keys')).toHaveText(
       'lang',
@@ -523,7 +527,11 @@ test.describe(`create-pages`, () => {
   }) => {
     await page.goto(`http://localhost:${port}/layout-props/static/en/post-1`);
     await expect(
-      page.getByRole('heading', { name: 'Static Parent Layout' }),
+      page.getByRole('heading', {
+        name: 'Static Parent Layout',
+        exact: true,
+        level: 2,
+      }),
     ).toBeVisible();
     await expect(page.getByTestId('static-layout-props-keys')).toHaveText(
       'lang',
@@ -544,7 +552,11 @@ test.describe(`create-pages`, () => {
       `http://localhost:${port}/layout-props/dynamic-complex/aaa/parent-b/ccc/parent-d/eee/child-f`,
     );
     await expect(
-      page.getByRole('heading', { name: 'Dynamic Complex Layout' }),
+      page.getByRole('heading', {
+        name: 'Dynamic Complex Layout',
+        exact: true,
+        level: 2,
+      }),
     ).toBeVisible();
     await expect(
       page.getByTestId('dynamic-complex-layout-props-keys'),
@@ -572,7 +584,11 @@ test.describe(`create-pages`, () => {
       `http://localhost:${port}/layout-props/static-grouped/en/docs/post-1`,
     );
     await expect(
-      page.getByRole('heading', { name: 'Static Grouped Layout' }),
+      page.getByRole('heading', {
+        name: 'Static Grouped Layout',
+        exact: true,
+        level: 2,
+      }),
     ).toBeVisible();
     await expect(
       page.getByTestId('static-grouped-layout-props-keys'),

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -497,6 +497,133 @@ test.describe(`create-pages`, () => {
     expect(dynamicTime2).not.toEqual(staticTime2);
   });
 
+  test('dynamic layout receives parent slug but not child slug', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/layout-props/dynamic/en/post-1`);
+    await expect(
+      page.getByRole('heading', { name: 'Dynamic Parent Layout' }),
+    ).toBeVisible();
+    await expect(page.getByTestId('dynamic-layout-props-keys')).toHaveText(
+      'lang',
+    );
+    await expect(page.getByTestId('dynamic-layout-props-lang')).toHaveText(
+      'en',
+    );
+    await expect(page.getByTestId('dynamic-layout-props-slug')).toHaveText(
+      'missing',
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Dynamic Layout Props Page post-1' }),
+    ).toBeVisible();
+  });
+
+  test('static layout receives parent slug but not child slug', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/layout-props/static/en/post-1`);
+    await expect(
+      page.getByRole('heading', { name: 'Static Parent Layout' }),
+    ).toBeVisible();
+    await expect(page.getByTestId('static-layout-props-keys')).toHaveText(
+      'lang',
+    );
+    await expect(page.getByTestId('static-layout-props-lang')).toHaveText('en');
+    await expect(page.getByTestId('static-layout-props-slug')).toHaveText(
+      'missing',
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Static Layout Props Page post-1' }),
+    ).toBeVisible();
+  });
+
+  test('dynamic layout receives all parent slugs in a complex path but not child slugs', async ({
+    page,
+  }) => {
+    await page.goto(
+      `http://localhost:${port}/layout-props/dynamic-complex/aaa/parent-b/ccc/parent-d/eee/child-f`,
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Dynamic Complex Layout' }),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('dynamic-complex-layout-props-keys'),
+    ).toHaveText('bbb,ddd');
+    await expect(
+      page.getByTestId('dynamic-complex-layout-props-bbb'),
+    ).toHaveText('parent-b');
+    await expect(
+      page.getByTestId('dynamic-complex-layout-props-ddd'),
+    ).toHaveText('parent-d');
+    await expect(
+      page.getByTestId('dynamic-complex-layout-props-fff'),
+    ).toHaveText('missing');
+    await expect(
+      page.getByRole('heading', {
+        name: 'Dynamic Complex Layout Props Page child-f',
+      }),
+    ).toBeVisible();
+  });
+
+  test('static grouped layout receives parent slugs and keeps cache separated by concrete path', async ({
+    page,
+  }) => {
+    await page.goto(
+      `http://localhost:${port}/layout-props/static-grouped/en/docs/post-1`,
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Static Grouped Layout' }),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('static-grouped-layout-props-keys'),
+    ).toHaveText('lang,section');
+    await expect(
+      page.getByTestId('static-grouped-layout-props-lang'),
+    ).toHaveText('en');
+    await expect(
+      page.getByTestId('static-grouped-layout-props-section'),
+    ).toHaveText('docs');
+    await expect(
+      page.getByTestId('static-grouped-layout-props-slug'),
+    ).toHaveText('missing');
+    await expect(
+      page.getByRole('heading', {
+        name: 'Static Grouped Layout Props Page post-1',
+      }),
+    ).toBeVisible();
+
+    await page.goto(
+      `http://localhost:${port}/layout-props/static-grouped/fr/blog/post-2`,
+    );
+    await expect(
+      page.getByTestId('static-grouped-layout-props-keys'),
+    ).toHaveText('lang,section');
+    await expect(
+      page.getByTestId('static-grouped-layout-props-lang'),
+    ).toHaveText('fr');
+    await expect(
+      page.getByTestId('static-grouped-layout-props-section'),
+    ).toHaveText('blog');
+    await expect(
+      page.getByTestId('static-grouped-layout-props-slug'),
+    ).toHaveText('missing');
+    await expect(
+      page.getByRole('heading', {
+        name: 'Static Grouped Layout Props Page post-2',
+      }),
+    ).toBeVisible();
+
+    await page.goto(
+      `http://localhost:${port}/layout-props/static-grouped/en/docs/post-1`,
+    );
+    await expect(
+      page.getByTestId('static-grouped-layout-props-lang'),
+    ).toHaveText('en');
+    await expect(
+      page.getByTestId('static-grouped-layout-props-section'),
+    ).toHaveText('docs');
+  });
+
   test('no ssr', async ({ page }) => {
     await page.goto(`http://localhost:${port}/no-ssr`);
     await expect(

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -21,6 +21,25 @@ import { Slice001 } from './components/slice001.js';
 import { Slice002 } from './components/slice002.js';
 import { Slice003 } from './components/slice003.js';
 
+const renderLayoutProps = (title: string, testIdPrefix: string, props: any) => (
+  <div>
+    <h2>{title}</h2>
+    <p data-testid={`${testIdPrefix}-keys`}>
+      {Object.keys(props)
+        .filter((key) => key !== 'children')
+        .sort()
+        .join(',') || 'none'}
+    </p>
+    <p data-testid={`${testIdPrefix}-bbb`}>{props.bbb ?? 'missing'}</p>
+    <p data-testid={`${testIdPrefix}-ddd`}>{props.ddd ?? 'missing'}</p>
+    <p data-testid={`${testIdPrefix}-fff`}>{props.fff ?? 'missing'}</p>
+    <p data-testid={`${testIdPrefix}-lang`}>{props.lang ?? 'missing'}</p>
+    <p data-testid={`${testIdPrefix}-section`}>{props.section ?? 'missing'}</p>
+    <p data-testid={`${testIdPrefix}-slug`}>{props.slug ?? 'missing'}</p>
+    {props.children}
+  </div>
+);
+
 const pages: ReturnType<typeof createPages> = createPages(
   async ({ createPage, createLayout, createApi, createSlice }) => [
     createLayout({
@@ -336,6 +355,82 @@ const pages: ReturnType<typeof createPages> = createPages(
       render: 'dynamic',
       path: '/dynamic',
       component: () => <h1>Dynamic Page</h1>,
+    }),
+
+    createLayout({
+      render: 'dynamic',
+      path: '/layout-props/dynamic/[lang]',
+      component: ((props: any) =>
+        renderLayoutProps(
+          'Dynamic Parent Layout',
+          'dynamic-layout-props',
+          props,
+        )) as any,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/layout-props/dynamic/[lang]/[slug]',
+      component: ({ slug }) => <h1>Dynamic Layout Props Page {slug}</h1>,
+    }),
+
+    createLayout({
+      render: 'dynamic',
+      path: '/layout-props/dynamic-complex/aaa/[bbb]/ccc/[ddd]',
+      component: ((props: any) =>
+        renderLayoutProps(
+          'Dynamic Complex Layout',
+          'dynamic-complex-layout-props',
+          props,
+        )) as any,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/layout-props/dynamic-complex/aaa/[bbb]/ccc/[ddd]/eee/[fff]',
+      component: ({ fff }) => <h1>Dynamic Complex Layout Props Page {fff}</h1>,
+    }),
+
+    createLayout({
+      render: 'static',
+      path: '/layout-props/static/[lang]',
+      component: ((props: any) =>
+        renderLayoutProps(
+          'Static Parent Layout',
+          'static-layout-props',
+          props,
+        )) as any,
+    }),
+
+    createPage({
+      render: 'static',
+      path: '/layout-props/static/[lang]/[slug]',
+      staticPaths: [
+        ['en', 'post-1'],
+        ['fr', 'post-2'],
+      ] as const,
+      component: ({ slug }) => <h1>Static Layout Props Page {slug}</h1>,
+    }),
+
+    createLayout({
+      render: 'static',
+      path: '/(group)/layout-props/static-grouped/[lang]/[section]',
+      component: ((props: any) =>
+        renderLayoutProps(
+          'Static Grouped Layout',
+          'static-grouped-layout-props',
+          props,
+        )) as any,
+    }),
+
+    createPage({
+      render: 'static',
+      path: '/(group)/layout-props/static-grouped/[lang]/[section]/[slug]',
+      staticPaths: [
+        ['en', 'docs', 'post-1'],
+        ['fr', 'blog', 'post-2'],
+      ] as const,
+      component: ({ slug }) => <h1>Static Grouped Layout Props Page {slug}</h1>,
     }),
 
     createLayout({

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -389,15 +389,14 @@ export const createPages = <
     return (pathname: string) => pathMappingWithoutGroups(pathSpec, pathname);
   };
 
-  const getLayoutIdPath = (
-    layoutPath: string,
-    routePath: string,
-  ): string => {
+  const getLayoutIdPath = (layoutPath: string, routePath: string): string => {
     const numSegments = parsePathWithSlug(layoutPath).length;
     if (numSegments === 0) {
       return '/';
     }
-    return '/' + routePath.split('/').filter(Boolean).slice(0, numSegments).join('/');
+    return (
+      '/' + routePath.split('/').filter(Boolean).slice(0, numSegments).join('/')
+    );
   };
 
   /** Builds the routeElement renderer from layouts and page slots */

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -458,7 +458,8 @@ export const createPages = <
       component: Slot,
       props: { id: `layout:${layoutIdPath}` },
     }));
-    return () => createNestedElements(layoutElements, <Slot id={`page:${path}`} />);
+    return () =>
+      createNestedElements(layoutElements, <Slot id={`page:${path}`} />);
   };
 
   /** Renders the root component */

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -179,12 +179,16 @@ export type CreateLayout = <Path extends string>(
     | {
         render: 'dynamic';
         path: Path;
-        component: FunctionComponent<{ children: ReactNode }>;
+        component: FunctionComponent<
+          { children: ReactNode } & Omit<PropsForPages<Path>, 'path' | 'query'>
+        >;
       }
     | {
         render: 'static';
         path: Path;
-        component: FunctionComponent<{ children: ReactNode }>;
+        component: FunctionComponent<
+          { children: ReactNode } & Omit<PropsForPages<Path>, 'path' | 'query'>
+        >;
       },
 ) => void;
 
@@ -387,6 +391,26 @@ export const createPages = <
     const layoutMatchPath = groupPathLookup.get(path) ?? path;
     const pathSpec = parsePathWithSlug(layoutMatchPath);
     return (pathname: string) => pathMappingWithoutGroups(pathSpec, pathname);
+  };
+
+  const createLayoutPropsMapper = (layoutPath: string) => {
+    const pathSpec = parsePathWithSlug(layoutPath);
+    const numSegments = pathSpec.filter(
+      (segment) =>
+        !(segment.type === 'literal' && segment.name.startsWith('(')),
+    ).length;
+    return (routePath: string) => {
+      const layoutRoutePath =
+        numSegments === 0
+          ? '/'
+          : '/' +
+            routePath
+              .split('/')
+              .filter(Boolean)
+              .slice(0, numSegments)
+              .join('/');
+      return pathMappingWithoutGroups(pathSpec, layoutRoutePath) ?? {};
+    };
   };
 
   const getLayoutIdPath = (layoutPath: string, routePath: string): string => {
@@ -718,9 +742,15 @@ export const createPages = <
           if (!layout || Array.isArray(layout)) {
             throw new Error('Invalid layout ' + layoutPath);
           }
+          const getLayoutPropsMapping = createLayoutPropsMapper(layoutPath);
           elements[`layout:${layoutIdPath}`] = {
             isStatic: !dynamicLayoutPathMap.has(layoutPath),
-            renderer: () => createElement(layout, null, <Children />),
+            renderer: (option) =>
+              createElement(
+                layout,
+                getLayoutPropsMapping(option.routePath),
+                <Children />,
+              ),
           };
         }
 
@@ -774,9 +804,15 @@ export const createPages = <
           if (!layout || Array.isArray(layout)) {
             throw new Error('Invalid layout ' + layoutPath);
           }
+          const getLayoutPropsMapping = createLayoutPropsMapper(layoutPath);
           elements[`layout:${layoutIdPath}`] = {
             isStatic: !dynamicLayoutPathMap.has(layoutPath),
-            renderer: () => createElement(layout, null, <Children />),
+            renderer: (option) =>
+              createElement(
+                layout,
+                getLayoutPropsMapping(option.routePath),
+                <Children />,
+              ),
           };
         }
 
@@ -846,9 +882,15 @@ export const createPages = <
           if (!layout || Array.isArray(layout)) {
             throw new Error('Invalid layout ' + layoutPath);
           }
+          const getLayoutPropsMapping = createLayoutPropsMapper(layoutPath);
           elements[`layout:${layoutIdPath}`] = {
             isStatic: !dynamicLayoutPathMap.has(layoutPath),
-            renderer: () => createElement(layout, null, <Children />),
+            renderer: (option) =>
+              createElement(
+                layout,
+                getLayoutPropsMapping(option.routePath),
+                <Children />,
+              ),
           };
         }
 

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -389,15 +389,26 @@ export const createPages = <
     return (pathname: string) => pathMappingWithoutGroups(pathSpec, pathname);
   };
 
+  const getLayoutIdPath = (
+    layoutPath: string,
+    routePath: string,
+  ): string => {
+    const numSegments = parsePathWithSlug(layoutPath).length;
+    if (numSegments === 0) {
+      return '/';
+    }
+    return '/' + routePath.split('/').filter(Boolean).slice(0, numSegments).join('/');
+  };
+
   /** Builds the routeElement renderer from layouts and page slots */
   const buildRouteElement = (
-    layoutPaths: string[],
+    layouts: { layoutPath: string; layoutIdPath: string }[],
     path: string,
     pageComponent: ComponentEntry,
   ) => {
-    const layouts = layoutPaths.map((lPath) => ({
+    const layoutElements = layouts.map(({ layoutIdPath }) => ({
       component: Slot,
-      props: { id: `layout:${lPath}` },
+      props: { id: `layout:${layoutIdPath}` },
     }));
     const finalPageChildren = Array.isArray(pageComponent) ? (
       <>
@@ -408,7 +419,7 @@ export const createPages = <
     ) : (
       <Slot id={`page:${path}`} />
     );
-    return () => createNestedElements(layouts, finalPageChildren);
+    return () => createNestedElements(layoutElements, finalPageChildren);
   };
 
   /** Renders the root component */
@@ -687,7 +698,13 @@ export const createPages = <
       const rootIsStatic = !rootItem || rootItem.render === 'static';
       for (const [path, { literalSpec, originalSpec }] of staticPathMap) {
         const noSsr = noSsrSet.has(literalSpec);
-        const layoutPaths = getLayouts(originalSpec ?? literalSpec);
+        const routePath = groupPathLookup.get(path) ?? path;
+        const layouts = getLayouts(originalSpec ?? literalSpec).map(
+          (layoutPath) => ({
+            layoutPath,
+            layoutIdPath: getLayoutIdPath(layoutPath, routePath),
+          }),
+        );
         const pageComponent = staticComponentMap.get(
           joinPath(path, 'page').slice(1),
         )!;
@@ -696,13 +713,14 @@ export const createPages = <
         const elements: Record<string, ElementSpec> = {};
 
         // Add layout elements
-        for (const lPath of layoutPaths) {
-          const layout = getDynamicLayout(lPath) ?? getStaticLayout(lPath);
+        for (const { layoutPath, layoutIdPath } of layouts) {
+          const layout =
+            getDynamicLayout(layoutPath) ?? getStaticLayout(layoutPath);
           if (!layout || Array.isArray(layout)) {
-            throw new Error('Invalid layout ' + lPath);
+            throw new Error('Invalid layout ' + layoutPath);
           }
-          elements[`layout:${lPath}`] = {
-            isStatic: !dynamicLayoutPathMap.has(lPath),
+          elements[`layout:${layoutIdPath}`] = {
+            isStatic: !dynamicLayoutPathMap.has(layoutPath),
             renderer: () => createElement(layout, null, <Children />),
           };
         }
@@ -733,7 +751,7 @@ export const createPages = <
           rootElement: { isStatic: rootIsStatic, renderer: renderRoot },
           routeElement: {
             isStatic: true,
-            renderer: buildRouteElement(layoutPaths, path, pageComponent),
+            renderer: buildRouteElement(layouts, path, pageComponent),
           },
           elements,
           noSsr,
@@ -742,19 +760,23 @@ export const createPages = <
       }
       for (const [path, [pathSpec, components]] of dynamicPagePathMap) {
         const noSsr = noSsrSet.has(pathSpec);
-        const layoutPaths = getLayouts(pathSpec);
+        const layouts = getLayouts(pathSpec).map((layoutPath) => ({
+          layoutPath,
+          layoutIdPath: layoutPath,
+        }));
         const getPropsMapping = createPathPropsMapper(path);
 
         const elements: Record<string, ElementSpec> = {};
 
         // Add layout elements
-        for (const lPath of layoutPaths) {
-          const layout = getDynamicLayout(lPath) ?? getStaticLayout(lPath);
+        for (const { layoutPath, layoutIdPath } of layouts) {
+          const layout =
+            getDynamicLayout(layoutPath) ?? getStaticLayout(layoutPath);
           if (!layout || Array.isArray(layout)) {
-            throw new Error('Invalid layout ' + lPath);
+            throw new Error('Invalid layout ' + layoutPath);
           }
-          elements[`layout:${lPath}`] = {
-            isStatic: !dynamicLayoutPathMap.has(lPath),
+          elements[`layout:${layoutIdPath}`] = {
+            isStatic: !dynamicLayoutPathMap.has(layoutPath),
             renderer: () => createElement(layout, null, <Children />),
           };
         }
@@ -801,7 +823,7 @@ export const createPages = <
           rootElement: { isStatic: rootIsStatic, renderer: renderRoot },
           routeElement: {
             isStatic: true,
-            renderer: buildRouteElement(layoutPaths, path, components),
+            renderer: buildRouteElement(layouts, path, components),
           },
           elements,
           noSsr,
@@ -810,19 +832,23 @@ export const createPages = <
       }
       for (const [path, [pathSpec, components]] of wildcardPagePathMap) {
         const noSsr = noSsrSet.has(pathSpec);
-        const layoutPaths = getLayouts(pathSpec);
+        const layouts = getLayouts(pathSpec).map((layoutPath) => ({
+          layoutPath,
+          layoutIdPath: layoutPath,
+        }));
         const getPropsMapping = createPathPropsMapper(path);
 
         const elements: Record<string, ElementSpec> = {};
 
         // Add layout elements
-        for (const lPath of layoutPaths) {
-          const layout = getDynamicLayout(lPath) ?? getStaticLayout(lPath);
+        for (const { layoutPath, layoutIdPath } of layouts) {
+          const layout =
+            getDynamicLayout(layoutPath) ?? getStaticLayout(layoutPath);
           if (!layout || Array.isArray(layout)) {
-            throw new Error('Invalid layout ' + lPath);
+            throw new Error('Invalid layout ' + layoutPath);
           }
-          elements[`layout:${lPath}`] = {
-            isStatic: !dynamicLayoutPathMap.has(lPath),
+          elements[`layout:${layoutIdPath}`] = {
+            isStatic: !dynamicLayoutPathMap.has(layoutPath),
             renderer: () => createElement(layout, null, <Children />),
           };
         }
@@ -869,7 +895,7 @@ export const createPages = <
           rootElement: { isStatic: rootIsStatic, renderer: renderRoot },
           routeElement: {
             isStatic: true,
-            renderer: buildRouteElement(layoutPaths, path, components),
+            renderer: buildRouteElement(layouts, path, components),
           },
           elements,
           noSsr,

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 import { expectType } from 'ts-expect';
 import type { TypeEqual } from 'ts-expect';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -2821,6 +2821,83 @@ describe('createPages - grouped paths', () => {
         slices: [],
       },
     ]);
+  });
+
+  it('layout renderer passes parent slug props without child slug for dynamic routes', async () => {
+    const TestPage = () => null;
+    const TestLayout = (_props: { children: ReactNode; lang: string }) => null;
+    createPages(async ({ createPage, createLayout }) => [
+      createLayout({
+        render: 'dynamic',
+        path: '/layout-props/[lang]',
+        component: TestLayout,
+      }),
+      createPage({
+        render: 'dynamic',
+        path: '/layout-props/[lang]/[slug]',
+        component: TestPage,
+      }),
+    ]);
+    const { getConfigs } = injectedFunctions();
+    const configs = Array.from(await getConfigs()) as any[];
+    const routeConfig = configs.find(
+      (config) =>
+        config.type === 'route' &&
+        config.path?.[0]?.name === 'layout-props' &&
+        config.path?.[1]?.name === 'lang' &&
+        config.path?.[2]?.name === 'slug',
+    );
+    const element = routeConfig.elements[
+      'layout:/layout-props/[lang]'
+    ].renderer({
+      routePath: '/layout-props/en/post-1',
+      query: undefined,
+    });
+    expect(element.props.lang).toBe('en');
+    expect(element.props.slug).toBeUndefined();
+    expect(element.props.children.type).toBe(Children);
+  });
+
+  it('layout renderer passes grouped parent slug props without child slug for static routes', async () => {
+    const TestPage = () => null;
+    const TestLayout = (_props: {
+      children: ReactNode;
+      lang: string;
+      section: string;
+    }) => null;
+    createPages(async ({ createPage, createLayout }) => [
+      createLayout({
+        render: 'static',
+        path: '/(group)/layout-props/[lang]/[section]',
+        component: TestLayout,
+      }),
+      createPage({
+        render: 'static',
+        path: '/(group)/layout-props/[lang]/[section]/[slug]',
+        staticPaths: [['en', 'docs', 'post-1']] as const,
+        component: TestPage,
+      }),
+    ]);
+    const { getConfigs } = injectedFunctions();
+    const configs = Array.from(await getConfigs()) as any[];
+    const routeConfig = configs.find(
+      (config) =>
+        config.type === 'route' &&
+        config.path?.[0]?.name === 'layout-props' &&
+        config.path?.[1]?.name === 'en' &&
+        config.path?.[2]?.name === 'docs' &&
+        config.path?.[3]?.name === 'post-1',
+    );
+    const element = routeConfig.elements[
+      'layout:/(group)/layout-props/en/docs'
+    ].renderer({
+      routePath: '/layout-props/en/docs/post-1',
+      query: undefined,
+    });
+    expect(element.props.lang).toBe('en');
+    expect(element.props.section).toBe('docs');
+    expect(element.props.slug).toBeUndefined();
+    expect(element.props.children.type).toBe(Children);
   });
 });
 

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -2753,6 +2753,75 @@ describe('createPages - grouped paths', () => {
       },
     ]);
   });
+
+  it('uses concrete layout ids for static layout under grouped dynamic segment', async () => {
+    const TestPage = () => null;
+    const TestLayout = ({ children }: PropsWithChildren) => children;
+    createPages(async ({ createPage, createLayout }) => [
+      createLayout({
+        render: 'static',
+        path: '/(group)/[lang]',
+        component: TestLayout,
+      }),
+      createPage({
+        render: 'static',
+        path: '/(group)/[lang]/about',
+        staticPaths: ['en', 'fr'] as const,
+        component: TestPage,
+      }),
+    ]);
+    const { getConfigs } = injectedFunctions();
+    expect(await getConfigs()).toEqual([
+      {
+        type: 'route',
+        elements: {
+          'layout:/(group)/en': {
+            isStatic: true,
+            renderer: expect.any(Function),
+          },
+          'page:/en/about': { isStatic: true, renderer: expect.any(Function) },
+        },
+        rootElement: { isStatic: true, renderer: expect.any(Function) },
+        routeElement: { isStatic: true, renderer: expect.any(Function) },
+        noSsr: false,
+        path: [
+          { type: 'literal', name: 'en' },
+          { type: 'literal', name: 'about' },
+        ],
+        pathPattern: [
+          { type: 'literal', name: '(group)' },
+          { type: 'group', name: 'lang' },
+          { type: 'literal', name: 'about' },
+        ],
+        isStatic: true,
+        slices: [],
+      },
+      {
+        type: 'route',
+        elements: {
+          'layout:/(group)/fr': {
+            isStatic: true,
+            renderer: expect.any(Function),
+          },
+          'page:/fr/about': { isStatic: true, renderer: expect.any(Function) },
+        },
+        rootElement: { isStatic: true, renderer: expect.any(Function) },
+        routeElement: { isStatic: true, renderer: expect.any(Function) },
+        noSsr: false,
+        path: [
+          { type: 'literal', name: 'fr' },
+          { type: 'literal', name: 'about' },
+        ],
+        pathPattern: [
+          { type: 'literal', name: '(group)' },
+          { type: 'group', name: 'lang' },
+          { type: 'literal', name: 'about' },
+        ],
+        isStatic: true,
+        slices: [],
+      },
+    ]);
+  });
 });
 
 describe('pathMappingWithoutGroups', () => {


### PR DESCRIPTION
close #1665 

## Summary

This PR adds slug props support for layouts by introducing a breaking change in static layout behavior.

## Layout slug props

Before this PR, layouts only received `children`, even when the layout path itself contained dynamic segments.

With this PR, layouts receive slug props, but only for parent path.

Examples:

```tsx
createLayout({
  render: 'dynamic',
  path: '/[lang]',
  component: ({ lang, children }) => (
    <div>
      <h1>{lang}</h1>
      <p>{children}</p>
    </div>
  ),
});

createPage({
  render: 'dynamic',
  path: '/[lang]/blog/[slug]',
  component: ({ slug }) => <h2>{slug}</h2>,
});
```

For `/en/blog/hello`:
- the layout receives `{ lang: 'en' }`
- the layout does **not** receive `slug`
- the page receives `{ lang: 'en', slug: 'hello' }`

## Breaking behavioral change

This PR also changes how static layouts are cached.

Previously, a static layout under a dynamic segment was effectively shared. That is no longer the case. Static layout is rendered and cached for each path.

So if we have routes like,
- `/en/blog/hello`
- `/ja/blog/hello`

The layout example above will render twice for `/en` and `/ja`.

## Migration path for shared static UI: use a static slice

If your intent was to share one static wrapper across many slug variants, the recommended migration path is to move that shared part into a static slice.

### Before

```tsx
createLayout({
  render: 'static',
  path: '/[lang]',
  component: ({ children }) => (
    <div>
      <nav>Shared navigation</nav>
      <main>{children}</main>
    </div>
  ),
});
```

### After

```tsx
createPage({
  render: 'dynamic',
  path: '/[lang]/blog/[slug]',
  slices: ['shared-shell'],
  component: ({ slug }) => (
    <Slice id="shared-shell">
      <article>{slug}</article>
    </Slice>
  ),
});

createSlice({
  render: 'static',
  id: 'shared-shell',
  component: ({ children }) => (
    <div>
      <nav>Shared navigation</nav>
      <main>{children}</main>
    </div>
  ),
});
```

This keeps the shared wrapper static and reusable, while avoiding incorrect sharing of slug-dependent layout output. You can use the slice in a layout too rather than the page.

## Notes

- This change affects both dynamic and static layouts in `createPages`.
- The key behavioral change is only for **static** layouts under dynamic segments.
- This works for fs-router and managed mode too.
