### PR TITLE
fix(router): prioritize api wildcard routes over catch-all pages

### DIFF
--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -446,6 +446,21 @@ const routePriorityComparator = (
     return aHasWildcard ? 1 : -1;
   }
 
+  // If the routes are otherwise indistinguishable, fall back to the route
+  // type so the overall order is:
+  //   "standard routes" -> api routes -> api wildcard routes -> standard wildcard routes
+  // For non-wildcard routes, standard routes win over api routes; for wildcard
+  // routes, api routes win over standard routes. This prevents a catch-all page
+  // (e.g. `/[...notFound]`) from shadowing an api wildcard route since the first
+  // match is used. See https://github.com/wakujs/waku/issues/1448
+  if (a.type !== b.type) {
+    const aIsApi = a.type === 'api';
+    if (aHasWildcard) {
+      return aIsApi ? -1 : 1;
+    }
+    return aIsApi ? 1 : -1;
+  }
+
   // If all else is equal, routes have the same priority
   return 0;
 };

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -1614,6 +1614,47 @@ describe('createPages pages and layouts', () => {
     );
   });
 
+  it('api wildcard route takes priority over standard wildcard page route', async () => {
+    const NotFoundPage = vi.fn();
+    const ApiHandler = vi.fn(async () => new Response('api'));
+    createPages(async ({ createPage, createApi }) => [
+      // Registered first so insertion order alone would put it ahead.
+      createPage({
+        render: 'dynamic',
+        path: '/[...notFound]',
+        component: NotFoundPage,
+      }),
+      createApi({
+        path: '/[...apiPath]',
+        render: 'dynamic',
+        handlers: {
+          GET: ApiHandler,
+        },
+      }),
+    ]);
+    const { getConfigs } = injectedFunctions();
+    const configs = Array.from(await getConfigs());
+    const apiRoute = configs.find(
+      (config) =>
+        config.type === 'api' &&
+        config.path.length === 1 &&
+        config.path[0]?.type === 'wildcard',
+    );
+    const wildcardPage = configs.find(
+      (config) =>
+        config.type === 'route' &&
+        config.path.length === 1 &&
+        config.path[0]?.type === 'wildcard',
+    );
+    expect(apiRoute).toBeDefined();
+    expect(wildcardPage).toBeDefined();
+    // The api wildcard must be checked before the catch-all page so the page
+    // does not shadow it (the router uses the first matching config).
+    expect(configs.indexOf(apiRoute!)).toBeLessThan(
+      configs.indexOf(wildcardPage!),
+    );
+  });
+
   it('fails if static paths do not match the slug pattern', async () => {
     createPages(async ({ createPage }) => [
       createPage({


### PR DESCRIPTION
## Problem

A standard catch-all page route (e.g. `/[...notFound]`) shadows an API wildcard route (e.g. `_api/[...path]`) of the same depth. A request to the API route is incorrectly handled by the catch-all page instead.

This is a regression of the bug originally fixed in #1451 / #1508 (issue #1448).

## Root cause

`createPages` sorts the route configs with `routePriorityComparator` and `define-router` then picks the **first** matching config (`getPathConfigItem` uses `Array.prototype.find`), so ordering determines precedence.

The original fix used a `getRoutePriority` helper that ranked routes by **both** wildcard presence **and** route type:

```
standard route (0) -> api route (1) -> api wildcard (2) -> standard wildcard (3)
```

A later refactor replaced that call with `routePriorityComparator`, which only compares path length, literal-vs-dynamic segments, and wildcard presence — it ignores the `type` field entirely (even though the field is part of its parameter type and the adjacent comment still documents the type-aware ordering). For two equal-length wildcard routes the comparator returns `0`, so insertion order wins and the catch-all page (spread before the api configs) ends up first.

## Fix

Restore the type tiebreaker in `routePriorityComparator` for the case where the routes are otherwise indistinguishable:

- non-wildcard routes: standard routes win over api routes
- wildcard routes: api routes win over standard routes

This matches the documented ordering and the original `getRoutePriority` semantics, while preserving the comparator's existing length / literal-priority behavior. The comparator is also used for API-vs-API ordering, where `type` is always `'api'`, so that path is unaffected.

## Test

Added a regression test in `create-pages.test.ts` that registers a catch-all page **before** an api wildcard route and asserts the api route is ordered first. It fails without the fix and passes with it.

```
order without fix: ['route:wildcard', 'api:wildcard']  // api shadowed
order with fix:    ['api:wildcard', 'route:wildcard']
```

All 354 unit tests pass (`pnpm -F waku test`); prettier, eslint, and `tsc -b` are clean.

Closes #1448