### PR TITLE
feat(router): unstable useNavigationStatus

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -111,7 +111,7 @@ export const NavLink = () => (
 );
 ```
 
-`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>`. Called outside any `<Link>`, it returns an empty object.
+`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>`, which means the indicator lives inside the `<a>`. Keep it non-interactive and `aria-hidden` (as above), since it becomes part of the link's accessible name and click target; to render pending UI outside the anchor, drive it from route-change events instead. Called outside any `<Link>`, the hook returns an empty object (not `{ pending: false }`).
 
 ## Custom Transitions
 
@@ -134,5 +134,7 @@ export const Link = (props: ComponentProps<typeof WakuLink>) => (
   <WakuLink {...props} unstable_startTransition={startViewTransition} />
 );
 ```
+
+Because `unstable_startTransition` replaces React's transition, `useNavigationStatus_UNSTABLE()` stays `{ pending: false }` for links that use it.
 
 The prefetch and transition props in this guide are experimental and may change.

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -82,29 +82,36 @@ Prefer intent-based prefetching for expensive dynamic routes. View-based prefetc
 
 ## Pending UI
 
-`<Link>` can render adjacent pending UI while a navigation transition is in progress:
+A descendant of `<Link>` can read the navigation status with `useNavigationStatus_UNSTABLE()` and render pending UI while a navigation transition is in progress. It works like React's `useFormStatus`: it reflects the nearest enclosing `<Link>`, and `pending` stays `true` until the destination route's async components resolve (including client-only Suspense).
+
+```tsx
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const PendingIndicator = () => {
+  const { pending } = useNavigationStatus();
+  return (
+    <span aria-hidden style={{ opacity: pending ? 1 : 0 }}>
+      Loading...
+    </span>
+  );
+};
+```
 
 ```tsx
 import { Link } from 'waku';
-
-const Pending = ({ active }: { active: boolean }) => (
-  <span aria-hidden style={{ opacity: active ? 1 : 0 }}>
-    Loading...
-  </span>
-);
+import { PendingIndicator } from './pending-indicator';
 
 export const NavLink = () => (
-  <Link
-    to="/reports"
-    unstable_pending={<Pending active />}
-    unstable_notPending={<Pending active={false} />}
-  >
+  <Link to="/reports">
     Reports
+    <PendingIndicator />
   </Link>
 );
 ```
 
-The pending nodes are rendered next to the link. They do not replace the link's children.
+`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>`. Called outside any `<Link>`, it returns an empty object.
 
 ## Custom Transitions
 

--- a/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
+++ b/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
@@ -1,19 +1,8 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
+import { Pending } from './pending';
 
 import '../styles.css';
-
-const Pending = ({ isPending }: { isPending: boolean }) => (
-  <span
-    style={{
-      marginLeft: 5,
-      transition: 'opacity 75ms 100ms',
-      opacity: isPending ? 1 : 0,
-    }}
-  >
-    Pending...
-  </span>
-);
 
 let renderCount = 0;
 
@@ -24,21 +13,15 @@ const HomeLayout = ({ children }: { children: ReactNode }) => {
       <title>Waku</title>
       <ul>
         <li>
-          <Link
-            to="/"
-            unstable_pending={<Pending isPending />}
-            unstable_notPending={<Pending isPending={false} />}
-          >
+          <Link to="/">
             Home
+            <Pending />
           </Link>
         </li>
         <li>
-          <Link
-            to="/foo"
-            unstable_pending={<Pending isPending />}
-            unstable_notPending={<Pending isPending={false} />}
-          >
+          <Link to="/foo">
             Foo
+            <Pending />
           </Link>
         </li>
         <li>

--- a/e2e/fixtures/create-pages/src/components/LongSuspenseLayout.tsx
+++ b/e2e/fixtures/create-pages/src/components/LongSuspenseLayout.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import type { ReactNode } from 'react';
 import { Link } from 'waku';
+import { LongSuspensePending } from './pending';
 
 export const SlowComponent = async ({ children }: { children?: ReactNode }) => {
   await new Promise((resolve) => setTimeout(resolve, 500));
@@ -20,13 +21,9 @@ export const StaticLongSuspenseLayout = ({
     <div>
       <h2>Static Long Suspense Layout</h2>
       <div>
-        <Link
-          to="/static-long-suspense/5"
-          unstable_pending={
-            <div data-testid="long-suspense-pending">Pending...</div>
-          }
-        >
+        <Link to="/static-long-suspense/5">
           Click Me
+          <LongSuspensePending />
         </Link>
       </div>
       <div>
@@ -45,23 +42,15 @@ export const LongSuspenseLayout = ({ children }: { children: ReactNode }) => {
     <div>
       <h2>Long Suspense Layout</h2>
       <div>
-        <Link
-          to="/long-suspense/2"
-          unstable_pending={
-            <div data-testid="long-suspense-pending">Pending...</div>
-          }
-        >
+        <Link to="/long-suspense/2">
           Click Me
+          <LongSuspensePending />
         </Link>
       </div>
       <div>
-        <Link
-          to="/long-suspense/3"
-          unstable_pending={
-            <div data-testid="long-suspense-pending">Pending...</div>
-          }
-        >
+        <Link to="/long-suspense/3">
           Click Me Too
+          <LongSuspensePending />
         </Link>
       </div>
       <Suspense fallback={<div data-testid="long-suspense">Loading...</div>}>

--- a/e2e/fixtures/create-pages/src/components/pending.tsx
+++ b/e2e/fixtures/create-pages/src/components/pending.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const Pending = () => {
+  const { pending } = useNavigationStatus();
+  return (
+    <span
+      style={{
+        marginLeft: 5,
+        transition: 'opacity 75ms 100ms',
+        opacity: pending ? 1 : 0,
+      }}
+    >
+      Pending...
+    </span>
+  );
+};
+
+export const LongSuspensePending = () => {
+  const { pending } = useNavigationStatus();
+  return pending ? (
+    <div data-testid="long-suspense-pending">Pending...</div>
+  ) : null;
+};

--- a/e2e/fixtures/define-router/src/components/pending.tsx
+++ b/e2e/fixtures/define-router/src/components/pending.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const Pending = () => {
+  const { pending } = useNavigationStatus();
+  return (
+    <span
+      style={{
+        marginLeft: 5,
+        transition: 'opacity 75ms 100ms',
+        opacity: pending ? 1 : 0,
+      }}
+    >
+      Pending...
+    </span>
+  );
+};

--- a/e2e/fixtures/define-router/src/routes/layout.tsx
+++ b/e2e/fixtures/define-router/src/routes/layout.tsx
@@ -1,73 +1,44 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
-
-const Pending = ({ isPending }: { isPending: boolean }) => (
-  <span
-    style={{
-      marginLeft: 5,
-      transition: 'opacity 75ms 100ms',
-      opacity: isPending ? 1 : 0,
-    }}
-  >
-    Pending...
-  </span>
-);
+import { Pending } from '../components/pending';
 
 const HomeLayout = ({ children }: { children: ReactNode }) => (
   <div>
     <ul>
       <li>
-        <Link
-          to="/"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/">
           Home
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/foo"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/foo">
           Foo
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/bar1"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/bar1">
           Bar1
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/bar2"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/bar2">
           Bar2
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/baz1"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/baz1">
           Baz1
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/baz2"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/baz2">
           Baz2
+          <Pending />
         </Link>
       </li>
     </ul>

--- a/e2e/fixtures/fs-router/src/components/pending.tsx
+++ b/e2e/fixtures/fs-router/src/components/pending.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const Pending = () => {
+  const { pending } = useNavigationStatus();
+  return (
+    <span
+      style={{
+        marginLeft: 5,
+        transition: 'opacity 75ms 100ms',
+        opacity: pending ? 1 : 0,
+      }}
+    >
+      Pending...
+    </span>
+  );
+};

--- a/e2e/fixtures/fs-router/src/pages/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/_layout.tsx
@@ -1,102 +1,63 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
-
-const Pending = ({ isPending }: { isPending: boolean }) => (
-  <span
-    style={{
-      marginLeft: 5,
-      transition: 'opacity 75ms 100ms',
-      opacity: isPending ? 1 : 0,
-    }}
-  >
-    Pending...
-  </span>
-);
+import { Pending } from '../components/pending';
 
 const HomeLayout = ({ children }: { children: ReactNode }) => (
   <div>
     <title>Waku</title>
     <ul>
       <li>
-        <Link
-          to="/"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/">
           Home
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/foo"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/foo">
           Foo
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/bar"
-          unstable_prefetchOnEnter
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/bar" unstable_prefetchOnEnter>
           Bar
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/nested/baz"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/nested/baz">
           Nested / Baz
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/nested/qux"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/nested/qux">
           Nested / Qux
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/nested/encoded%20path"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/nested/encoded%20path">
           Nested / Encoded Path
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/nested/encoded%E6%B8%AC%E8%A9%A6path"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/nested/encoded%E6%B8%AC%E8%A9%A6path">
           Nested / Encoded Unicode Path
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/static-nested/encoded%20path"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/static-nested/encoded%20path">
           Nested / Static Encoded Path
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/static-nested/encoded%E6%B8%AC%E8%A9%A6path"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/static-nested/encoded%E6%B8%AC%E8%A9%A6path">
           Nested / Static Encoded Unicode Path
+          <Pending />
         </Link>
       </li>
       <li>

--- a/e2e/fixtures/router-client/src/components/client-suspense.tsx
+++ b/e2e/fixtures/router-client/src/components/client-suspense.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { use } from 'react';
+
+// A client-only suspense with no data fetch. A suspended route is invisible
+// during a transition (the old page stays mounted), so there is no DOM element
+// to drive it from; the resolver is exposed on the global instead, and the test
+// releases it on demand via window.__resolveClientSuspense().
+let resolveClientSuspense = () => {};
+const clientSuspensePromise = new Promise<void>((resolve) => {
+  resolveClientSuspense = resolve;
+});
+(
+  globalThis as unknown as { __resolveClientSuspense?: () => void }
+).__resolveClientSuspense = resolveClientSuspense;
+
+export function ClientSuspense() {
+  use(clientSuspensePromise);
+  return <p data-testid="client-suspense-content">client loaded</p>;
+}

--- a/e2e/fixtures/router-client/src/components/client-suspense.tsx
+++ b/e2e/fixtures/router-client/src/components/client-suspense.tsx
@@ -3,18 +3,29 @@
 import { use } from 'react';
 
 // A client-only suspense with no data fetch. A suspended route is invisible
-// during a transition (the old page stays mounted), so there is no DOM element
-// to drive it from; the resolver is exposed on the global instead, and the test
-// releases it on demand via window.__resolveClientSuspense().
+// during a transition (the old page stays mounted), so the resolver can't live
+// on the suspended page. Instead the still-mounted start page renders
+// <ResolveClientSuspenseButton/>, which shares this module's promise and
+// releases it on click. The promise is module-level, so the route suspends once
+// per page load (one navigation/test).
 let resolveClientSuspense = () => {};
 const clientSuspensePromise = new Promise<void>((resolve) => {
   resolveClientSuspense = resolve;
 });
-(
-  globalThis as unknown as { __resolveClientSuspense?: () => void }
-).__resolveClientSuspense = resolveClientSuspense;
 
 export function ClientSuspense() {
   use(clientSuspensePromise);
   return <p data-testid="client-suspense-content">client loaded</p>;
+}
+
+export function ResolveClientSuspenseButton() {
+  return (
+    <button
+      type="button"
+      data-testid="resolve-client-suspense"
+      onClick={() => resolveClientSuspense()}
+    >
+      Resolve client suspense
+    </button>
+  );
 }

--- a/e2e/fixtures/router-client/src/components/nav-indicator.tsx
+++ b/e2e/fixtures/router-client/src/components/nav-indicator.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const NavIndicator = ({ name }: { name?: string }) => {
+  const { pending } = useNavigationStatus();
+  const suffix = name ? `-${name}` : '';
+  return pending ? (
+    <span data-testid={`pending${suffix}-indicator`}>
+      Pending transition...
+    </span>
+  ) : (
+    <span data-testid={`not-pending${suffix}-indicator`}>Not pending</span>
+  );
+};

--- a/e2e/fixtures/router-client/src/pages/pending-client.tsx
+++ b/e2e/fixtures/router-client/src/pages/pending-client.tsx
@@ -1,0 +1,16 @@
+import { ClientSuspense } from '../components/client-suspense.js';
+
+export default function PendingClientPage() {
+  return (
+    <div>
+      <h1>Pending Client</h1>
+      <ClientSuspense />
+    </div>
+  );
+}
+
+export const getConfig = () => {
+  return {
+    render: 'dynamic',
+  } as const;
+};

--- a/e2e/fixtures/router-client/src/pages/start.tsx
+++ b/e2e/fixtures/router-client/src/pages/start.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'waku';
+import { ResolveClientSuspenseButton } from '../components/client-suspense.js';
 import { NavIndicator } from '../components/nav-indicator.js';
 import { PushMissingButton, RouteState } from '../components/route-state.js';
 
@@ -42,6 +43,9 @@ export default function StartPage() {
           Go to a route with a client-only delay
           <NavIndicator name="client" />
         </Link>
+      </p>
+      <p>
+        <ResolveClientSuspenseButton />
       </p>
       <p>
         <Link to="/trigger-not-found" data-testid="go-trigger-not-found">

--- a/e2e/fixtures/router-client/src/pages/start.tsx
+++ b/e2e/fixtures/router-client/src/pages/start.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'waku';
+import { NavIndicator } from '../components/nav-indicator.js';
 import { PushMissingButton, RouteState } from '../components/route-state.js';
 
 export default function StartPage() {
@@ -31,17 +32,15 @@ export default function StartPage() {
         </Link>
       </p>
       <p>
-        <Link
-          to="/next?from=pending"
-          unstable_pending={
-            <span data-testid="pending-indicator">Pending transition...</span>
-          }
-          unstable_notPending={
-            <span data-testid="not-pending-indicator">Not pending</span>
-          }
-          data-testid="pending-link"
-        >
+        <Link to="/next?from=pending" data-testid="pending-link">
           Go next with pending state
+          <NavIndicator />
+        </Link>
+      </p>
+      <p>
+        <Link to="/pending-client" data-testid="pending-client-link">
+          Go to a route with a client-only delay
+          <NavIndicator name="client" />
         </Link>
       </p>
       <p>

--- a/e2e/router-client.spec.ts
+++ b/e2e/router-client.spec.ts
@@ -490,7 +490,7 @@ test.describe('router-client', () => {
     await expect(page.getByRole('heading', { name: 'Start' })).toBeVisible();
   });
 
-  test('unstable_pending and unstable_notPending reflect async transition state', async ({
+  test('useNavigationStatus pending reflects async transition state', async ({
     page,
   }) => {
     await page.route('**/RSC/R/next.txt**', async (route) => {
@@ -506,6 +506,41 @@ test.describe('router-client', () => {
     await expect(page.getByTestId('pending-indicator')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Next' })).toBeVisible();
     await expect(page.getByTestId('pending-indicator')).toHaveCount(0);
+  });
+
+  test('pending stays until a client-only async resolves, not just data loading', async ({
+    page,
+  }) => {
+    // No RSC delay here: the target route's RSC loads normally, but it renders a
+    // client component that suspends with no data fetch. Pending must persist
+    // until that client-only async resolves, proving it tracks the transition.
+    await page.goto(`http://localhost:${port}/start`);
+    await waitForHydration(page);
+
+    await page.getByTestId('pending-client-link').click();
+
+    // Wait until the route's client component has loaded and is suspended; by
+    // now its RSC has already arrived. The pending indicator must STILL be
+    // visible here, which is the load-bearing assertion: it proves pending is
+    // held by the client-only suspense, not merely flashed during data loading.
+    // (A data-loading-only implementation would have cleared pending by now.)
+    await page.waitForFunction(
+      () =>
+        typeof (
+          globalThis as unknown as { __resolveClientSuspense?: () => void }
+        ).__resolveClientSuspense === 'function',
+    );
+    await expect(page.getByTestId('pending-client-indicator')).toBeVisible();
+    await expect(page.getByTestId('client-suspense-content')).toHaveCount(0);
+
+    // Resolve the client-only async; the transition settles and pending clears.
+    await page.evaluate(() => {
+      (
+        globalThis as unknown as { __resolveClientSuspense?: () => void }
+      ).__resolveClientSuspense?.();
+    });
+    await expect(page.getByTestId('client-suspense-content')).toBeVisible();
+    await expect(page.getByTestId('pending-client-indicator')).toHaveCount(0);
   });
 
   test('client notFound navigation uses /404 page content when present', async ({

--- a/e2e/router-client.spec.ts
+++ b/e2e/router-client.spec.ts
@@ -511,34 +511,26 @@ test.describe('router-client', () => {
   test('pending stays until a client-only async resolves, not just data loading', async ({
     page,
   }) => {
-    // No RSC delay here: the target route's RSC loads normally, but it renders a
-    // client component that suspends with no data fetch. Pending must persist
-    // until that client-only async resolves, proving it tracks the transition.
+    // The target route's RSC loads normally, but it renders a client component
+    // that suspends with no data fetch. Pending must persist until that
+    // client-only async resolves, proving it tracks the transition.
     await page.goto(`http://localhost:${port}/start`);
     await waitForHydration(page);
 
+    const rscResponse = page.waitForResponse('**/RSC/R/pending-client.txt**');
     await page.getByTestId('pending-client-link').click();
 
-    // Wait until the route's client component has loaded and is suspended; by
-    // now its RSC has already arrived. The pending indicator must STILL be
-    // visible here, which is the load-bearing assertion: it proves pending is
-    // held by the client-only suspense, not merely flashed during data loading.
-    // (A data-loading-only implementation would have cleared pending by now.)
-    await page.waitForFunction(
-      () =>
-        typeof (
-          globalThis as unknown as { __resolveClientSuspense?: () => void }
-        ).__resolveClientSuspense === 'function',
-    );
+    // Once the RSC has arrived the router's data loading is done, yet the
+    // pending indicator must STILL be visible because the client component is
+    // suspended. This is the load-bearing assertion: a data-loading-only
+    // implementation would have cleared pending by now.
+    await rscResponse;
     await expect(page.getByTestId('pending-client-indicator')).toBeVisible();
     await expect(page.getByTestId('client-suspense-content')).toHaveCount(0);
 
-    // Resolve the client-only async; the transition settles and pending clears.
-    await page.evaluate(() => {
-      (
-        globalThis as unknown as { __resolveClientSuspense?: () => void }
-      ).__resolveClientSuspense?.();
-    });
+    // Release the client-only async from the still-mounted start page; the
+    // transition settles and pending clears.
+    await page.getByTestId('resolve-client-suspense').click();
     await expect(page.getByTestId('client-suspense-content')).toBeVisible();
     await expect(page.getByTestId('pending-client-indicator')).toHaveCount(0);
   });

--- a/examples/11_fs-router/src/components/pending.tsx
+++ b/examples/11_fs-router/src/components/pending.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const Pending = () => {
+  const { pending } = useNavigationStatus();
+  return (
+    <span
+      style={{
+        marginLeft: 5,
+        transition: 'opacity 75ms 100ms',
+        opacity: pending ? 1 : 0,
+      }}
+    >
+      Pending...
+    </span>
+  );
+};

--- a/examples/11_fs-router/src/pages/_layout.tsx
+++ b/examples/11_fs-router/src/pages/_layout.tsx
@@ -1,66 +1,39 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
-
-const Pending = ({ isPending }: { isPending: boolean }) => (
-  <span
-    style={{
-      marginLeft: 5,
-      transition: 'opacity 75ms 100ms',
-      opacity: isPending ? 1 : 0,
-    }}
-  >
-    Pending...
-  </span>
-);
+import { Pending } from '../components/pending';
 
 const HomeLayout = ({ children }: { children: ReactNode }) => (
   <div>
     <title>Waku</title>
     <ul>
       <li>
-        <Link
-          to="/"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/">
           Home
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/foo"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/foo">
           Foo
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/bar"
-          unstable_prefetchOnEnter
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/bar" unstable_prefetchOnEnter>
           Bar
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/nested/baz"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/nested/baz">
           Nested / Baz
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/nested/qux"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/nested/qux">
           Nested / Qux
+          <Pending />
         </Link>
       </li>
       <li>

--- a/examples/21_create-pages/src/components/HomeLayout.tsx
+++ b/examples/21_create-pages/src/components/HomeLayout.tsx
@@ -1,40 +1,23 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
+import { Pending } from './pending';
 import '../styles.css';
 import { RoutingHandler } from './RoutingHandler';
-
-const Pending = ({ isPending }: { isPending: boolean }) => (
-  <span
-    style={{
-      marginLeft: 5,
-      transition: 'opacity 75ms 100ms',
-      opacity: isPending ? 1 : 0,
-    }}
-  >
-    Pending...
-  </span>
-);
 
 const HomeLayout = ({ children }: { children: ReactNode }) => (
   <div>
     <RoutingHandler />
     <ul>
       <li>
-        <Link
-          to="/"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/">
           Home
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/foo"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/foo">
           Foo
+          <Pending />
         </Link>
       </li>
       <li>

--- a/examples/21_create-pages/src/components/pending.tsx
+++ b/examples/21_create-pages/src/components/pending.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const Pending = () => {
+  const { pending } = useNavigationStatus();
+  return (
+    <span
+      style={{
+        marginLeft: 5,
+        transition: 'opacity 75ms 100ms',
+        opacity: pending ? 1 : 0,
+      }}
+    >
+      Pending...
+    </span>
+  );
+};

--- a/examples/22_define-router/src/components/HomeLayout.tsx
+++ b/examples/22_define-router/src/components/HomeLayout.tsx
@@ -1,39 +1,22 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
+import { Pending } from './pending';
 
 import '../styles.css';
-
-const Pending = ({ isPending }: { isPending: boolean }) => (
-  <span
-    style={{
-      marginLeft: 5,
-      transition: 'opacity 75ms 100ms',
-      opacity: isPending ? 1 : 0,
-    }}
-  >
-    Pending...
-  </span>
-);
 
 const HomeLayout = ({ children }: { children: ReactNode }) => (
   <div>
     <ul>
       <li>
-        <Link
-          to="/"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/">
           Home
+          <Pending />
         </Link>
       </li>
       <li>
-        <Link
-          to="/foo"
-          unstable_pending={<Pending isPending />}
-          unstable_notPending={<Pending isPending={false} />}
-        >
+        <Link to="/foo">
           Foo
+          <Pending />
         </Link>
       </li>
       <li>

--- a/examples/22_define-router/src/components/pending.tsx
+++ b/examples/22_define-router/src/components/pending.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const Pending = () => {
+  const { pending } = useNavigationStatus();
+  return (
+    <span
+      style={{
+        marginLeft: 5,
+        transition: 'opacity 75ms 100ms',
+        opacity: pending ? 1 : 0,
+      }}
+    >
+      Pending...
+    </span>
+  );
+};

--- a/examples/43_weave-render/src/components/BarLayout.tsx
+++ b/examples/43_weave-render/src/components/BarLayout.tsx
@@ -1,19 +1,8 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
+import { Pending } from './pending';
 
 import '../styles.css';
-
-const Pending = ({ isPending }: { isPending: boolean }) => (
-  <span
-    style={{
-      marginLeft: 5,
-      transition: 'opacity 75ms 100ms',
-      opacity: isPending ? 1 : 0,
-    }}
-  >
-    Pending...
-  </span>
-);
 
 const BarLayout = ({ children }: { children: ReactNode }) => {
   return (
@@ -21,30 +10,21 @@ const BarLayout = ({ children }: { children: ReactNode }) => {
       <p>This Layout is expected to be static</p>
       <ul>
         <li>
-          <Link
-            to="/"
-            unstable_pending={<Pending isPending />}
-            unstable_notPending={<Pending isPending={false} />}
-          >
+          <Link to="/">
             Home
+            <Pending />
           </Link>
         </li>
         <li>
-          <Link
-            to="/foo"
-            unstable_pending={<Pending isPending />}
-            unstable_notPending={<Pending isPending={false} />}
-          >
+          <Link to="/foo">
             Foo
+            <Pending />
           </Link>
         </li>
         <li>
-          <Link
-            to={'/nested/bar' as never}
-            unstable_pending={<Pending isPending />}
-            unstable_notPending={<Pending isPending={false} />}
-          >
+          <Link to={'/nested/bar' as never}>
             Link to 404
+            <Pending />
           </Link>
         </li>
       </ul>

--- a/examples/43_weave-render/src/components/HomeLayout.tsx
+++ b/examples/43_weave-render/src/components/HomeLayout.tsx
@@ -1,19 +1,8 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
+import { Pending } from './pending';
 
 import '../styles.css';
-
-const Pending = ({ isPending }: { isPending: boolean }) => (
-  <span
-    style={{
-      marginLeft: 5,
-      transition: 'opacity 75ms 100ms',
-      opacity: isPending ? 1 : 0,
-    }}
-  >
-    Pending...
-  </span>
-);
 
 const getCurrentTime = () => new Date();
 
@@ -28,30 +17,21 @@ const HomeLayout = ({ children }: { children: ReactNode }) => {
         <p>Last render time: {currentTime.toISOString()}</p>
         <ul>
           <li>
-            <Link
-              to="/"
-              unstable_pending={<Pending isPending />}
-              unstable_notPending={<Pending isPending={false} />}
-            >
+            <Link to="/">
               Home
+              <Pending />
             </Link>
           </li>
           <li>
-            <Link
-              to="/foo"
-              unstable_pending={<Pending isPending />}
-              unstable_notPending={<Pending isPending={false} />}
-            >
+            <Link to="/foo">
               Foo
+              <Pending />
             </Link>
           </li>
           <li>
-            <Link
-              to="/bar"
-              unstable_pending={<Pending isPending />}
-              unstable_notPending={<Pending isPending={false} />}
-            >
+            <Link to="/bar">
               Bar
+              <Pending />
             </Link>
           </li>
         </ul>

--- a/examples/43_weave-render/src/components/pending.tsx
+++ b/examples/43_weave-render/src/components/pending.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';
+
+export const Pending = () => {
+  const { pending } = useNavigationStatus();
+  return (
+    <span
+      style={{
+        marginLeft: 5,
+        transition: 'opacity 75ms 100ms',
+        opacity: pending ? 1 : 0,
+      }}
+    >
+      Pending...
+    </span>
+  );
+};

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -324,6 +324,19 @@ function useSharedRef<T>(
   return [managedRef, handleRef];
 }
 
+type NavigationStatus = { pending?: boolean };
+
+const NavigationStatusContext = createContext<NavigationStatus>({});
+
+/**
+ * Returns the navigation status of the enclosing `Link`.
+ * `pending` is `true` while the navigation transition is in flight, including
+ * until any async components in the destination route resolve. Returns an empty
+ * object when called outside a `Link`.
+ */
+export const useNavigationStatus_UNSTABLE = (): NavigationStatus =>
+  useContext(NavigationStatusContext);
+
 export type LinkProps = {
   to: InferredPaths;
   children: ReactNode;
@@ -334,8 +347,6 @@ export type LinkProps = {
    * - `undefined`: scroll on path/hash change (not on query-only change)
    */
   scroll?: boolean;
-  unstable_pending?: ReactNode;
-  unstable_notPending?: ReactNode;
   unstable_prefetchOnEnter?: boolean;
   unstable_prefetchOnView?: boolean;
   unstable_startTransition?: ((fn: TransitionFunction) => void) | undefined;
@@ -346,8 +357,6 @@ export function Link({
   to,
   children,
   scroll,
-  unstable_pending,
-  unstable_notPending,
   unstable_prefetchOnEnter,
   unstable_prefetchOnView,
   unstable_startTransition,
@@ -367,10 +376,7 @@ export function Link({
         throw new Error('Missing Router');
       };
   const [isPending, startTransition] = useTransition();
-  const startTransitionFn =
-    unstable_startTransition ||
-    ((unstable_pending || unstable_notPending) && startTransition) ||
-    ((fn: TransitionFunction) => fn());
+  const startTransitionFn = unstable_startTransition || startTransition;
   const [ref, setRef] = useSharedRef<HTMLAnchorElement>(refProp);
 
   useEffect(() => {
@@ -437,34 +443,19 @@ export function Link({
         props.onMouseEnter?.(event);
       }
     : props.onMouseEnter;
-  const ele = (
-    <a
-      {...props}
-      href={resolvedTo}
-      onClick={onClick}
-      onMouseEnter={onMouseEnter}
-      ref={setRef}
-    >
-      {children}
-    </a>
+  return (
+    <NavigationStatusContext value={{ pending: isPending }}>
+      <a
+        {...props}
+        href={resolvedTo}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        ref={setRef}
+      >
+        {children}
+      </a>
+    </NavigationStatusContext>
   );
-  if (isPending && unstable_pending !== undefined) {
-    return (
-      <>
-        {ele}
-        {unstable_pending}
-      </>
-    );
-  }
-  if (!isPending && unstable_notPending !== undefined) {
-    return (
-      <>
-        {ele}
-        {unstable_notPending}
-      </>
-    );
-  }
-  return ele;
 }
 
 const notAvailableInServer = (name: string) => () => {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -8,6 +8,7 @@ import {
   useContext,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   useTransition,
@@ -329,10 +330,10 @@ type NavigationStatus = { pending?: boolean };
 const NavigationStatusContext = createContext<NavigationStatus>({});
 
 /**
- * Returns the navigation status of the enclosing `Link`.
- * `pending` is `true` while the navigation transition is in flight, including
- * until any async components in the destination route resolve. Returns an empty
- * object when called outside a `Link`.
+ * Returns the navigation status of the enclosing `Link`, like React's
+ * `useFormStatus`. `pending` is `true` while the navigation transition is in
+ * flight, until the destination route's async components resolve. Returns an
+ * empty object when called outside a `Link`.
  */
 export const useNavigationStatus_UNSTABLE = (): NavigationStatus =>
   useContext(NavigationStatusContext);
@@ -349,6 +350,12 @@ export type LinkProps = {
   scroll?: boolean;
   unstable_prefetchOnEnter?: boolean;
   unstable_prefetchOnView?: boolean;
+  /**
+   * Overrides how the navigation transition is started, e.g. to integrate the
+   * browser View Transitions API. When provided, React's `useTransition` is
+   * bypassed, so `useNavigationStatus_UNSTABLE()` stays `{ pending: false }` for
+   * this link.
+   */
   unstable_startTransition?: ((fn: TransitionFunction) => void) | undefined;
   ref?: Ref<HTMLAnchorElement> | undefined;
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
@@ -443,8 +450,9 @@ export function Link({
         props.onMouseEnter?.(event);
       }
     : props.onMouseEnter;
+  const navigationStatus = useMemo(() => ({ pending: isPending }), [isPending]);
   return (
-    <NavigationStatusContext value={{ pending: isPending }}>
+    <NavigationStatusContext value={navigationStatus}>
       <a
         {...props}
         href={resolvedTo}

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { StrictMode, act } from 'react';
+import { StrictMode, act, use } from 'react';
 import type { ReactElement } from 'react';
 import { preloadModule } from 'react-dom';
 import { createRoot } from 'react-dom/client';
@@ -34,6 +34,7 @@ import {
   unstable_getRouteSlotId,
   unstable_getSliceSlotId,
   unstable_parseRoute,
+  useNavigationStatus_UNSTABLE as useNavigationStatus,
   useRouter,
 } from '../src/router/client.js';
 import {
@@ -1004,6 +1005,10 @@ describe('Router integration', () => {
   });
 
   test('link transitions still write committed history after pathname drift', async () => {
+    const PendingLabel = () => {
+      const { pending } = useNavigationStatus();
+      return pending ? <div>Pending...</div> : null;
+    };
     const firstNavigation = createDeferred<Record<string, unknown>>();
     const secondNavigation = createDeferred<Record<string, unknown>>();
     const thirdNavigation = createDeferred<Record<string, unknown>>();
@@ -1023,24 +1028,27 @@ describe('Router integration', () => {
         [unstable_getRouteSlotId('/one')]: (
           <>
             <h1>Page 1</h1>
-            <Link to="/two" unstable_pending={<div>Pending...</div>}>
+            <Link to="/two">
               Go to two
+              <PendingLabel />
             </Link>
           </>
         ),
         [unstable_getRouteSlotId('/two')]: (
           <>
             <h1>Page 2</h1>
-            <Link to="/three" unstable_pending={<div>Pending...</div>}>
+            <Link to="/three">
               Go to three
+              <PendingLabel />
             </Link>
           </>
         ),
         [unstable_getRouteSlotId('/three')]: (
           <>
             <h1>Page 3</h1>
-            <Link to="/two" unstable_pending={<div>Pending...</div>}>
+            <Link to="/two">
               Go back to two
+              <PendingLabel />
             </Link>
           </>
         ),
@@ -2210,6 +2218,92 @@ describe('Router integration', () => {
     } finally {
       view.unmount();
       replaceLocationSpy.mockRestore();
+    }
+  });
+
+  test('useNavigationStatus pending stays until the new route client async resolves', async () => {
+    // The next route's data resolves immediately, but a client component in it
+    // suspends with no data fetch. Pending must persist until that resolves,
+    // proving it tracks the navigation transition, not just data loading.
+    const clientDelay = createDeferred<void>();
+    const ClientSuspends = () => {
+      use(clientDelay.promise);
+      return <h1>Page 2</h1>;
+    };
+    const PendingProbe = () => {
+      const { pending } = useNavigationStatus();
+      return pending ? (
+        <div data-testid="pending">Pending</div>
+      ) : (
+        <div data-testid="not-pending">Idle</div>
+      );
+    };
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
+      [ROUTE_ID]: ['/two', ''],
+      [IS_STATIC_ID]: false,
+    }));
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+    window.history.replaceState({}, '', '/one');
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/one', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/one')]: (
+          <>
+            <h1>Page 1</h1>
+            <Link to="/two">
+              Go to two
+              <PendingProbe />
+            </Link>
+          </>
+        ),
+        [unstable_getRouteSlotId('/two')]: <ClientSuspends />,
+        [ROUTE_ID]: ['/one', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+
+    try {
+      const has = (testid: string) =>
+        view.container.querySelector(`[data-testid="${testid}"]`) !== null;
+
+      expect(has('not-pending')).toBe(true);
+      expect(has('pending')).toBe(false);
+
+      const link = Array.from(view.container.querySelectorAll('a')).find(
+        (anchor) => anchor.textContent?.includes('Go to two'),
+      ) as HTMLAnchorElement | undefined;
+      if (!link) {
+        throw new Error('expected link');
+      }
+      await act(async () => {
+        link.dispatchEvent(
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            button: 0,
+          }),
+        );
+      });
+      await flush();
+
+      // Data is ready, but the client component is still suspended.
+      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(has('pending')).toBe(true);
+      expect(has('not-pending')).toBe(false);
+      expect(view.container.textContent).not.toContain('Page 2');
+
+      // Resolve the client-only async; the transition settles and commits the
+      // new page (the old page, with its Link and indicators, unmounts).
+      await act(async () => {
+        clientDelay.resolve();
+        await flush();
+      });
+
+      expect(has('pending')).toBe(false);
+      expect(view.container.textContent).toContain('Page 2');
+    } finally {
+      view.unmount();
     }
   });
 });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2306,6 +2306,93 @@ describe('Router integration', () => {
       view.unmount();
     }
   });
+
+  test('useNavigationStatus stays idle when the Link uses unstable_startTransition', async () => {
+    // A custom unstable_startTransition replaces React's useTransition, so
+    // isPending never flips and the hook reports { pending: false } for that
+    // link even mid-navigation. This locks the documented limitation.
+    const navigation = createDeferred<Record<string, unknown>>();
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(
+      () => navigation.promise,
+    );
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+    window.history.replaceState({}, '', '/one');
+
+    const PendingProbe = () => {
+      const { pending } = useNavigationStatus();
+      return pending ? (
+        <div data-testid="pending">Pending</div>
+      ) : (
+        <div data-testid="not-pending">Idle</div>
+      );
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/one', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/one')]: (
+          <>
+            <h1>Page 1</h1>
+            <Link
+              to="/two"
+              unstable_startTransition={(fn) => {
+                void fn();
+              }}
+            >
+              Go to two
+              <PendingProbe />
+            </Link>
+          </>
+        ),
+        [unstable_getRouteSlotId('/two')]: <h1>Page 2</h1>,
+        [ROUTE_ID]: ['/one', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+
+    try {
+      const has = (testid: string) =>
+        view.container.querySelector(`[data-testid="${testid}"]`) !== null;
+
+      expect(has('not-pending')).toBe(true);
+
+      const link = Array.from(view.container.querySelectorAll('a')).find(
+        (anchor) => anchor.textContent?.includes('Go to two'),
+      ) as HTMLAnchorElement | undefined;
+      if (!link) {
+        throw new Error('expected link');
+      }
+      await act(async () => {
+        link.dispatchEvent(
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            button: 0,
+          }),
+        );
+      });
+      await flush();
+
+      // Navigation is in flight (refetch not resolved), but the custom
+      // transition bypassed useTransition, so pending never flipped.
+      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(has('pending')).toBe(false);
+      expect(has('not-pending')).toBe(true);
+      expect(view.container.textContent).toContain('Page 1');
+
+      await act(async () => {
+        navigation.resolve({
+          [ROUTE_ID]: ['/two', ''],
+          [IS_STATIC_ID]: false,
+        });
+        await flush();
+      });
+
+      expect(view.container.textContent).toContain('Page 2');
+    } finally {
+      view.unmount();
+    }
+  });
 });
 
 describe('INTERNAL_ServerRouter', () => {


### PR DESCRIPTION
## Summary

Replace `<Link>`'s `unstable_pending` / `unstable_notPending` props with a `useNavigationStatus_UNSTABLE()` hook, like React's `useFormStatus`. A child of `<Link>` reads `{ pending }`:

```tsx
import { useNavigationStatus_UNSTABLE as useNavigationStatus } from 'waku/router/client';

const Pending = () => {
  const { pending } = useNavigationStatus();
  return <span aria-hidden style={{ opacity: pending ? 1 : 0 }}>Loading...</span>;
};
```

`pending` follows the link's transition, so it stays true until the new route's async components resolve (including a client-only Suspense), not just until data loads.

## Notes

- Breaking: `unstable_pending` / `unstable_notPending` removed.
- Every `<Link>` now navigates inside a transition.
- Exported from `waku/router/client` only.
