### PR TITLE
fix(router): static slices with slugs

### DIFF
--- a/e2e/fixtures/fs-router/src/pages/_slices/preset/[id].tsx
+++ b/e2e/fixtures/fs-router/src/pages/_slices/preset/[id].tsx
@@ -1,0 +1,10 @@
+export default function PresetSlice({ id }: { id: string }) {
+  return <h4 data-testid="preset-slice">Preset Slice: {id}</h4>;
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'static',
+    staticPaths: ['foo', 'bar'],
+  } as const;
+};

--- a/e2e/fixtures/fs-router/src/pages/page-with-slices/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/page-with-slices/index.tsx
@@ -13,6 +13,11 @@ export default function Slices() {
         lazy
         fallback={<span data-testid="dynamic-slice-loading">Loading...</span>}
       />
+      <Slice
+        id="preset/foo"
+        lazy
+        fallback={<span data-testid="preset-slice-loading">Loading...</span>}
+      />
     </>
   );
 }

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { expect } from '@playwright/test';
 import {
   prepareNormalSetup,
@@ -11,9 +13,10 @@ const startApp = prepareNormalSetup('fs-router');
 test.describe('fs-router', () => {
   let port: number;
   let stopApp: () => Promise<void>;
+  let fixtureDir: string;
 
   test.beforeAll(async ({ mode }) => {
-    ({ port, stopApp } = await startApp(mode));
+    ({ port, stopApp, fixtureDir } = await startApp(mode));
   });
 
   test.afterAll(async () => {
@@ -273,6 +276,26 @@ test.describe('fs-router', () => {
     await waitForHydration(page);
     await expect(page.getByTestId('dynamic-slice')).toHaveText(
       'Dynamic Slice: test123',
+    );
+  });
+
+  test('static slug slice emits an RSC file per staticPaths entry', ({
+    mode,
+  }) => {
+    test.skip(mode !== 'PRD');
+    const distPublic = join(fixtureDir, 'dist', 'public');
+    for (const slug of ['foo', 'bar']) {
+      expect(
+        existsSync(join(distPublic, 'RSC', 'S', 'preset', `${slug}.txt`)),
+      ).toBe(true);
+    }
+  });
+
+  test('static slug slice renders on the page', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/page-with-slices`);
+    await waitForHydration(page);
+    await expect(page.getByTestId('preset-slice')).toHaveText(
+      'Preset Slice: foo',
     );
   });
 

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -215,11 +215,35 @@ type SlugPropsFromId<ID extends string> =
       ? { [K in GetSlugs<`/${ID}`>[number]]: string }
       : {};
 
-export type CreateSlice = <ID extends string>(slice: {
-  render: 'static' | 'dynamic';
-  id: ID;
-  component: FunctionComponent<{ children: ReactNode } & SlugPropsFromId<ID>>;
-}) => void;
+export type CreateSlice = <
+  ID extends string,
+  StaticPaths extends StaticSlugRoutePaths<`/${ID}`>,
+>(
+  slice:
+    | {
+        render: 'dynamic';
+        id: ID;
+        component: FunctionComponent<
+          { children: ReactNode } & SlugPropsFromId<ID>
+        >;
+      }
+    | {
+        // Static slice without a slug in its id.
+        render: 'static';
+        id: PathWithoutSlug<`/${ID}`> extends never ? never : ID;
+        component: FunctionComponent<{ children: ReactNode }>;
+      }
+    | {
+        // Static slice with a slug — staticPaths is required and
+        // enumerates the concrete slug values to pre-build.
+        render: 'static';
+        id: PathWithStaticSlugs<`/${ID}`> extends never ? never : ID;
+        component: FunctionComponent<
+          { children: ReactNode } & SlugPropsFromId<ID>
+        >;
+        staticPaths: StaticPaths;
+      },
+) => void;
 
 type RootItem = {
   render: 'static' | 'dynamic';
@@ -621,6 +645,38 @@ export const createPages = <
   const createSlice: CreateSlice = (slice) => {
     if (configured) {
       throw new Error('createSlice no longer available');
+    }
+    const slicePathSpec = parsePathWithSlug(slice.id);
+    const { numSlugs, numWildcards } = countSlugsAndWildcards(slicePathSpec);
+    if (slice.render === 'static' && numSlugs > 0) {
+      if (!('staticPaths' in slice) || !slice.staticPaths) {
+        throw new Error(
+          `Static slice with slug requires staticPaths: ${slice.id}`,
+        );
+      }
+      const staticPaths = slice.staticPaths.map((item) =>
+        (Array.isArray(item) ? item : [item]).map(sanitizeSlug),
+      );
+      for (const staticPath of staticPaths) {
+        if (staticPath.length !== numSlugs && numWildcards === 0) {
+          throw new Error('staticPaths does not match with slug pattern');
+        }
+        const { definedPath, mapping } = expandStaticPathSpec(
+          slicePathSpec,
+          staticPath,
+        );
+        const concreteId = definedPath.replace(/^\//, '');
+        if (sliceIdMap.has(concreteId)) {
+          throw new Error(`Duplicated slice id: ${concreteId}`);
+        }
+        const WrappedComponent = (props: Record<string, unknown>) =>
+          createElement(slice.component as any, { ...props, ...mapping });
+        sliceIdMap.set(concreteId, {
+          component: WrappedComponent,
+          isStatic: true,
+        });
+      }
+      return;
     }
     if (sliceIdMap.has(slice.id)) {
       throw new Error(`Duplicated slice id: ${slice.id}`);

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -137,7 +137,7 @@ export function fsRouter(
             render: 'static',
             id: pathItems.slice(1).join('/'),
             ...config,
-          });
+          } as never); // FIXME avoid as never
         } else if (pathItems.at(-1) === '_layout') {
           createLayout({
             path,

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -318,6 +318,22 @@ describe('type tests', () => {
       // good
       createSlice({ render: 'static', component: () => null, id: 'slice001' });
     });
+    it('static with slug', () => {
+      const createSlice: CreateSlice = vi.fn();
+      // @ts-expect-error: staticPaths is required for static slug slice
+      createSlice({
+        render: 'static',
+        component: () => null,
+        id: 'dynamic/[id]',
+      });
+      // good
+      createSlice({
+        render: 'static',
+        component: () => null,
+        id: 'dynamic/[id]',
+        staticPaths: ['foo', 'bar'],
+      });
+    });
     it('dynamic', () => {
       const createSlice: CreateSlice = vi.fn();
       // @ts-expect-error: path is invalid
@@ -1026,6 +1042,91 @@ describe('createPages pages and layouts', () => {
       renderer: expect.any(Function),
     });
     expect(sliceConfig).not.toHaveProperty('pathSpec');
+  });
+
+  it('static slug slice expands staticPaths into concrete entries', async () => {
+    const TestPage = () => null;
+    const TestSlice = (_props: { id: string }) => null;
+    createPages(async ({ createSlice, createPage }) => [
+      createPage({
+        render: 'dynamic',
+        path: '/',
+        component: TestPage,
+      }),
+      createSlice({
+        render: 'static',
+        component: TestSlice,
+        id: 'dynamic/[id]',
+        staticPaths: ['foo', 'bar'],
+      }),
+    ]);
+    const { getConfigs } = injectedFunctions();
+    const configs = Array.from(await getConfigs());
+    const sliceConfigs = configs.filter((c: any) => c.type === 'slice');
+    expect(sliceConfigs).toHaveLength(2);
+    expect(sliceConfigs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'slice',
+          id: 'dynamic/foo',
+          isStatic: true,
+        }),
+        expect.objectContaining({
+          type: 'slice',
+          id: 'dynamic/bar',
+          isStatic: true,
+        }),
+      ]),
+    );
+    // Concrete entries are literal — no pathSpec.
+    sliceConfigs.forEach((c: any) => expect(c).not.toHaveProperty('pathSpec'));
+    // Renderer binds the slug param: invoking the wrapper passes the
+    // mapped slug value through to the user's component as a prop.
+    const fooConfig = sliceConfigs.find((c: any) => c.id === 'dynamic/foo');
+    const wrapper = await (fooConfig as any).renderer();
+    const inner = (wrapper as any).type((wrapper as any).props);
+    expect(inner.props.id).toBe('foo');
+  });
+
+  it('static slug slice fails when staticPaths is missing', async () => {
+    createPages(async ({ createSlice, createPage }) => [
+      createPage({
+        render: 'dynamic',
+        path: '/',
+        component: () => null,
+      }),
+      // @ts-expect-error: staticPaths is required for slug slices
+      createSlice({
+        render: 'static',
+        component: () => null,
+        id: 'dynamic/[id]',
+      }),
+    ]);
+    const { getConfigs } = injectedFunctions();
+    await expect(getConfigs).rejects.toThrowError(
+      /Static slice with slug requires staticPaths/,
+    );
+  });
+
+  it('static slug slice fails when staticPaths length does not match slugs', async () => {
+    createPages(async ({ createSlice, createPage }) => [
+      createPage({
+        render: 'dynamic',
+        path: '/',
+        component: () => null,
+      }),
+      createSlice({
+        render: 'static',
+        component: () => null,
+        id: 'items/[category]/[id]',
+        // @ts-expect-error: each entry must be [string, string] for two slugs
+        staticPaths: ['only-one'],
+      }),
+    ]);
+    const { getConfigs } = injectedFunctions();
+    await expect(getConfigs).rejects.toThrowError(
+      'staticPaths does not match with slug pattern',
+    );
   });
 
   it('creates a nested static page', async () => {


### PR DESCRIPTION
follow up #2001.

If a static slice has slugs, we need to provide staticPaths.