### PR TITLE
Add npm bugs metadata for waku package

### DIFF
--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/wakujs/waku.git",
     "directory": "packages/waku"
   },
+  "bugs": {
+    "url": "https://github.com/wakujs/waku/issues"
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
Adds the standard npm `bugs.url` metadata to the published `waku` package, pointing to the Waku GitHub issue tracker.

Microbounty reference: https://github.com/charles-openclaw/charles-microbounties/issues/704

Validation:
- node -e "const p=require('./packages/waku/package.json'); if (p.bugs?.url !== 'https://github.com/wakujs/waku/issues') process.exit(1)"
- npm pack --dry-run --ignore-scripts ./packages/waku
- git diff --check