### PR TITLE
fix(website): sticky sidebar navigation on xl screens

### DIFF
--- a/docs/create-pages.mdx
+++ b/docs/create-pages.mdx
@@ -336,7 +336,7 @@ export const AboutPage = ({ foo }: PageProps<'/about/[foo]'>) => {
 
 ### Layouts
 
-Layouts wrap an entire route and its descendents. They must accept a `children` prop of type `ReactNode`. While not required, you will typically want at least a root layout.
+Layouts wrap an entire route and its descendants. They must accept a `children` prop of type `ReactNode`. While not required, you will typically want at least a root layout.
 
 #### Root layout
 

--- a/packages/website/src/components/navigation.tsx
+++ b/packages/website/src/components/navigation.tsx
@@ -23,7 +23,7 @@ export const Navigation = ({ isHome }: NavigationProps) => {
         isMenuOpen
           ? 'pointer-events-auto opacity-100'
           : 'pointer-events-none opacity-0',
-        'xl:pointer-events-auto! xl:z-9999 fixed inset-0 z-90 flex shrink-0 flex-col overflow-clip border-gray-800 bg-gray-950 transition-opacity duration-300 ease-in-out xl:bottom-auto xl:left-0 xl:right-auto xl:top-0 xl:h-screen xl:border-r xl:opacity-100',
+        'xl:pointer-events-auto! xl:z-9999 fixed inset-0 z-90 flex shrink-0 flex-col overflow-clip border-gray-800 bg-gray-950 transition-opacity duration-300 ease-in-out xl:sticky xl:bottom-auto xl:left-0 xl:right-auto xl:top-0 xl:h-screen xl:self-start xl:border-r xl:opacity-100',
       )}
     >
       <div className="2xl:px-18 relative z-10 flex min-h-0 w-full flex-1 flex-col items-center justify-start gap-8 overflow-y-auto p-8 pb-16 text-white xl:gap-12 xl:p-12">

--- a/packages/website/src/components/page.tsx
+++ b/packages/website/src/components/page.tsx
@@ -16,8 +16,10 @@ export const Page = async ({ isHome = false, children }: PageProps) => {
       <Menu />
       <Background />
       <Fade always={true} />
-      <Navigation isHome={isHome} />
-      <Main>{children}</Main>
+      <div className="xl:flex xl:items-start">
+        <Navigation isHome={isHome} />
+        <Main>{children}</Main>
+      </div>
       <Credits />
       <Scroll />
     </>


### PR DESCRIPTION
Fixes #2131

The sidebar nav scrolls with the page on xl screens instead of staying fixed.

**Root cause:** `position: fixed` is broken when a parent has an active CSS animation (the `#__waku` fade-in). Browsers can create a new compositing layer for animated elements, which becomes the containing block for fixed descendants.

**Changes:**
- Wrap `Navigation` and `Main` in `xl:flex xl:items-start` in `page.tsx`
- Add `xl:sticky xl:self-start` to the nav in `navigation.tsx`

The nav now uses `position: sticky; top: 0; height: 100vh` at xl, which is unaffected by parent compositing.