### PR TITLE
feat: cache tag for client (experimental)

### DIFF
--- a/e2e/cache-tag.spec.ts
+++ b/e2e/cache-tag.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from '@playwright/test';
+import { prepareNormalSetup, test, waitForHydration } from './utils.js';
+
+const startApp = prepareNormalSetup('cache-tag');
+
+test.skip(
+  ({ browserName }) => browserName !== 'chromium',
+  'One browser is enough for this server-behavior test.',
+);
+
+test.describe('cache-tag', () => {
+  let port: number;
+  let stopApp: () => Promise<void>;
+
+  test.beforeAll(async ({ mode }) => {
+    ({ port, stopApp } = await startApp(mode));
+  });
+
+  test.afterAll(async () => {
+    await stopApp();
+  });
+
+  test('etag omits a cached element on the wire until invalidated', async ({
+    page,
+    browser,
+  }) => {
+    await page.goto(`http://localhost:${port}/`);
+    await waitForHydration(page);
+    await expect(page.getByTestId('home-heading')).toBeVisible();
+
+    // 1) First navigation to /cached: the element is sent over the wire.
+    const firstRsc = page.waitForResponse('**/RSC/R/cached.txt**');
+    await page.getByTestId('to-cached').click();
+    const firstBody = await (await firstRsc).text();
+    await expect(page.getByTestId('cached-content')).toHaveText(
+      'cached render #1',
+    );
+    expect(firstBody).toContain('cached-content');
+
+    // 1b) A fresh client (no etags) is served the element from the server
+    //     cache: the render count stays at #1, proving the stored RSC payload
+    //     was replayed rather than re-rendered.
+    const freshContext = await browser.newContext();
+    const freshPage = await freshContext.newPage();
+    await freshPage.goto(`http://localhost:${port}/cached`);
+    await waitForHydration(freshPage);
+    await expect(freshPage.getByTestId('cached-content')).toHaveText(
+      'cached render #1',
+    );
+    await freshContext.close();
+
+    // 2) Navigate away and back: the etag still matches, so the element is
+    //    omitted from the wire yet still rendered from the client's cache.
+    await page.getByTestId('to-home').click();
+    await expect(page.getByTestId('home-heading')).toBeVisible();
+    const secondRsc = page.waitForResponse('**/RSC/R/cached.txt**');
+    await page.getByTestId('to-cached').click();
+    const secondBody = await (await secondRsc).text();
+    await expect(page.getByTestId('cached-content')).toHaveText(
+      'cached render #1',
+    );
+    expect(secondBody).not.toContain('cached-content');
+
+    // 3) Invalidate the cache (bumps the etag), then navigate: the element is
+    //    re-sent over the wire and re-rendered.
+    await page.getByTestId('to-home').click();
+    await expect(page.getByTestId('home-heading')).toBeVisible();
+    const invalidation = await page.request.get(
+      `http://localhost:${port}/invalidate`,
+    );
+    expect(invalidation.ok()).toBe(true);
+    const thirdRsc = page.waitForResponse('**/RSC/R/cached.txt**');
+    await page.getByTestId('to-cached').click();
+    const thirdBody = await (await thirdRsc).text();
+    await expect(page.getByTestId('cached-content')).toHaveText(
+      'cached render #2',
+    );
+    expect(thirdBody).toContain('cached-content');
+  });
+});

--- a/e2e/fixtures/cache-tag/package.json
+++ b/e2e/fixtures/cache-tag/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cache-tag",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev",
+    "build": "waku build",
+    "start": "waku start"
+  },
+  "dependencies": {
+    "react": "~19.2.6",
+    "react-dom": "~19.2.6",
+    "react-server-dom-webpack": "~19.2.6",
+    "waku": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.16",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^6.0.3"
+  }
+}

--- a/e2e/fixtures/cache-tag/src/lib/waku-cache.tsx
+++ b/e2e/fixtures/cache-tag/src/lib/waku-cache.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import { deserializeRsc, serializeRsc } from 'waku/server';
+
+// A minimal reference implementation of a "waku-cache"-style server cache. It
+// wraps a component so its rendered subtree is serialized to RSC bytes once and
+// replayed on later requests, and exposes a matching `getEtag`, an eager per-key
+// cache tag that lets Waku skip re-sending an unchanged element to the client.
+// A real library would use a pluggable store (memory/redis/etc.) and offer
+// richer invalidation; here everything is in-memory and the tag is derived from
+// a per-key version counter so it is known without rendering.
+
+type PageProps = Record<string, unknown>;
+
+const versions = new Map<string, number>();
+const renderCache = new Map<string, Promise<Uint8Array>>();
+
+const tagOf = (key: string) => `${key}@${versions.get(key) ?? 0}`;
+
+export const cacheRsc = (
+  Component: (props: PageProps) => ReactNode | Promise<ReactNode>,
+  getKey: (props: PageProps) => string,
+) => {
+  const Cached = async (props: PageProps): Promise<ReactNode> => {
+    const key = getKey(props);
+    let bytes = renderCache.get(key);
+    if (!bytes) {
+      bytes = serializeRsc(await Component(props));
+      renderCache.set(key, bytes);
+    }
+    return (await deserializeRsc(await bytes)) as ReactNode;
+  };
+  // Eager cache tag: known from the key + version, no rendering required. Wire
+  // it into `getConfig` as `unstable_getEtag` so Waku can skip the slot on
+  // navigation when the client already holds the current tag.
+  const getEtag = async (props: PageProps): Promise<string> =>
+    tagOf(getKey(props));
+  return { Component: Cached, getEtag };
+};
+
+export const invalidate = (key: string): void => {
+  versions.set(key, (versions.get(key) ?? 0) + 1);
+  renderCache.delete(key);
+};

--- a/e2e/fixtures/cache-tag/src/pages/_api/invalidate.ts
+++ b/e2e/fixtures/cache-tag/src/pages/_api/invalidate.ts
@@ -1,0 +1,6 @@
+import { invalidate } from '../../lib/waku-cache.js';
+
+export async function GET() {
+  invalidate('cached-page');
+  return new Response('ok');
+}

--- a/e2e/fixtures/cache-tag/src/pages/cached.tsx
+++ b/e2e/fixtures/cache-tag/src/pages/cached.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'waku';
+import { cacheRsc } from '../lib/waku-cache.js';
+
+// Incremented only on an actual render; a cache hit reuses the prior element,
+// so the visible number stays put until the cache key is invalidated.
+let renderCount = 0;
+
+const CachedContent = () => {
+  ++renderCount;
+  return (
+    <div>
+      <h1>Cached</h1>
+      <p data-testid="cached-content">cached render #{renderCount}</p>
+      <p>
+        <Link to="/" data-testid="to-home">
+          Go home
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+const { Component, getEtag } = cacheRsc(CachedContent, () => 'cached-page');
+
+export default Component;
+
+export const getConfig = () => {
+  return {
+    render: 'dynamic',
+    unstable_getEtag: getEtag,
+  } as const;
+};

--- a/e2e/fixtures/cache-tag/src/pages/index.tsx
+++ b/e2e/fixtures/cache-tag/src/pages/index.tsx
@@ -1,0 +1,14 @@
+import { Link } from 'waku';
+
+export default function HomePage() {
+  return (
+    <div>
+      <h1 data-testid="home-heading">Home</h1>
+      <p>
+        <Link to="/cached" data-testid="to-cached">
+          Go to cached
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/e2e/fixtures/cache-tag/src/waku.client.tsx
+++ b/e2e/fixtures/cache-tag/src/waku.client.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
+import { Router } from 'waku/router/client';
+
+const rootElement = (
+  <StrictMode>
+    <Router />
+  </StrictMode>
+);
+
+if ((globalThis as any).__WAKU_HYDRATE__) {
+  hydrateRoot(document.body, rootElement, defaultRootOptions);
+} else {
+  createRoot(document.body, defaultRootOptions).render(rootElement);
+}

--- a/e2e/fixtures/cache-tag/tsconfig.json
+++ b/e2e/fixtures/cache-tag/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/e2e/router-client.spec.ts
+++ b/e2e/router-client.spec.ts
@@ -353,9 +353,9 @@ test.describe('router-client', () => {
 
     const skipHeader = request.headers()['x-waku-router-skip'];
     expect(skipHeader).toBeTruthy();
-    const skippedIds = JSON.parse(skipHeader as string) as unknown;
-    expect(Array.isArray(skippedIds)).toBe(true);
-    expect((skippedIds as unknown[]).length).toBeGreaterThan(0);
+    const skipped = JSON.parse(skipHeader as string) as Record<string, string>;
+    expect(Array.isArray(skipped)).toBe(false);
+    expect(Object.keys(skipped).length).toBeGreaterThan(0);
 
     await expect(page.getByRole('heading', { name: 'Next' })).toBeVisible();
     await expect(page.getByTestId('route-path')).toHaveText('/next');
@@ -388,9 +388,9 @@ test.describe('router-client', () => {
     const skipHeader = request.headers()['x-waku-router-skip'];
 
     expect(skipHeader).toBeTruthy();
-    const skipIds = JSON.parse(skipHeader as string) as unknown;
-    expect(Array.isArray(skipIds)).toBe(true);
-    expect(skipIds).toContain('root');
+    const skipped = JSON.parse(skipHeader as string) as Record<string, string>;
+    expect(Array.isArray(skipped)).toBe(false);
+    expect('root' in skipped).toBe(true);
 
     const payload = await response.text();
     expect(payload).toContain('SKIP_B_PAGE_MARKER');

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -817,11 +817,11 @@ const InnerRouter = ({
         }
         const etags: Record<string, string> = {};
         for (const [key, value] of Object.entries(elements)) {
-          // An empty tag is the server's signal to drop a now-stale tag.
+          // Drop empty (clear signal) and non-Latin1 (breaks fetch) tags.
           if (
             key.startsWith(ETAG_ID_PREFIX) &&
             typeof value === 'string' &&
-            value
+            /^[\u0020-\u00ff]+$/.test(value)
           ) {
             etags[key.slice(ETAG_ID_PREFIX.length)] = value;
           }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -38,6 +38,7 @@ import {
 } from '../minimal/client.js';
 import type { RouteConfig } from './base-types.js';
 import {
+  ETAG_ID_PREFIX,
   HAS404_ID,
   IS_STATIC_ID,
   ROUTE_ID,
@@ -774,7 +775,7 @@ const InnerRouter = ({
   if (import.meta.hot) {
     const refetchRoute = () => {
       staticPathSetRef.current.clear();
-      cachedIdSetRef.current.clear();
+      cachedEtagsRef.current = {};
       const rscPath = encodeRoutePath(route.path);
       const rscParams = createRscParams(route.query);
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -794,7 +795,7 @@ const InnerRouter = ({
 
   const [has404, setHas404] = useState(false);
   const staticPathSetRef = useRef(new Set<string>());
-  const cachedIdSetRef = useRef(new Set<string>());
+  const cachedEtagsRef = useRef<Record<string, string>>({});
   // FIXME this "fetchingSlices" hack feels suboptimal.
   const fetchingSlicesRef = useRef(new Set<SliceId>());
   useEffect(() => {
@@ -804,7 +805,6 @@ const InnerRouter = ({
           [ROUTE_ID]: routeData,
           [IS_STATIC_ID]: isStatic,
           [HAS404_ID]: has404FromElements,
-          ...rest
         } = elements;
         if (has404FromElements) {
           setHas404(true);
@@ -815,7 +815,18 @@ const InnerRouter = ({
             staticPathSetRef.current.add(path);
           }
         }
-        cachedIdSetRef.current = new Set(Object.keys(rest));
+        const etags: Record<string, string> = {};
+        for (const [key, value] of Object.entries(elements)) {
+          // An empty tag is the server's signal to drop a now-stale tag.
+          if (
+            key.startsWith(ETAG_ID_PREFIX) &&
+            typeof value === 'string' &&
+            value
+          ) {
+            etags[key.slice(ETAG_ID_PREFIX.length)] = value;
+          }
+        }
+        cachedEtagsRef.current = etags;
       },
       () => {},
     );
@@ -900,7 +911,7 @@ const InnerRouter = ({
             if (init.signal === undefined) {
               init.signal = abortController.signal;
             }
-            const skipStr = JSON.stringify(Array.from(cachedIdSetRef.current));
+            const skipStr = JSON.stringify(cachedEtagsRef.current);
             const headers = (init.headers ||= {});
             if (Array.isArray(headers)) {
               headers.push([SKIP_HEADER, skipStr]);
@@ -1016,7 +1027,7 @@ const InnerRouter = ({
     const skipHeaderEnhancer =
       (fetchFn: typeof fetch) =>
       (input: RequestInfo | URL, init: RequestInit = {}) => {
-        const skipStr = JSON.stringify(Array.from(cachedIdSetRef.current));
+        const skipStr = JSON.stringify(cachedEtagsRef.current);
         const headers = (init.headers ||= {});
         if (Array.isArray(headers)) {
           headers.push([SKIP_HEADER, skipStr]);

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -87,6 +87,7 @@ export function decodeSliceId(rscPath: string): string | null {
 export const ROUTE_ID = 'ROUTE';
 export const IS_STATIC_ID = 'IS_STATIC';
 export const HAS404_ID = 'HAS404';
+export const ETAG_ID_PREFIX = 'ETAG:';
 
 // For HTTP header
 export const SKIP_HEADER = 'X-Waku-Router-Skip';

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -159,10 +159,14 @@ export type PathWithWildcard<
 > = PathWithSlug<Path, SlugKey | `...${WildSlugKey}`>;
 
 /**
- * Returns a `dynamic` slot's element tag (etag) so the client can reuse its
- * cached element while the tag is unchanged. Opaque to Waku, compared with
- * `===`. Return `undefined` for no tag: the element is always sent, and any tag
- * the client still holds for the slot is cleared.
+ * Returns a `dynamic` slot's element tag (etag). While the tag is unchanged the
+ * client reuses its cached element instead of receiving it again. Only consulted
+ * for dynamic slots.
+ *
+ * - Opaque to Waku; compared with `===`.
+ * - Keep it short (a hash or version): the client echoes its tags in a header.
+ * - Return `undefined` for no tag: the element is always sent, overriding the
+ *   client's cache for the slot.
  */
 type GetEtag<Props> = (props: Props) => Promise<string | undefined>;
 

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -158,6 +158,14 @@ export type PathWithWildcard<
   WildSlugKey extends string,
 > = PathWithSlug<Path, SlugKey | `...${WildSlugKey}`>;
 
+/**
+ * Returns a `dynamic` slot's element tag (etag) so the client can reuse its
+ * cached element while the tag is unchanged. Opaque to Waku, compared with
+ * `===`. Return `undefined` for no tag: the element is always sent, and any tag
+ * the client still holds for the slot is cleared.
+ */
+type GetEtag<Props> = (props: Props) => Promise<string | undefined>;
+
 export type CreatePage = <
   Path extends string,
   SlugKey extends string,
@@ -209,6 +217,11 @@ export type CreatePage = <
      * chunks from the runtime server bundle if the route is fully static.
      */
     unstable_sourceFile?: string | undefined;
+    /**
+     * Per-render element tag (etag) for a `dynamic` page. Ignored for `static`
+     * pages.
+     */
+    unstable_getEtag?: GetEtag<PropsForPages<Path>>;
   },
 ) => Omit<
   Extract<
@@ -219,7 +232,7 @@ export type CreatePage = <
 >;
 
 export type CreateLayout = <Path extends string>(
-  layout:
+  layout: (
     | {
         render: 'dynamic';
         path: Path;
@@ -238,7 +251,14 @@ export type CreateLayout = <Path extends string>(
       }
     | {
         component: null; // For build-time pruning
-      },
+      }
+  ) & {
+    /**
+     * Per-render element tag (etag) for a `dynamic` layout. Ignored for `static`
+     * layouts.
+     */
+    unstable_getEtag?: GetEtag<Omit<PropsForPages<Path>, 'path' | 'query'>>;
+  },
 ) => void;
 
 export type CreateApi = <Path extends string>(
@@ -282,7 +302,7 @@ export type CreateSlice = <
   ID extends string,
   StaticPaths extends StaticSlugRoutePaths<`/${ID}`>,
 >(
-  slice:
+  slice: (
     | {
         render: 'dynamic';
         id: ID;
@@ -311,13 +331,25 @@ export type CreateSlice = <
       }
     | {
         component: null; // For build-time pruning
-      },
+      }
+  ) & {
+    /**
+     * Per-render element tag (etag) for a `dynamic` slice. Ignored for `static`
+     * slices.
+     */
+    unstable_getEtag?: GetEtag<SlugPropsFromId<ID>>;
+  },
 ) => void;
 
 type RootItem = {
   render: 'static' | 'dynamic';
   component: FunctionComponent<{ children: ReactNode }>;
   unstable_sourceFile?: string | undefined;
+  /**
+   * Per-render element tag (etag) for a `dynamic` root. Ignored for a `static`
+   * root. The root takes no props, so the getter is parameterless.
+   */
+  unstable_getEtag?: () => Promise<string | undefined>;
 };
 
 export type CreateRoot = (
@@ -441,16 +473,18 @@ export const createPages = <
       sourceFile?: string | undefined;
     }
   >();
-  type DynamicPageEntry = {
+  type DynamicPageEntry<Props = any> = {
     routePathSpec: PathSpec;
-    component: FunctionComponent<any>;
+    component: FunctionComponent<Props>;
     noSsr: boolean;
     sourceFile?: string | undefined;
+    getEtag?: GetEtag<Props> | undefined;
   };
-  type LayoutEntry = {
+  type LayoutEntry<Props = any> = {
     routePathSpec: PathSpec;
-    component: FunctionComponent<any>;
+    component: FunctionComponent<{ children: ReactNode } & Props>;
     sourceFile?: string | undefined;
+    getEtag?: GetEtag<Props> | undefined;
   };
   const dynamicPageEntryByRoutePath = new Map<string, DynamicPageEntry>();
   const wildcardPageEntryByRoutePath = new Map<string, DynamicPageEntry>();
@@ -472,14 +506,13 @@ export const createPages = <
   const getStaticLayout = (id: string) =>
     staticComponentById.get(joinPath(id, 'layout').slice(1))?.component;
   const sliceIdsByRoutePath = new Map<string, string[]>();
-  const sliceEntryById = new Map<
-    string,
-    {
-      component: FunctionComponent<any>;
-      isStatic: boolean;
-      sourceFile?: string | undefined;
-    }
-  >();
+  type SliceEntry<Props = any> = {
+    component: FunctionComponent<{ children?: ReactNode } & Props>;
+    isStatic: boolean;
+    sourceFile?: string | undefined;
+    getEtag?: GetEtag<Props> | undefined;
+  };
+  const sliceEntryById = new Map<string, SliceEntry>();
   let rootItem: RootItem | undefined = undefined;
 
   const pagePathExists = (path: string) =>
@@ -579,6 +612,7 @@ export const createPages = <
     const noSsr = page.unstable_disableSSR ?? false;
     const slices = page.slices || [];
     const sourceFile = page.unstable_sourceFile;
+    const getEtag = page.unstable_getEtag;
 
     const registerPageWithExactPath = () => {
       const routePath = pageRoutePath;
@@ -597,6 +631,7 @@ export const createPages = <
           component: page.component,
           noSsr,
           sourceFile,
+          getEtag,
         });
       }
       sliceIdsByRoutePath.set(routePath, slices);
@@ -658,6 +693,7 @@ export const createPages = <
         component: page.component,
         noSsr,
         sourceFile,
+        getEtag,
       });
       sliceIdsByRoutePath.set(routePath, slices);
     };
@@ -672,6 +708,7 @@ export const createPages = <
         component: page.component,
         noSsr,
         sourceFile,
+        getEtag,
       });
       sliceIdsByRoutePath.set(routePath, slices);
     };
@@ -705,6 +742,7 @@ export const createPages = <
     }
     const routePath = pathnameToRoutePath(layout.path);
     const sourceFile = layout.unstable_sourceFile;
+    const getEtag = layout.unstable_getEtag;
     if (layout.render === 'static') {
       const id = joinPath(routePath, 'layout').replace(/^\//, '');
       registerStaticComponent(id, layout.component, sourceFile);
@@ -717,6 +755,7 @@ export const createPages = <
         routePathSpec,
         component: layout.component,
         sourceFile,
+        getEtag,
       });
     } else {
       throw new Error('Invalid layout configuration');
@@ -810,6 +849,7 @@ export const createPages = <
     const slicePathSpec = parsePathWithSlug(slice.id);
     const { numSlugs } = countSlugsAndWildcards(slicePathSpec);
     const sourceFile = slice.unstable_sourceFile;
+    const getEtag = slice.unstable_getEtag;
     if (slice.render === 'static' && numSlugs > 0) {
       if (!('staticPaths' in slice) || !slice.staticPaths) {
         throw new Error(
@@ -842,6 +882,7 @@ export const createPages = <
       component: slice.component,
       isStatic: slice.render === 'static',
       sourceFile,
+      getEtag,
     });
   };
 
@@ -889,13 +930,14 @@ export const createPages = <
   const definedRouter = unstable_defineRouter({
     getConfigs: async () => {
       await configure();
+      type RendererOption = { routePath: string; query: string | undefined };
       type ElementSpec = {
         isStatic: boolean;
-        renderer: (options: {
-          routePath: string;
-          query: string | undefined;
-        }) => ReactNode;
+        renderer: (option: RendererOption) => ReactNode;
         sourceFile?: string;
+        getEtagFromOption?: (
+          option: RendererOption,
+        ) => Promise<string | undefined>;
       };
       type LayoutMatch = { layoutPath: string; layoutIdPath: string };
       const collectLayoutMatches = (
@@ -908,6 +950,35 @@ export const createPages = <
             ? getLayoutIdPath(layoutPath, routePath)
             : layoutPath,
         }));
+      // Memoize so component and getEtag get the same props reference.
+      const buildElementSpec = <Props,>(
+        component: FunctionComponent<Props>,
+        buildProps: (option: RendererOption) => Props,
+        isStatic: boolean,
+        sourceFile: string | undefined,
+        getEtag: GetEtag<Props> | undefined,
+      ): ElementSpec => {
+        const propsCache = new WeakMap<RendererOption, Props>();
+        const toProps = (option: RendererOption): Props => {
+          if (!propsCache.has(option)) {
+            propsCache.set(option, buildProps(option));
+          }
+          return propsCache.get(option)!;
+        };
+        return {
+          isStatic,
+          renderer: (option) =>
+            createElement(
+              component as FunctionComponent<any>,
+              toProps(option),
+              <Children />,
+            ),
+          ...(sourceFile ? { sourceFile } : {}),
+          ...(getEtag
+            ? { getEtagFromOption: (option) => getEtag(toProps(option)) }
+            : {}),
+        };
+      };
       const buildLayoutElement = (layoutPath: string): ElementSpec => {
         const dynamicEntry = dynamicLayoutEntryByRoutePath.get(layoutPath);
         const staticEntry = dynamicEntry
@@ -919,16 +990,13 @@ export const createPages = <
         }
         const sourceFile = dynamicEntry?.sourceFile ?? staticEntry?.sourceFile;
         const getLayoutPropsMapping = createLayoutPropsMapper(layoutPath);
-        return {
-          isStatic: !dynamicEntry,
-          renderer: (option) =>
-            createElement(
-              layout,
-              getLayoutPropsMapping(option.routePath),
-              <Children />,
-            ),
-          ...(sourceFile ? { sourceFile } : {}),
-        };
+        return buildElementSpec(
+          layout,
+          (option) => getLayoutPropsMapping(option.routePath),
+          !dynamicEntry,
+          sourceFile,
+          dynamicEntry?.getEtag,
+        );
       };
       const buildLayoutElements = (
         matches: LayoutMatch[],
@@ -939,31 +1007,33 @@ export const createPages = <
             buildLayoutElement(layoutPath),
           ]),
         );
-      const buildPageElement = (
-        component: FunctionComponent<any>,
+      const buildPageElement = <Props,>(
+        component: FunctionComponent<Props>,
         getPropsMapping: (routePath: string) => Record<string, unknown> | null,
         isStatic: boolean,
         sourceFile?: string,
-      ): ElementSpec => ({
-        isStatic,
-        renderer: (option) =>
-          createElement(
-            component,
-            {
+        getEtag?: GetEtag<Props>,
+      ): ElementSpec =>
+        buildElementSpec(
+          component,
+          (option) =>
+            ({
               ...getPropsMapping(option.routePath),
               ...(option.query ? { query: option.query } : {}),
               path: option.routePath,
-            },
-            <Children />,
-          ),
-        ...(sourceFile ? { sourceFile } : {}),
-      });
+            }) as unknown as Props,
+          isStatic,
+          sourceFile,
+          getEtag,
+        );
       const rootIsStatic = !rootItem || rootItem.render === 'static';
       const rootSourceFile = rootItem?.unstable_sourceFile;
+      const rootGetEtag = rootItem?.unstable_getEtag;
       const buildRootElement = (): ElementSpec => ({
         isStatic: rootIsStatic,
         renderer: renderRoot,
         ...(rootSourceFile ? { sourceFile: rootSourceFile } : {}),
+        ...(rootGetEtag ? { getEtagFromOption: () => rootGetEtag() } : {}),
       });
       const buildStaticRouteConfigs = () =>
         Array.from(
@@ -1010,7 +1080,13 @@ export const createPages = <
         );
       const buildDynamicLikeRouteConfig = (
         routePath: string,
-        { routePathSpec, component, noSsr, sourceFile }: DynamicPageEntry,
+        {
+          routePathSpec,
+          component,
+          noSsr,
+          sourceFile,
+          getEtag,
+        }: DynamicPageEntry,
       ) => {
         const layouts = collectLayoutMatches(routePathSpec);
         const getPropsMapping = createPathPropsMapper(routePath);
@@ -1021,6 +1097,7 @@ export const createPages = <
           getPropsMapping,
           false,
           sourceFile,
+          getEtag,
         );
         return {
           type: 'route' as const,
@@ -1075,24 +1152,28 @@ export const createPages = <
           }),
         );
       const buildSliceConfigs = () =>
-        Array.from(sliceEntryById, ([id, { isStatic, sourceFile }]) => {
-          const slicePathSpec = parsePathWithSlug(id);
-          const hasSlug = slicePathSpec.some((s) => s.type !== 'literal');
-          return {
-            type: 'slice' as const,
-            id,
-            ...(hasSlug ? { pathSpec: slicePathSpec } : {}),
-            isStatic,
-            renderer: async (params?: Record<string, string | string[]>) => {
-              const slice = sliceEntryById.get(id);
-              if (!slice) {
-                throw new Error('Slice not found: ' + id);
-              }
-              return createElement(slice.component, params, <Children />);
-            },
-            ...(sourceFile ? { sourceFile } : {}),
-          };
-        });
+        Array.from(
+          sliceEntryById,
+          ([id, { isStatic, sourceFile, getEtag }]) => {
+            const slicePathSpec = parsePathWithSlug(id);
+            const hasSlug = slicePathSpec.some((s) => s.type !== 'literal');
+            return {
+              type: 'slice' as const,
+              id,
+              ...(hasSlug ? { pathSpec: slicePathSpec } : {}),
+              isStatic,
+              renderer: async (params?: Record<string, string | string[]>) => {
+                const slice = sliceEntryById.get(id);
+                if (!slice) {
+                  throw new Error('Slice not found: ' + id);
+                }
+                return createElement(slice.component, params, <Children />);
+              },
+              ...(sourceFile ? { sourceFile } : {}),
+              ...(getEtag ? { getEtagFromParams: getEtag } : {}),
+            };
+          },
+        );
 
       const routeConfigs = [
         ...buildStaticRouteConfigs(),

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -164,7 +164,9 @@ export type PathWithWildcard<
  * for dynamic slots.
  *
  * - Opaque to Waku; compared with `===`.
- * - Keep it short (a hash or version): the client echoes its tags in a header.
+ * - Must change whenever the rendered content would.
+ * - Keep it a short ASCII string (a hash or version): the client echoes its
+ *   tags in a header.
  * - Return `undefined` for no tag: the element is always sent, overriding the
  *   client's cache for the slot.
  */

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -13,6 +13,7 @@ import { unstable_defineHandlers as defineHandlers } from '../minimal/server.js'
 import { deserializeRsc, serializeRsc } from '../server.js';
 import { INTERNAL_ServerRouter } from './client.js';
 import {
+  ETAG_ID_PREFIX,
   HAS404_ID,
   IS_STATIC_ID,
   ROUTE_ID,
@@ -29,8 +30,19 @@ export type ApiHandler = (
   apiContext: { params: Record<string, string | string[]> },
 ) => Promise<Response>;
 
-const isStringArray = (x: unknown): x is string[] =>
-  Array.isArray(x) && x.every((y) => typeof y === 'string');
+const isStringRecord = (x: unknown): x is Record<string, string> =>
+  typeof x === 'object' &&
+  x !== null &&
+  !Array.isArray(x) &&
+  Object.values(x).every((v) => typeof v === 'string');
+
+const safeJsonParse = (text: string): unknown => {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+};
 
 const parseRscParams = (
   rscParams: unknown,
@@ -180,6 +192,9 @@ const ROOT_SLOT_ID = 'root';
 const ROUTE_SLOT_ID_PREFIX = 'route:';
 const SLICE_SLOT_ID_PREFIX = 'slice:';
 
+// The element tag (etag) used for every static slot; known without rendering.
+const STATIC_ETAG = 'static';
+
 type CacheId = string;
 
 const getSlotCacheId = (slotId: SlotId): CacheId => `slot/${slotId}`;
@@ -202,6 +217,13 @@ const assertNonReservedSlotId = (slotId: SlotId) => {
 
 type RendererOption = { routePath: string; query: string | undefined };
 
+type GetEtagFromOption = (
+  option: RendererOption,
+) => Promise<string | undefined>;
+type GetEtagFromParams = (
+  params?: Record<string, string | string[]>,
+) => Promise<string | undefined>;
+
 type RouteConfig = {
   type: 'route';
   path: PathSpec;
@@ -210,17 +232,20 @@ type RouteConfig = {
   rootElement: {
     isStatic: boolean;
     renderer: (option: RendererOption) => ReactNode;
+    getEtagFromOption?: GetEtagFromOption;
     sourceFile?: string;
   };
   routeElement: {
     isStatic: boolean;
     renderer: (option: RendererOption) => ReactNode;
+    getEtagFromOption?: GetEtagFromOption;
   };
   elements: Record<
     SlotId,
     {
       isStatic: boolean;
       renderer: (option: RendererOption) => ReactNode;
+      getEtagFromOption?: GetEtagFromOption;
       sourceFile?: string;
     }
   >;
@@ -242,6 +267,7 @@ type SliceConfig = {
   pathSpec?: PathSpec;
   isStatic: boolean;
   renderer: (params?: Record<string, string | string[]>) => Promise<ReactNode>;
+  getEtagFromParams?: GetEtagFromParams;
   sourceFile?: string;
 };
 
@@ -251,14 +277,26 @@ type SerializableRouteConfig = Omit<
   RouteConfig,
   'rootElement' | 'routeElement' | 'elements'
 > & {
-  rootElement: Omit<RouteConfig['rootElement'], 'renderer'>;
-  routeElement: Omit<RouteConfig['routeElement'], 'renderer'>;
-  elements: Record<SlotId, Omit<RouteConfig['elements'][string], 'renderer'>>;
+  rootElement: Omit<
+    RouteConfig['rootElement'],
+    'renderer' | 'getEtagFromOption'
+  >;
+  routeElement: Omit<
+    RouteConfig['routeElement'],
+    'renderer' | 'getEtagFromOption'
+  >;
+  elements: Record<
+    SlotId,
+    Omit<RouteConfig['elements'][string], 'renderer' | 'getEtagFromOption'>
+  >;
 };
 
 type SerializableApiConfig = Omit<ApiConfig, 'handler'>;
 
-type SerializableSliceConfig = Omit<SliceConfig, 'renderer'>;
+type SerializableSliceConfig = Omit<
+  SliceConfig,
+  'renderer' | 'getEtagFromParams'
+>;
 
 type SerializableConfig =
   | SerializableRouteConfig
@@ -268,17 +306,27 @@ type SerializableConfig =
 const toSerializable = (c: RuntimeConfig): SerializableConfig => {
   if (c.type === 'route') {
     const { rootElement, routeElement, elements, ...rest } = c;
-    const { renderer: _rootRenderer, ...rootElementRest } = rootElement;
-    const { renderer: _routeRenderer, ...routeElementRest } = routeElement;
+    const {
+      renderer: _rootRenderer,
+      getEtagFromOption: _rootGetEtag,
+      ...rootElementRest
+    } = rootElement;
+    const {
+      renderer: _routeRenderer,
+      getEtagFromOption: _routeGetEtag,
+      ...routeElementRest
+    } = routeElement;
     return {
       ...rest,
       rootElement: rootElementRest,
       routeElement: routeElementRest,
       elements: Object.fromEntries(
-        Object.entries(elements).map(([id, { renderer: _r, ...elRest }]) => [
-          id,
-          elRest,
-        ]),
+        Object.entries(elements).map(
+          ([id, { renderer: _r, getEtagFromOption: _g, ...elRest }]) => [
+            id,
+            elRest,
+          ],
+        ),
       ),
     };
   }
@@ -286,7 +334,7 @@ const toSerializable = (c: RuntimeConfig): SerializableConfig => {
     const { handler: _handler, ...rest } = c;
     return rest;
   }
-  const { renderer: _renderer, ...rest } = c;
+  const { renderer: _r, getEtagFromParams: _g, ...rest } = c;
   return rest;
 };
 
@@ -339,12 +387,16 @@ const mergeWithRuntimeConfigs = (
       const label = `route ${pathSpecAsString(c.path)}`;
       const elements: RouteConfig['elements'] = {};
       for (const [id, val] of Object.entries(c.elements)) {
+        const elementSpec = runtimeItem?.elements[id];
         elements[id] = {
           isStatic: val.isStatic,
           renderer:
-            runtimeItem?.elements[id]?.renderer ??
+            elementSpec?.renderer ??
             sharedElementRenderers.get(id) ??
             (() => noRuntimeFn(`element "${id}" of ${label}`)),
+          ...(elementSpec?.getEtagFromOption
+            ? { getEtagFromOption: elementSpec.getEtagFromOption }
+            : {}),
           ...(val.sourceFile ? { sourceFile: val.sourceFile } : {}),
         };
       }
@@ -359,6 +411,9 @@ const mergeWithRuntimeConfigs = (
             runtimeItem?.rootElement.renderer ??
             sharedRootRenderer ??
             (() => noRuntimeFn(`rootElement of ${label}`)),
+          ...(runtimeItem?.rootElement.getEtagFromOption
+            ? { getEtagFromOption: runtimeItem.rootElement.getEtagFromOption }
+            : {}),
           ...(c.rootElement.sourceFile
             ? { sourceFile: c.rootElement.sourceFile }
             : {}),
@@ -368,6 +423,9 @@ const mergeWithRuntimeConfigs = (
           renderer:
             runtimeItem?.routeElement.renderer ??
             (() => noRuntimeFn(`routeElement of ${label}`)),
+          ...(runtimeItem?.routeElement.getEtagFromOption
+            ? { getEtagFromOption: runtimeItem.routeElement.getEtagFromOption }
+            : {}),
         },
         elements,
         ...(c.noSsr !== undefined ? { noSsr: c.noSsr } : {}),
@@ -394,6 +452,9 @@ const mergeWithRuntimeConfigs = (
       isStatic: c.isStatic,
       renderer:
         runtimeItem?.renderer ?? (async () => noRuntimeFn(`slice ${c.id}`)),
+      ...(runtimeItem?.getEtagFromParams
+        ? { getEtagFromParams: runtimeItem.getEtagFromParams }
+        : {}),
       ...(c.sourceFile ? { sourceFile: c.sourceFile } : {}),
     };
   });
@@ -540,13 +601,12 @@ export function unstable_defineRouter(fns: {
     if (pathConfigItem?.type !== 'route') {
       return null;
     }
-    let skipParam: unknown;
-    try {
-      skipParam = JSON.parse(headers[SKIP_HEADER.toLowerCase()] || '');
-    } catch {
-      // ignore
-    }
-    const skipIdSet = new Set(isStringArray(skipParam) ? skipParam : []);
+    const parsedEtags = safeJsonParse(
+      headers[SKIP_HEADER.toLowerCase()] || '{}',
+    );
+    const clientEtags: Record<string, string> = isStringRecord(parsedEtags)
+      ? parsedEtags
+      : {};
     const { query } = parseRscParams(rscParams);
     const routeId = ROUTE_SLOT_ID_PREFIX + routePath;
     const routeTemplateCacheId = getPathSpecCacheId(pathConfigItem.path);
@@ -564,6 +624,8 @@ export function unstable_defineRouter(fns: {
         renderer: (
           params?: Record<string, string | string[]>,
         ) => Promise<ReactNode>;
+        getEtagFromParams?: GetEtagFromParams;
+        params?: Record<string, string | string[]>;
       }
     >();
     slices.forEach((sliceId) => {
@@ -575,67 +637,83 @@ export function unstable_defineRouter(fns: {
               !!getPathMapping(item.pathSpec, '/' + sliceId))),
       );
       if (sliceConfig) {
-        sliceConfigMap.set(sliceId, sliceConfig);
+        const params = sliceConfig.pathSpec
+          ? getPathMapping(sliceConfig.pathSpec, '/' + sliceId)
+          : null;
+        sliceConfigMap.set(sliceId, {
+          ...sliceConfig,
+          ...(params ? { params } : {}),
+        });
       }
     });
     const entries: Record<SlotId, unknown> = {};
+    const addEntry = async (
+      slotId: SlotId,
+      isStatic: boolean,
+      cacheId: CacheId,
+      render: () => ReactNode | Promise<ReactNode>,
+      getEtag: () => Promise<string | undefined> | undefined,
+    ) => {
+      if (isStatic) {
+        if (clientEtags[slotId] === STATIC_ETAG) {
+          return;
+        }
+        if (!getCachedElement(cacheId)) {
+          await setCachedElement(cacheId, await render());
+        }
+        entries[slotId] = await getCachedElement(cacheId);
+        entries[ETAG_ID_PREFIX + slotId] = STATIC_ETAG;
+      } else {
+        const etag = await getEtag();
+        if (etag !== undefined && etag === clientEtags[slotId]) {
+          return;
+        }
+        entries[slotId] = await render();
+        if (etag !== undefined) {
+          entries[ETAG_ID_PREFIX + slotId] = etag;
+        } else if (clientEtags[slotId] !== undefined) {
+          // The slot no longer has a tag but the client still holds one; send
+          // an empty tag to clear it (the client drops empty tags).
+          entries[ETAG_ID_PREFIX + slotId] = '';
+        }
+      }
+    };
     await Promise.all([
-      (async () => {
-        const cacheId = getSlotCacheId(ROOT_SLOT_ID);
-        if (!pathConfigItem.rootElement.isStatic) {
-          entries[ROOT_SLOT_ID] = pathConfigItem.rootElement.renderer(option);
-        } else if (!skipIdSet.has(ROOT_SLOT_ID)) {
-          if (!getCachedElement(cacheId)) {
-            await setCachedElement(
-              cacheId,
-              pathConfigItem.rootElement.renderer(option),
-            );
-          }
-          entries[ROOT_SLOT_ID] = await getCachedElement(cacheId);
-        }
-      })(),
-      (async () => {
-        if (!pathConfigItem.routeElement.isStatic) {
-          entries[routeId] = pathConfigItem.routeElement.renderer(option);
-        } else if (!skipIdSet.has(routeId)) {
-          if (!getCachedElement(routeTemplateCacheId)) {
-            await setCachedElement(
-              routeTemplateCacheId,
-              pathConfigItem.routeElement.renderer(option),
-            );
-          }
-          entries[routeId] = await getCachedElement(routeTemplateCacheId);
-        }
-      })(),
-      ...Object.entries(pathConfigItem.elements).map(
-        async ([id, { isStatic }]) => {
-          const cacheId = getSlotCacheId(id);
-          const renderer = pathConfigItem.elements[id]?.renderer;
-          if (!isStatic) {
-            entries[id] = renderer?.(option);
-          } else if (!skipIdSet.has(id)) {
-            if (!getCachedElement(cacheId)) {
-              await setCachedElement(cacheId, renderer?.(option));
-            }
-            entries[id] = await getCachedElement(cacheId);
-          }
-        },
+      addEntry(
+        ROOT_SLOT_ID,
+        pathConfigItem.rootElement.isStatic,
+        getSlotCacheId(ROOT_SLOT_ID),
+        () => pathConfigItem.rootElement.renderer(option),
+        () => pathConfigItem.rootElement.getEtagFromOption?.(option),
       ),
-      ...slices.map(async (sliceId) => {
-        const id = SLICE_SLOT_ID_PREFIX + sliceId;
+      addEntry(
+        routeId,
+        pathConfigItem.routeElement.isStatic,
+        routeTemplateCacheId,
+        () => pathConfigItem.routeElement.renderer(option),
+        () => pathConfigItem.routeElement.getEtagFromOption?.(option),
+      ),
+      ...Object.entries(pathConfigItem.elements).map(([id, el]) =>
+        addEntry(
+          id,
+          el.isStatic,
+          getSlotCacheId(id),
+          () => el.renderer(option),
+          () => el.getEtagFromOption?.(option),
+        ),
+      ),
+      ...slices.map((sliceId) => {
         const sliceConfig = sliceConfigMap.get(sliceId);
         if (!sliceConfig) {
           throw new Error(`Slice not found: ${sliceId}`);
         }
-        if (sliceConfig.isStatic && skipIdSet.has(id)) {
-          return null;
-        }
-        const sliceElement = await getSliceElement(
-          sliceConfig,
-          getCachedElement,
-          setCachedElement,
+        return addEntry(
+          SLICE_SLOT_ID_PREFIX + sliceId,
+          sliceConfig.isStatic,
+          getSlotCacheId(SLICE_SLOT_ID_PREFIX + sliceConfig.id),
+          () => sliceConfig.renderer(sliceConfig.params),
+          () => sliceConfig.getEtagFromParams?.(sliceConfig.params),
         );
-        entries[id] = sliceElement;
       }),
     ]);
     entries[ROUTE_ID] = [routePath, query];
@@ -787,6 +865,9 @@ export function unstable_defineRouter(fns: {
             sliceId,
             sliceParams,
           );
+          const sliceEtag = sliceConfig.isStatic
+            ? STATIC_ETAG
+            : await sliceConfig.getEtagFromParams?.(sliceParams);
           return renderRsc({
             [SLICE_SLOT_ID_PREFIX + sliceId]: sliceElement,
             ...(sliceConfig.isStatic
@@ -794,6 +875,9 @@ export function unstable_defineRouter(fns: {
                   // FIXME: hard-coded for now
                   [IS_STATIC_ID + ':' + SLICE_SLOT_ID_PREFIX + sliceId]: true,
                 }
+              : {}),
+            ...(sliceEtag !== undefined
+              ? { [ETAG_ID_PREFIX + SLICE_SLOT_ID_PREFIX + sliceId]: sliceEtag }
               : {}),
           });
         }
@@ -1149,6 +1233,7 @@ export function unstable_defineRouter(fns: {
             [SLICE_SLOT_ID_PREFIX + item.id]: sliceElement,
             // FIXME: hard-coded for now
             [IS_STATIC_ID + ':' + SLICE_SLOT_ID_PREFIX + item.id]: true,
+            [ETAG_ID_PREFIX + SLICE_SLOT_ID_PREFIX + item.id]: STATIC_ETAG,
           });
           await generateFile(rscPath2pathname(rscPath), body);
         });

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -836,6 +836,9 @@ export function unstable_defineRouter(fns: {
         if (sliceId !== null) {
           // LIMITATION: This is a single slice request.
           // Ideally, we should be able to respond with multiple slices in one request.
+          // The skip header is not consulted here; the etag skip only covers
+          // route-bundled slices. The etag is still sent to keep the client's
+          // tag fresh.
           let sliceConfig: SliceConfig | undefined;
           let sliceParams: Record<string, string | string[]> | undefined;
           for (const item of getCachedConfigs()) {

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -710,7 +710,7 @@ export function unstable_defineRouter(fns: {
         return addEntry(
           SLICE_SLOT_ID_PREFIX + sliceId,
           sliceConfig.isStatic,
-          getSlotCacheId(SLICE_SLOT_ID_PREFIX + sliceConfig.id),
+          getSlotCacheId(SLICE_SLOT_ID_PREFIX + sliceId),
           () => sliceConfig.renderer(sliceConfig.params),
           () => sliceConfig.getEtagFromParams?.(sliceConfig.params),
         );
@@ -858,6 +858,9 @@ export function unstable_defineRouter(fns: {
           if (!sliceConfig) {
             return null;
           }
+          const sliceEtag = sliceConfig.isStatic
+            ? STATIC_ETAG
+            : await sliceConfig.getEtagFromParams?.(sliceParams);
           const sliceElement = await getSliceElement(
             sliceConfig,
             getCachedElement,
@@ -865,9 +868,6 @@ export function unstable_defineRouter(fns: {
             sliceId,
             sliceParams,
           );
-          const sliceEtag = sliceConfig.isStatic
-            ? STATIC_ETAG
-            : await sliceConfig.getEtagFromParams?.(sliceParams);
           return renderRsc({
             [SLICE_SLOT_ID_PREFIX + sliceId]: sliceElement,
             ...(sliceConfig.isStatic

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -89,6 +89,7 @@ export function fsRouter(
           default: FunctionComponent<{ children: ReactNode }>;
           getConfig?: () => Promise<{
             render?: 'static' | 'dynamic';
+            unstable_getEtag?: (props?: any) => Promise<string | undefined>;
           }>;
           GET?: (req: Request) => Promise<Response>;
         };

--- a/packages/waku/tests/define-router-etag.test.ts
+++ b/packages/waku/tests/define-router-etag.test.ts
@@ -1,0 +1,273 @@
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ETAG_ID_PREFIX,
+  SKIP_HEADER,
+  encodeRoutePath,
+} from '../src/router/common.js';
+import { unstable_defineRouter } from '../src/router/define-router.js';
+
+vi.mock('../src/server.js', () => ({
+  // Static slots round-trip through serialize/deserialize; for these tests the
+  // identity of the deserialized element does not matter, only its presence.
+  deserializeRsc: vi.fn().mockResolvedValue('static-element'),
+  serializeRsc: vi.fn().mockResolvedValue(new Uint8Array([1])),
+}));
+
+const makeStream = () =>
+  new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1]));
+      controller.close();
+    },
+  });
+
+type Option = { routePath: string; query: string | undefined };
+
+type ElementSpec = {
+  isStatic: boolean;
+  renderer: (option: Option) => ReactNode;
+  getEtagFromOption?: (option: Option) => Promise<string | undefined>;
+};
+
+const buildRouter = (elements: Record<string, ElementSpec>) =>
+  unstable_defineRouter({
+    getConfigs: async () => [
+      {
+        type: 'route' as const,
+        path: [{ type: 'literal' as const, name: 'foo' }],
+        isStatic: false,
+        rootElement: { isStatic: false, renderer: () => 'root' },
+        routeElement: { isStatic: false, renderer: () => 'route' },
+        elements,
+      },
+    ],
+  });
+
+// Drive a single RSC ("component") request and capture the entries record that
+// the router hands to renderRsc, so we can assert which slots were sent.
+const getEntries = async (
+  router: ReturnType<typeof unstable_defineRouter>,
+  clientEtags?: Record<string, string>,
+): Promise<Record<string, unknown>> => {
+  let captured: Record<string, unknown> = {};
+  await router.handleRequest(
+    {
+      type: 'component',
+      pathname: '/foo',
+      rscPath: encodeRoutePath('/foo'),
+      rscParams: undefined,
+      req: new Request('http://localhost/foo', {
+        headers: clientEtags
+          ? { [SKIP_HEADER]: JSON.stringify(clientEtags) }
+          : {},
+      }),
+    },
+    {
+      renderRsc: vi.fn(async (entries: unknown) => {
+        captured = entries as Record<string, unknown>;
+        return makeStream();
+      }),
+      parseRsc: vi.fn(),
+      renderHtml: vi.fn(),
+      loadBuildMetadata: vi.fn(),
+    },
+  );
+  return captured;
+};
+
+const etagKey = (slotId: string) => `${ETAG_ID_PREFIX}${slotId}`;
+
+describe('define-router etags (element tag skip)', () => {
+  it('sends a dynamic slot with its etag when the client has none', async () => {
+    const router = buildRouter({
+      page: {
+        isStatic: false,
+        renderer: () => createElement('div', null, 'page'),
+        getEtagFromOption: async () => 'v1',
+      },
+    });
+
+    const entries = await getEntries(router);
+    expect('page' in entries).toBe(true);
+    expect(entries[etagKey('page')]).toBe('v1');
+  });
+
+  it('omits a dynamic slot when the client etag still matches', async () => {
+    const router = buildRouter({
+      page: {
+        isStatic: false,
+        renderer: () => createElement('div', null, 'page'),
+        getEtagFromOption: async () => 'v1',
+      },
+    });
+
+    const entries = await getEntries(router, { page: 'v1' });
+    expect('page' in entries).toBe(false);
+    expect(etagKey('page') in entries).toBe(false);
+  });
+
+  it('re-sends a dynamic slot with the new etag when it changed', async () => {
+    let tag = 'v1';
+    const router = buildRouter({
+      page: {
+        isStatic: false,
+        renderer: () => createElement('div', null, 'page'),
+        getEtagFromOption: async () => tag,
+      },
+    });
+
+    // The tag changed (e.g. after an invalidation) -> getEtag returns it.
+    tag = 'v2';
+    const entries = await getEntries(router, { page: 'v1' });
+    expect('page' in entries).toBe(true);
+    expect(entries[etagKey('page')]).toBe('v2');
+  });
+
+  it('always sends a dynamic slot without a getEtag (no etag carried)', async () => {
+    const router = buildRouter({
+      page: {
+        isStatic: false,
+        renderer: () => createElement('div', null, 'page'),
+      },
+    });
+
+    const entries = await getEntries(router);
+    expect('page' in entries).toBe(true);
+    expect(etagKey('page') in entries).toBe(false);
+  });
+
+  it('clears a stale etag when a dynamic slot no longer provides one', async () => {
+    let tag: string | undefined = 'v1';
+    const router = buildRouter({
+      page: {
+        isStatic: false,
+        renderer: () => createElement('div', null, 'page'),
+        getEtagFromOption: async () => tag,
+      },
+    });
+
+    // The slot drops its tag; the client still holds 'v1', so the slot is sent
+    // with an empty tag to clear it.
+    tag = undefined;
+    const entries = await getEntries(router, { page: 'v1' });
+    expect('page' in entries).toBe(true);
+    expect(entries[etagKey('page')]).toBe('');
+  });
+
+  it('uses the constant "static" etag for static slots and omits on match', async () => {
+    const router = buildRouter({
+      page: { isStatic: true, renderer: () => createElement('div') },
+    });
+
+    const first = await getEntries(router);
+    expect('page' in first).toBe(true);
+    expect(first[etagKey('page')]).toBe('static');
+
+    const second = await getEntries(router, { page: 'static' });
+    expect('page' in second).toBe(false);
+    expect(etagKey('page') in second).toBe(false);
+  });
+
+  it('ignores a getEtag on a static slot (tag stays "static")', async () => {
+    const router = buildRouter({
+      page: {
+        isStatic: true,
+        renderer: () => createElement('div'),
+        getEtagFromOption: async () => 'should-be-ignored',
+      },
+    });
+
+    const entries = await getEntries(router);
+    expect(entries[etagKey('page')]).toBe('static');
+  });
+
+  it('passes the element option to getEtag', async () => {
+    const seen: unknown[] = [];
+    const router = buildRouter({
+      page: {
+        isStatic: false,
+        renderer: () => createElement('div'),
+        getEtagFromOption: async (option) => {
+          seen.push(option);
+          return 'v1';
+        },
+      },
+    });
+
+    await getEntries(router);
+    expect(seen).toContainEqual(expect.objectContaining({ routePath: '/foo' }));
+  });
+
+  it('applies the same etag skip to a dynamic slice', async () => {
+    let sliceTag = 'sv1';
+    const router = unstable_defineRouter({
+      getConfigs: async () => [
+        {
+          type: 'route' as const,
+          path: [{ type: 'literal' as const, name: 'foo' }],
+          isStatic: false,
+          rootElement: { isStatic: false, renderer: () => 'root' },
+          routeElement: { isStatic: false, renderer: () => 'route' },
+          elements: {},
+          slices: ['mySlice'],
+        },
+        {
+          type: 'slice' as const,
+          id: 'mySlice',
+          isStatic: false,
+          renderer: async () => createElement('div', null, 'slice'),
+          getEtagFromParams: async () => sliceTag,
+        },
+      ],
+    });
+    const slot = 'slice:mySlice';
+
+    const first = await getEntries(router);
+    expect(slot in first).toBe(true);
+    expect(first[etagKey(slot)]).toBe('sv1');
+
+    const omitted = await getEntries(router, { [slot]: 'sv1' });
+    expect(slot in omitted).toBe(false);
+
+    // Slice invalidated -> tag changed -> re-sent.
+    sliceTag = 'sv2';
+    const resent = await getEntries(router, { [slot]: 'sv1' });
+    expect(slot in resent).toBe(true);
+    expect(resent[etagKey(slot)]).toBe('sv2');
+  });
+
+  it('applies the etag skip to the root element', async () => {
+    let tag = 'r1';
+    const router = unstable_defineRouter({
+      getConfigs: async () => [
+        {
+          type: 'route' as const,
+          path: [{ type: 'literal' as const, name: 'foo' }],
+          isStatic: false,
+          rootElement: {
+            isStatic: false,
+            renderer: () => 'root',
+            getEtagFromOption: async () => tag,
+          },
+          routeElement: { isStatic: false, renderer: () => 'route' },
+          elements: {},
+        },
+      ],
+    });
+
+    const first = await getEntries(router);
+    expect('root' in first).toBe(true);
+    expect(first[etagKey('root')]).toBe('r1');
+
+    const omitted = await getEntries(router, { root: 'r1' });
+    expect('root' in omitted).toBe(false);
+
+    // Root invalidated -> tag changed -> re-sent.
+    tag = 'r2';
+    const resent = await getEntries(router, { root: 'r1' });
+    expect('root' in resent).toBe(true);
+    expect(resent[etagKey('root')]).toBe('r2');
+  });
+});

--- a/packages/waku/tests/define-router-etag.test.ts
+++ b/packages/waku/tests/define-router-etag.test.ts
@@ -47,9 +47,9 @@ const buildRouter = (elements: Record<string, ElementSpec>) =>
 
 // Drive a single RSC ("component") request and capture the entries record that
 // the router hands to renderRsc, so we can assert which slots were sent.
-const getEntries = async (
+const drive = async (
   router: ReturnType<typeof unstable_defineRouter>,
-  clientEtags?: Record<string, string>,
+  headers: Record<string, string>,
 ): Promise<Record<string, unknown>> => {
   let captured: Record<string, unknown> = {};
   await router.handleRequest(
@@ -58,11 +58,7 @@ const getEntries = async (
       pathname: '/foo',
       rscPath: encodeRoutePath('/foo'),
       rscParams: undefined,
-      req: new Request('http://localhost/foo', {
-        headers: clientEtags
-          ? { [SKIP_HEADER]: JSON.stringify(clientEtags) }
-          : {},
-      }),
+      req: new Request('http://localhost/foo', { headers }),
     },
     {
       renderRsc: vi.fn(async (entries: unknown) => {
@@ -76,6 +72,22 @@ const getEntries = async (
   );
   return captured;
 };
+
+const getEntries = (
+  router: ReturnType<typeof unstable_defineRouter>,
+  clientEtags?: Record<string, string>,
+): Promise<Record<string, unknown>> =>
+  drive(
+    router,
+    clientEtags ? { [SKIP_HEADER]: JSON.stringify(clientEtags) } : {},
+  );
+
+// Drive with a raw, un-serialized skip header (for legacy/malformed inputs).
+const getEntriesWithSkipHeader = (
+  router: ReturnType<typeof unstable_defineRouter>,
+  skipHeader: string,
+): Promise<Record<string, unknown>> =>
+  drive(router, { [SKIP_HEADER]: skipHeader });
 
 const etagKey = (slotId: string) => `${ETAG_ID_PREFIX}${slotId}`;
 
@@ -269,5 +281,73 @@ describe('define-router etags (element tag skip)', () => {
     const resent = await getEntries(router, { root: 'r1' });
     expect('root' in resent).toBe(true);
     expect(resent[etagKey('root')]).toBe('r2');
+  });
+
+  it('resolves each slot independently in one response', async () => {
+    let pageTag: string | undefined = 'p1';
+    let sliceTag: string | undefined = 's1';
+    const router = unstable_defineRouter({
+      getConfigs: async () => [
+        {
+          type: 'route' as const,
+          path: [{ type: 'literal' as const, name: 'foo' }],
+          isStatic: false,
+          rootElement: {
+            isStatic: false,
+            renderer: () => 'root',
+            getEtagFromOption: async () => 'r1',
+          },
+          routeElement: { isStatic: false, renderer: () => 'route' },
+          elements: {
+            page: {
+              isStatic: false,
+              renderer: () => createElement('div', null, 'page'),
+              getEtagFromOption: async () => pageTag,
+            },
+          },
+          slices: ['mySlice'],
+        },
+        {
+          type: 'slice' as const,
+          id: 'mySlice',
+          isStatic: false,
+          renderer: async () => createElement('div', null, 'slice'),
+          getEtagFromParams: async () => sliceTag,
+        },
+      ],
+    });
+
+    // root unchanged, page changed, slice loses its tag.
+    pageTag = 'p2';
+    sliceTag = undefined;
+    const entries = await getEntries(router, {
+      root: 'r1',
+      page: 'p1',
+      'slice:mySlice': 's1',
+    });
+
+    expect('root' in entries).toBe(false); // unchanged -> omitted
+    expect(entries.page).toBeDefined(); // changed -> re-sent
+    expect(entries[etagKey('page')]).toBe('p2');
+    expect(entries['slice:mySlice']).toBeDefined(); // lost tag -> re-sent
+    expect(entries[etagKey('slice:mySlice')]).toBe(''); // cleared
+  });
+
+  it('ignores a legacy, malformed, or non-string skip header', async () => {
+    const build = () =>
+      buildRouter({
+        page: { isStatic: true, renderer: () => createElement('div') },
+      });
+
+    // A valid map would skip the static slot; these never do.
+    for (const header of [
+      JSON.stringify(['page']), // legacy array of ids
+      'not json',
+      JSON.stringify({ page: 123 }), // non-string value
+    ]) {
+      const entries = await getEntriesWithSkipHeader(build(), header);
+      expect('page' in entries).toBe(true);
+      expect(entries[etagKey('page')]).toBe('static');
+    }
   });
 });

--- a/packages/waku/tests/define-router-etag.test.ts
+++ b/packages/waku/tests/define-router-etag.test.ts
@@ -5,6 +5,7 @@ import {
   ETAG_ID_PREFIX,
   SKIP_HEADER,
   encodeRoutePath,
+  encodeSliceId,
 } from '../src/router/common.js';
 import { unstable_defineRouter } from '../src/router/define-router.js';
 
@@ -50,13 +51,14 @@ const buildRouter = (elements: Record<string, ElementSpec>) =>
 const drive = async (
   router: ReturnType<typeof unstable_defineRouter>,
   headers: Record<string, string>,
+  rscPath = encodeRoutePath('/foo'),
 ): Promise<Record<string, unknown>> => {
   let captured: Record<string, unknown> = {};
   await router.handleRequest(
     {
       type: 'component',
       pathname: '/foo',
-      rscPath: encodeRoutePath('/foo'),
+      rscPath,
       rscParams: undefined,
       req: new Request('http://localhost/foo', { headers }),
     },
@@ -248,6 +250,30 @@ describe('define-router etags (element tag skip)', () => {
     const resent = await getEntries(router, { [slot]: 'sv1' });
     expect(slot in resent).toBe(true);
     expect(resent[etagKey(slot)]).toBe('sv2');
+  });
+
+  it('resolves the etag before rendering on a slice request, so a concurrent invalidation cannot tag stale content', async () => {
+    const calls: string[] = [];
+    const router = unstable_defineRouter({
+      getConfigs: async () => [
+        {
+          type: 'slice' as const,
+          id: 'mySlice',
+          isStatic: false,
+          renderer: async () => {
+            calls.push('render');
+            return createElement('div', null, 'slice');
+          },
+          getEtagFromParams: async () => {
+            calls.push('etag');
+            return 'sv1';
+          },
+        },
+      ],
+    });
+
+    await drive(router, {}, encodeSliceId('mySlice'));
+    expect(calls).toEqual(['etag', 'render']);
   });
 
   it('applies the etag skip to the root element', async () => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -38,6 +38,7 @@ import {
   useRouter,
 } from '../src/router/client.js';
 import {
+  ETAG_ID_PREFIX,
   HAS404_ID,
   IS_STATIC_ID,
   ROUTE_ID,
@@ -1841,8 +1842,10 @@ describe('Router integration', () => {
       [unstable_getRouteSlotId('/next')]: <Probe />,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
-      foo: true,
-      bar: true,
+      [`${ETAG_ID_PREFIX}foo`]: 'etag-foo',
+      [`${ETAG_ID_PREFIX}bar`]: 'etag-bar',
+      // An empty tag is the server's clear signal; it must not be sent back.
+      [`${ETAG_ID_PREFIX}cleared`]: '',
     };
 
     const view = await renderRouter(
@@ -1864,9 +1867,13 @@ describe('Router integration', () => {
       const headers = (requestInit?.headers ?? {}) as Record<string, string>;
       expect(headers).toBeDefined();
       expect(headers[SKIP_HEADER]).toBeTypeOf('string');
-      const skipped = JSON.parse(headers[SKIP_HEADER]! as string) as string[];
-      expect(skipped).toContain('foo');
-      expect(skipped).toContain('bar');
+      const skipped = JSON.parse(headers[SKIP_HEADER]! as string) as Record<
+        string,
+        string
+      >;
+      expect(skipped.foo).toBe('etag-foo');
+      expect(skipped.bar).toBe('etag-bar');
+      expect('cleared' in skipped).toBe(false);
       expect(capture.router.path).toBe('/next');
       expect(capture.router.query).toBe('');
     } finally {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1846,6 +1846,8 @@ describe('Router integration', () => {
       [`${ETAG_ID_PREFIX}bar`]: 'etag-bar',
       // An empty tag is the server's clear signal; it must not be sent back.
       [`${ETAG_ID_PREFIX}cleared`]: '',
+      // A non-Latin1 tag would make fetch reject the header; it must be dropped.
+      [`${ETAG_ID_PREFIX}nonLatin1`]: 'tag-☃',
     };
 
     const view = await renderRouter(
@@ -1874,6 +1876,7 @@ describe('Router integration', () => {
       expect(skipped.foo).toBe('etag-foo');
       expect(skipped.bar).toBe('etag-bar');
       expect('cleared' in skipped).toBe(false);
+      expect('nonLatin1' in skipped).toBe(false);
       expect(capture.router.path).toBe('/next');
       expect(capture.router.query).toBe('');
     } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,31 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  e2e/fixtures/cache-tag:
+    dependencies:
+      react:
+        specifier: ~19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ~19.2.6
+        version: 19.2.6(react@19.2.6)
+      react-server-dom-webpack:
+        specifier: ~19.2.6
+        version: 19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.99.9)
+      waku:
+        specifier: latest
+        version: link:../../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.16
+        version: 19.2.16
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.16)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   e2e/fixtures/cloudflare-adapter:
     dependencies:
       hono:


### PR DESCRIPTION
Generalize the navigation skip protocol from binary static/dynamic to an opaque per-slot element tag (etag), letting a server cache reuse unchanged dynamic elements. Opt in via `unstable_getEtag` in `getConfig`; without it, behavior is unchanged.
