### PR TITLE
chore(e2e): test without investigating fixture dist file structure

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -1,5 +1,3 @@
-import { statSync } from 'node:fs';
-import path from 'node:path';
 import { type Page, expect } from '@playwright/test';
 import {
   FETCH_ERROR_MESSAGES,
@@ -89,10 +87,9 @@ const expectNoPageErrorFor = async (page: Page) => {
 test.describe(`create-pages`, () => {
   let port: number;
   let stopApp: () => Promise<void>;
-  let fixtureDir: string;
 
   test.beforeAll(async ({ mode }) => {
-    ({ port, stopApp, fixtureDir } = await startApp(mode));
+    ({ port, stopApp } = await startApp(mode));
   });
 
   test.afterAll(async () => {
@@ -356,13 +353,21 @@ test.describe(`create-pages`, () => {
     expect(await res.text()).toBe('');
   });
 
-  test('api empty (PRD)', async ({ mode }) => {
+  test('static api is served from build-time pre-generation', async ({
+    mode,
+  }) => {
     test.skip(mode !== 'PRD', 'PRD only test');
-    expect(
-      statSync(
-        path.join(fixtureDir, 'dist', 'public', 'api', 'empty'),
-      ).isFile(),
-    ).toBe(true);
+    // `/api/cache-time` is a static API whose handler returns
+    // `Date.now()`. With build-time pre-generation it was emitted at
+    // build (before this test started), so the returned timestamp is
+    // older than `curr`. Without pre-generation the handler would run
+    // at request time, after `curr`. The route is dedicated so this
+    // test is the first request to it in the process.
+    const curr = Date.now();
+    const res = await fetch(`http://localhost:${port}/api/cache-time`);
+    expect(res.status).toBe(200);
+    const time = Number(await res.text());
+    expect(time).toBeLessThan(curr);
   });
 
   test('api hi with POST', async () => {

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -228,6 +228,19 @@ const pages: ReturnType<typeof createPages> = createPages(
     }),
 
     createApi({
+      // Returns `Date.now()` at handler-evaluation time. Used by an
+      // e2e test to detect whether the static API was pre-generated at
+      // build (response < test's `curr`) or rendered live at runtime
+      // (response > `curr`).
+      path: '/api/cache-time',
+      render: 'static',
+      method: 'GET',
+      handler: async () => {
+        return new Response(String(Date.now()));
+      },
+    }),
+
+    createApi({
       path: '/api/static-paths/[name]',
       render: 'static',
       method: 'GET',

--- a/e2e/fixtures/fs-router/src/pages/_slices/cache-time/[id].tsx
+++ b/e2e/fixtures/fs-router/src/pages/_slices/cache-time/[id].tsx
@@ -1,0 +1,19 @@
+export default function CacheTimeSlice({ id }: { id: string }) {
+  // Render `Date.now()` at render-time so an e2e test can detect
+  // whether this static slug slice was rendered at build time and
+  // served from the cache, or rendered live at runtime.
+  // eslint-disable-next-line react-hooks/purity
+  const time = Date.now();
+  return (
+    <span data-testid={`cache-time-${id}`}>
+      {id}:{time}
+    </span>
+  );
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'static',
+    staticPaths: ['foo'],
+  } as const;
+};

--- a/e2e/fixtures/fs-router/src/pages/cache-time/index.tsx
+++ b/e2e/fixtures/fs-router/src/pages/cache-time/index.tsx
@@ -1,0 +1,17 @@
+import { Slice } from 'waku/router/client';
+
+export default function CacheTimePage() {
+  return (
+    <Slice
+      id="cache-time/foo"
+      lazy
+      fallback={<span data-testid="cache-time-loading">Loading...</span>}
+    />
+  );
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'dynamic',
+  } as const;
+};

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -1,5 +1,3 @@
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
 import { expect } from '@playwright/test';
 import {
   prepareNormalSetup,
@@ -13,10 +11,9 @@ const startApp = prepareNormalSetup('fs-router');
 test.describe('fs-router', () => {
   let port: number;
   let stopApp: () => Promise<void>;
-  let fixtureDir: string;
 
   test.beforeAll(async ({ mode }) => {
-    ({ port, stopApp, fixtureDir } = await startApp(mode));
+    ({ port, stopApp } = await startApp(mode));
   });
 
   test.afterAll(async () => {
@@ -279,16 +276,25 @@ test.describe('fs-router', () => {
     );
   });
 
-  test('static slug slice emits an RSC file per staticPaths entry', ({
+  test('static slug slice is served from build-time cache', async ({
+    page,
     mode,
   }) => {
     test.skip(mode !== 'PRD');
-    const distPublic = join(fixtureDir, 'dist', 'public');
-    for (const slug of ['foo', 'bar']) {
-      expect(
-        existsSync(join(distPublic, 'RSC', 'S', 'preset', `${slug}.txt`)),
-      ).toBe(true);
-    }
+    // `_slices/cache-time/[id].tsx` is a static slug slice with
+    // `staticPaths: ['foo']`. With build-time pre-rendering its
+    // `Date.now()` is baked at build (before this test started), so
+    // it must be older than `curr`. Without it, the slice would
+    // render on the first PRD request — after `curr`. The route is
+    // dedicated so this test is the first request to that slice.
+    const curr = Date.now();
+    await page.goto(`http://localhost:${port}/cache-time`);
+    await waitForHydration(page);
+    const text = (await page
+      .getByTestId('cache-time-foo')
+      .textContent()) as string;
+    const time = Number(text.split(':')[1]);
+    expect(time).toBeLessThan(curr);
   });
 
   test('static slug slice renders on the page', async ({ page }) => {


### PR DESCRIPTION
feels a little safer. (though, the use of Date.now() feels still hacky.)