### PR TITLE
breaking(router): remove base option from fsRouter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1475,7 +1475,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/vercel';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
   { static: true },
 );
 ```
@@ -1500,7 +1500,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/netlify';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
   { static: true },
 );
 ```
@@ -1523,7 +1523,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
   { static: true },
 );
 ```
@@ -1537,7 +1537,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/deno';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
 );
 ```
 
@@ -1555,7 +1555,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/bun';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
 );
 ```
 
@@ -1572,7 +1572,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/aws-lambda';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
   { streaming: false }, // optional, default is false
 );
 ```

--- a/README.md
+++ b/README.md
@@ -1474,10 +1474,9 @@ For advanced users who want to avoid deploying functions, use the server entry f
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/vercel';
 
-export default adapter(
-  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
-  { static: true },
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')), {
+  static: true,
+});
 ```
 
 ### Netlify
@@ -1499,10 +1498,9 @@ For advanced users who want to avoid deploying functions, use the server entry f
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/netlify';
 
-export default adapter(
-  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
-  { static: true },
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')), {
+  static: true,
+});
 ```
 
 ### Cloudflare Workers
@@ -1522,10 +1520,9 @@ wrangler deploy
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
-export default adapter(
-  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
-  { static: true },
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')), {
+  static: true,
+});
 ```
 
 ### Deno Deploy (experimental)
@@ -1536,9 +1533,7 @@ export default adapter(
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/deno';
 
-export default adapter(
-  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')));
 ```
 
 ```sh
@@ -1554,9 +1549,7 @@ deployctl deploy --prod dist/serve-deno.js --exclude node_modules
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/bun';
 
-export default adapter(
-  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')));
 ```
 
 ```sh

--- a/docs/guides/cloudflare.mdx
+++ b/docs/guides/cloudflare.mdx
@@ -39,7 +39,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
 );
 ```
 
@@ -176,7 +176,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
   {
     handlers: {
       // Define additional Cloudflare Workers handlers here
@@ -266,7 +266,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
   { static: true },
 );
 ```

--- a/docs/guides/cloudflare.mdx
+++ b/docs/guides/cloudflare.mdx
@@ -38,9 +38,7 @@ Create a `src/waku.server.tsx` file that uses the Cloudflare adapter:
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
-export default adapter(
-  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')));
 ```
 
 Add `@cloudflare/vite-plugin` to your `waku.config.ts`:
@@ -175,24 +173,21 @@ Pass them to the adapter options in your waku.server.tsx file:
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
-export default adapter(
-  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
-  {
-    handlers: {
-      // Define additional Cloudflare Workers handlers here
-      // https://developers.cloudflare.com/workers/runtime-apis/handlers/
-      // async queue(
-      //   batch: MessageBatch,
-      //   _env: Env,
-      //   _ctx: ExecutionContext,
-      // ): Promise<void> {
-      //   for (const message of batch.messages) {
-      //     console.log('Received', message);
-      //   }
-      // },
-    } satisfies ExportedHandler<Env>,
-  },
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')), {
+  handlers: {
+    // Define additional Cloudflare Workers handlers here
+    // https://developers.cloudflare.com/workers/runtime-apis/handlers/
+    // async queue(
+    //   batch: MessageBatch,
+    //   _env: Env,
+    //   _ctx: ExecutionContext,
+    // ): Promise<void> {
+    //   for (const message of batch.messages) {
+    //     console.log('Received', message);
+    //   }
+    // },
+  } satisfies ExportedHandler<Env>,
+});
 ```
 
 ## Static vs. Dynamic Routing and Fetching Assets
@@ -265,10 +260,9 @@ and a `src/waku.server.tsx` file that uses the Cloudflare adapter with the `stat
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
-export default adapter(
-  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
-  { static: true },
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')), {
+  static: true,
+});
 ```
 
 You must also make sure that all of your pages and layouts are defined as static by exporting a getConfig function that specifies `render: 'static'`. For example, in `./src/pages/index.tsx`:

--- a/e2e/fixtures/custom-user-adapter/src/waku.server.tsx
+++ b/e2e/fixtures/custom-user-adapter/src/waku.server.tsx
@@ -1,6 +1,6 @@
 import { fsRouter } from 'waku';
 import adapter from './custom-adapter.js';
 
-const router = fsRouter(import.meta.glob('./**/*.tsx', { base: './pages' }));
+const router = fsRouter(import.meta.glob('./pages/**/*.tsx'));
 
 export default adapter(router);

--- a/e2e/fixtures/partial-build/src/waku.server.tsx
+++ b/e2e/fixtures/partial-build/src/waku.server.tsx
@@ -1,17 +1,14 @@
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 
-const router = fsRouter(
-  import.meta.glob('./**/*.{tsx,ts}', { base: './pages' }),
-  {
-    unstable_skipBuild: (routePath) => {
-      const onlyBuild = process.env.ONLY_BUILD;
-      if (!onlyBuild) {
-        return false;
-      }
-      return !new RegExp(onlyBuild).test(routePath);
-    },
+const router = fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}'), {
+  unstable_skipBuild: (routePath) => {
+    const onlyBuild = process.env.ONLY_BUILD;
+    if (!onlyBuild) {
+      return false;
+    }
+    return !new RegExp(onlyBuild).test(routePath);
   },
-);
+});
 
 export default adapter(router);

--- a/e2e/fixtures/ssr-catch-error/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/waku.server.tsx
@@ -2,7 +2,6 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 import validatorMiddleware from './middleware/validator';
 
-export default adapter(
-  fsRouter(import.meta.glob('./**/*.tsx', { base: './pages' })),
-  { middlewareFns: [validatorMiddleware] },
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.tsx')), {
+  middlewareFns: [validatorMiddleware],
+});

--- a/e2e/fixtures/styled-components/src/waku.server.tsx
+++ b/e2e/fixtures/styled-components/src/waku.server.tsx
@@ -2,9 +2,7 @@ import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 import { injectRenderHtml } from './server-html/ssr';
 
-const router = fsRouter(
-  import.meta.glob('./**/*.{tsx,ts}', { base: './pages' }),
-);
+const router = fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}'));
 
 export default adapter({
   handleRequest(input, utils) {

--- a/examples/07_cloudflare/src/waku.server.tsx
+++ b/examples/07_cloudflare/src/waku.server.tsx
@@ -1,21 +1,18 @@
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
 
-export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
-  {
-    handlers: {
-      // Define additional Cloudflare Workers handlers here
-      // https://developers.cloudflare.com/workers/runtime-apis/handlers/
-      // async queue(
-      //   batch: MessageBatch,
-      //   _env: Env,
-      //   _ctx: ExecutionContext,
-      // ): Promise<void> {
-      //   for (const message of batch.messages) {
-      //     console.log('Received', message);
-      //   }
-      // },
-    } satisfies ExportedHandler<Env>,
-  },
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')), {
+  handlers: {
+    // Define additional Cloudflare Workers handlers here
+    // https://developers.cloudflare.com/workers/runtime-apis/handlers/
+    // async queue(
+    //   batch: MessageBatch,
+    //   _env: Env,
+    //   _ctx: ExecutionContext,
+    // ): Promise<void> {
+    //   for (const message of batch.messages) {
+    //     console.log('Received', message);
+    //   }
+    // },
+  } satisfies ExportedHandler<Env>,
+});

--- a/examples/11_fs-router/src/waku.server.tsx
+++ b/examples/11_fs-router/src/waku.server.tsx
@@ -1,9 +1,7 @@
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 
-const router = fsRouter(
-  import.meta.glob('./**/*.{tsx,ts}', { base: './pages' }),
-);
+const router = fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}'));
 
 export const getRouterConfigs = () => router.unstable_getRouterConfigs();
 

--- a/examples/12_nossr/src/waku.server.tsx
+++ b/examples/12_nossr/src/waku.server.tsx
@@ -1,7 +1,7 @@
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 
-const router = fsRouter(import.meta.glob('./**/*.tsx', { base: './pages' }));
+const router = fsRouter(import.meta.glob('./pages/**/*.tsx'));
 
 export default adapter({
   handleRequest: async (input, utils) => {

--- a/examples/52_tanstack-router/src/waku.server.tsx
+++ b/examples/52_tanstack-router/src/waku.server.tsx
@@ -1,9 +1,7 @@
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 
-const router = fsRouter(
-  import.meta.glob('./**/*.{tsx,ts}', { base: './pages' }),
-);
+const router = fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}'));
 
 export default adapter({
   handleRequest: async (input, utils) => {

--- a/packages/waku/src/lib/utils/managed.ts
+++ b/packages/waku/src/lib/utils/managed.ts
@@ -1,28 +1,27 @@
 import { EXTENSIONS, SRC_MIDDLEWARE, SRC_PAGES } from '../constants.js';
 
 export const getManagedServerEntry = (srcDir: string) => {
-  const globBase = `/${srcDir}/${SRC_PAGES}`;
   const exts = EXTENSIONS.map((ext) => ext.slice(1)).join(',');
-  const globPattern = `${globBase}/**/*.{${exts}}`;
+  const globPattern = `/${srcDir}/${SRC_PAGES}/**/*.{${exts}}`;
+  const srcDirPrefix = `/${srcDir}/`;
   const middlewareGlob = [
     `/${srcDir}/${SRC_MIDDLEWARE}/*.{${exts}}`,
     `!/${srcDir}/${SRC_MIDDLEWARE}/*.{test,spec}.{${exts}}`,
   ];
+  // Strip srcDir prefix from glob keys so fsRouter's default `pagesDir: 'pages'` applies.
   return `
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 
-export default adapter(
-  fsRouter(
-    import.meta.glob(
-      ${JSON.stringify(globPattern)},
-      { base: ${JSON.stringify(globBase)} }
-    )
+const modules = Object.fromEntries(
+  Object.entries(import.meta.glob(${JSON.stringify(globPattern)})).map(
+    ([k, v]) => [k.slice(${srcDirPrefix.length}), v],
   ),
-  {
-    middlewareModules: import.meta.glob(${JSON.stringify(middlewareGlob)}),
-  },
 );
+
+export default adapter(fsRouter(modules), {
+  middlewareModules: import.meta.glob(${JSON.stringify(middlewareGlob)}),
+});
 `;
 };
 

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -1,7 +1,6 @@
 import type { FunctionComponent, ReactNode } from 'react';
 import type { ImportGlobFunction } from 'vite/types/importGlob.d.ts';
 import { isIgnoredPath } from '../lib/utils/fs-router.js';
-import { joinPath } from '../lib/utils/path.js';
 import { METHODS, createPages } from './create-pages.js';
 import type { Method } from './create-pages.js';
 
@@ -15,20 +14,20 @@ export function fsRouter(
   /**
    * A mapping from a file path to a route module, e.g.
    *   {
-   *     "_layout.tsx": () => ({ default: ... }),
-   *     "index.tsx": () => ({ default: ... }),
-   *     "foo/index.tsx": () => ...,
+   *     "./pages/_layout.tsx": () => ({ default: ... }),
+   *     "./pages/index.tsx": () => ({ default: ... }),
+   *     "./pages/foo/index.tsx": () => ...,
    *   }
-   * This mapping can be created by Vite's import.meta.glob, e.g.
-   *   import.meta.glob("./**\/*.{tsx,ts}", { base: "./pages" })
+   * Intended to be created by Vite's import.meta.glob with the pages
+   * directory included in the pattern, e.g.
+   *   import.meta.glob("./pages/**\/*.{tsx,ts}")
    */
-  pages: { [file: string]: () => Promise<unknown> },
+  modules: { [file: string]: () => Promise<unknown> },
   options?: {
     /**
-     * The pages directory name relative to the project's source root,
-     * matching the `base` you pass to `import.meta.glob`. Used to map
-     * glob keys (e.g. `./foo.tsx`) to src-relative paths (e.g.
-     * `pages/foo.tsx`) for build-time pruning.
+     * The pages directory name. Must match the directory in the glob
+     * pattern, e.g. `"pages"` for `import.meta.glob('./pages/**\/*')`.
+     * Glob keys whose first segment doesn't match are ignored.
      * Defaults to `"pages"`.
      */
     pagesDir?: string;
@@ -53,9 +52,16 @@ export function fsRouter(
       createApi,
       createSlice,
     }) => {
-      for (let file in pages) {
-        const srcPath = joinPath(pagesDir, file);
-        const mod = (await pages[file]!()) as {
+      const pagesDirPrefix = pagesDir + '/';
+      for (const file in modules) {
+        // Use WHATWG URL encoding for the file path (different from RFC2396-based encoding)
+        const srcPath = new URL(file, 'http://localhost:3000').pathname.slice(
+          1,
+        );
+        if (!srcPath.startsWith(pagesDirPrefix)) {
+          continue;
+        }
+        const mod = (await modules[file]!()) as {
           default: FunctionComponent<{ children: ReactNode }>;
           getConfig?: () => Promise<{
             render?: 'static' | 'dynamic';
@@ -63,10 +69,9 @@ export function fsRouter(
           GET?: (req: Request) => Promise<Response>;
         };
 
-        // Use WHATWG URL encoding for the file path (different from RFC2396-based encoding)
-        file = new URL(file, 'http://localhost:3000').pathname.slice(1);
         const config = await mod.getConfig?.();
-        const pathItems = file
+        const pathItems = srcPath
+          .slice(pagesDirPrefix.length)
           .replace(/\.\w+$/, '')
           .split('/')
           .filter(Boolean);

--- a/packages/waku/tests/fixtures/plugin-fs-router-typegen-with-fsrouter-fake/waku.server.tsx
+++ b/packages/waku/tests/fixtures/plugin-fs-router-typegen-with-fsrouter-fake/waku.server.tsx
@@ -2,5 +2,5 @@ import { createPages as fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 
 export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' }) as never),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}') as never),
 );

--- a/packages/waku/tests/fixtures/plugin-fs-router-typegen-with-fsrouter/waku.server.tsx
+++ b/packages/waku/tests/fixtures/plugin-fs-router-typegen-with-fsrouter/waku.server.tsx
@@ -1,6 +1,4 @@
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/default';
 
-export default adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
-);
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')));

--- a/packages/website/src/waku.server.tsx
+++ b/packages/website/src/waku.server.tsx
@@ -7,7 +7,7 @@ const adapter: typeof vercelAdapter = process.env.VERCEL
   : nodeAdapter;
 
 const handler: ReturnType<typeof adapter> = adapter(
-  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
+  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
   { static: true },
 );
 


### PR DESCRIPTION
## Breaking change: drop the `base` option from `import.meta.glob` in `fsRouter`

`fsRouter` no longer expects glob keys produced with `import.meta.glob`'s
`{ base: ... }` option. Move the pages directory into the glob pattern
itself.

### Migration

Before:

```ts
import { fsRouter } from 'waku';
import adapter from 'waku/adapters/default';

export default adapter(
  fsRouter(import.meta.glob('./**/*.{tsx,ts}', { base: './pages' })),
);
```

After:

```ts
import { fsRouter } from 'waku';
import adapter from 'waku/adapters/default';

export default adapter(
  fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')),
);
```

### Custom pages directory

If your pages live under a directory other than `pages` (or in a
subpath), pass `pagesDir` to `fsRouter` so it knows which prefix in
each glob key marks the pages root:

```ts
fsRouter(import.meta.glob('./my-pages/**/*.{tsx,ts}'), {
  pagesDir: 'my-pages',
});
```

`pagesDir` defaults to `'pages'`. Glob keys that don't begin with
`<pagesDir>/` are ignored.

