### PR TITLE
fix: set charset=utf-8 on SSR HTML responses

### DIFF
--- a/packages/waku/src/lib/utils/render.ts
+++ b/packages/waku/src/lib/utils/render.ts
@@ -93,7 +93,7 @@ export function createRenderUtils(
       });
       return new Response(htmlResult.stream, {
         status: htmlResult.status || options.status || 200,
-        headers: { 'content-type': 'text/html' },
+        headers: { 'content-type': 'text/html; charset=utf-8' },
       });
     },
   };

--- a/packages/waku/tests/render-utils.test.ts
+++ b/packages/waku/tests/render-utils.test.ts
@@ -57,11 +57,9 @@ describe('createRenderUtils', () => {
         }) as any,
     );
 
-    const res = await renderUtils.renderHtml(
-      new ReadableStream(),
-      { App: 'html' },
-      {},
-    );
+    const res = await renderUtils.renderHtml(new ReadableStream(), 'app', {
+      rscPath: '',
+    });
 
     expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8');
   });

--- a/packages/waku/tests/render-utils.test.ts
+++ b/packages/waku/tests/render-utils.test.ts
@@ -36,4 +36,33 @@ describe('createRenderUtils', () => {
       'RSC element IDs starting with "_" are reserved for Waku internals: _foo',
     );
   });
+
+  test('HTML response sets charset=utf-8 (full document reload decoding)', async () => {
+    const renderToReadableStream = vi.fn(
+      (_data: unknown, _options?: object, _extraOptions?: object) =>
+        new ReadableStream(),
+    );
+    const fakeHtmlStream = new ReadableStream();
+    const renderHtmlStream = vi.fn().mockResolvedValue({
+      stream: fakeHtmlStream,
+      status: undefined,
+    });
+    const renderUtils = createRenderUtils(
+      undefined,
+      renderToReadableStream,
+      vi.fn(),
+      async () =>
+        ({
+          INTERNAL_renderHtmlStream: renderHtmlStream,
+        }) as any,
+    );
+
+    const res = await renderUtils.renderHtml(
+      new ReadableStream(),
+      { App: 'html' },
+      {},
+    );
+
+    expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8');
+  });
 });


### PR DESCRIPTION
**Problem**: 
SSR HTML used Content-Type: text/html without charset.
On a full reload, some browsers defaulted to a Western encoding and corrupted UTF‑8 text (I hit this with Chinese). Client routing still looked fine.

**Fix**:
Use `text/html; charset=utf-8`, consistent with the existing fallback HTML path.

**Test**:
Added a unit check on the response header; optional manual hard refresh with non‑ASCII content.