### PR TITLE
refactor(router): startTransition internal option

### DIFF
--- a/e2e/router-client.spec.ts
+++ b/e2e/router-client.spec.ts
@@ -627,10 +627,23 @@ test.describe('router-client', () => {
     await expect(page.getByTestId('pending-client-indicator')).toBeVisible();
     await expect(page.getByTestId('client-suspense-content')).toHaveCount(0);
 
+    // The destination is held by the transition: the previous page stays
+    // mounted and visible while the suspending route does not commit (no
+    // Suspense fallback flash). This only holds because changeRoute re-wraps the
+    // post-fetch commit in startTransition (React does not treat state updates
+    // after an `await` inside startTransition as part of the transition).
+    await expect(page.getByRole('heading', { name: 'Start' })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Pending Client' }),
+    ).toHaveCount(0);
+
     // Release the client-only async from the still-mounted start page; the
-    // transition settles and pending clears.
+    // transition settles, the destination commits, and pending clears.
     await page.getByTestId('resolve-client-suspense').click();
     await expect(page.getByTestId('client-suspense-content')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Pending Client' }),
+    ).toBeVisible();
     await expect(page.getByTestId('pending-client-indicator')).toHaveCount(0);
   });
 

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -163,7 +163,7 @@ type ChangeRouteOptions = {
   refetch?: boolean; // true: force refetch, false: don't refetch, undefined: auto-decide based on route change
   mode?: undefined | 'push' | 'replace';
   url?: URL | undefined;
-  unstable_startTransition?: ((fn: TransitionFunction) => void) | undefined;
+  startTransition?: ((fn: TransitionFunction) => void) | undefined;
 };
 
 type ChangeRoute = (
@@ -440,7 +440,7 @@ export function Link({
           shouldScroll: scroll ?? shouldScrollByDefault(url),
           mode: 'push',
           url,
-          unstable_startTransition: startTransitionFn,
+          startTransition: startTransitionFn,
         });
       });
     } else if (url.hash && scroll !== false) {
@@ -937,7 +937,7 @@ const InnerRouter = ({
       const isAborted = () => abortController.signal.aborted;
       emitRouteChangeEvent('start', nextRoute);
       const startTransitionFn =
-        options.unstable_startTransition || ((fn: TransitionFunction) => fn());
+        options.startTransition || ((fn: TransitionFunction) => fn());
       const prevPathname = window.location.pathname;
       let { mode, url } = options;
       const routeBeforeChange = routeRef.current;

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -812,7 +812,7 @@ describe('useRouter + Link with context', () => {
     expect(changeRoute).toHaveBeenCalledWith(
       { path: '/next', query: '', hash: '' },
       expect.objectContaining({
-        unstable_startTransition: unstableStartTransition,
+        startTransition: unstableStartTransition,
       }),
     );
 


### PR DESCRIPTION
public api is still `unstable_startTransition` which will be removed when React ships `<ViewTransition>`.