### PR TITLE
feat(cloudflare-example): configure assets caching

### DIFF
--- a/examples/07_cloudflare/public/_headers
+++ b/examples/07_cloudflare/public/_headers
@@ -1,2 +1,4 @@
 /RSC/*
   X-Robots-Tag: noindex
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
The hashed asset output should be cached instead of Cloudflare's [default](https://developers.cloudflare.com/workers/static-assets/headers/#default-headers), which is `Cache-Control: public, max-age=0, must-revalidate`.