### PR TITLE
fix(router): prefetch typing

### DIFF
--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -285,7 +285,7 @@ export function useRouter() {
     window.history.forward();
   }, []);
   const prefetch = useCallback(
-    (to: string) => {
+    (to: InferredPaths) => {
       const url = new URL(to, window.location.href);
       prefetchRoute(parseRoute(url));
     },

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4,6 +4,8 @@ import { StrictMode, act, use } from 'react';
 import type { ReactElement } from 'react';
 import { preloadModule } from 'react-dom';
 import { createRoot } from 'react-dom/client';
+import { expectType } from 'ts-expect';
+import type { TypeEqual } from 'ts-expect';
 import {
   afterAll,
   afterEach,
@@ -38,6 +40,7 @@ import {
   useNavigationStatus_UNSTABLE as useNavigationStatus,
   useRouter,
 } from '../src/router/client.js';
+import type { Unstable_InferredPaths } from '../src/router/client.js';
 import {
   ETAG_ID_PREFIX,
   HAS404_ID,
@@ -255,6 +258,17 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+describe('router navigation method path typing', () => {
+  test('prefetch accepts the same path type as push and replace', () => {
+    type PrefetchArg = Parameters<RouterApi['prefetch']>[0];
+    type PushArg = Parameters<RouterApi['push']>[0];
+    type ReplaceArg = Parameters<RouterApi['replace']>[0];
+    expectType<TypeEqual<PrefetchArg, Unstable_InferredPaths>>(true);
+    expectType<TypeEqual<PrefetchArg, PushArg>>(true);
+    expectType<TypeEqual<PrefetchArg, ReplaceArg>>(true);
+  });
 });
 
 describe('router/client utilities', () => {


### PR DESCRIPTION
`router.prefetch()` accepted plain `string`, while `push`/`replace` already use the typed `InferredPaths` union. This tightens `prefetch` to match, so all three navigation methods share one path type and get route autocomplete. Type-level only; with no route typegen `InferredPaths` is `string`, so nothing changes.
