### PR TITLE
feat(router): typed .push() and .replace()

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,11 +804,11 @@ export const Component = () => {
 
 The `router` object also contains several methods for programmatic navigation:
 
-- `router.push(to: string)` - navigate to the provided route
+- `router.push(to)` - navigate to the provided route. `to` is a route string, or a structured `{ to, params, search, hash }` target for typed navigation to dynamic routes (see [Typed Routes](https://github.com/wakujs/waku/blob/main/docs/guides/typed-routes.mdx))
 
 - `router.prefetch(to: string)` - prefetch the provided route
 
-- `router.replace(to: string)` - replace the current history entry
+- `router.replace(to)` - replace the current history entry (same argument as `push`)
 
 - `router.reload()` - reload the current route
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -56,6 +56,8 @@ export const DashboardButton = () => {
 };
 ```
 
+For navigating to dynamic routes with typed params, see [Typed Routes](/guides/typed-routes).
+
 ## Link Prefetching
 
 `<Link>` also has experimental prefetch helpers for common interaction patterns:

--- a/docs/guides/typed-routes.mdx
+++ b/docs/guides/typed-routes.mdx
@@ -41,5 +41,5 @@ export const PostButton = ({ slug }: { slug: string }) => {
 ```
 
 - `to` is a route pattern (e.g. `/posts/[slug]`, `/docs/[...path]`). `params` is required when the pattern has slugs and is typed from it; a catch-all takes a `string[]`.
-- `search` accepts an object, a query string, or `URLSearchParams`. `hash` is optional.
+- `search` is an object of string query values (use an array for repeated keys); `undefined` values are omitted. `hash` is optional.
 - The plain string form (`router.push('/posts/hello')`) keeps working.

--- a/docs/guides/typed-routes.mdx
+++ b/docs/guides/typed-routes.mdx
@@ -1,0 +1,45 @@
+---
+slug: typed-routes
+title: Typed Routes
+description: Type-safe navigation to dynamic routes with router.push and router.replace.
+category: Routing and Navigation
+order: 11
+tags: [Experimental]
+---
+
+## Overview
+
+Waku's router provides type-safe routing helpers layered on top of the string-based APIs. The string APIs keep working; the typed helpers are additive.
+
+## Typed Navigation
+
+`router.push()` and `router.replace()` accept a structured target, so you can navigate to a dynamic route without interpolating slugs by hand. The `params` are type-checked against the route pattern:
+
+```tsx
+'use client';
+
+import { useRouter } from 'waku';
+
+export const PostButton = ({ slug }: { slug: string }) => {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() =>
+        router.push({
+          to: '/posts/[slug]',
+          params: { slug },
+          search: { tab: 'comments' },
+          hash: 'top',
+        })
+      }
+    >
+      Open post
+    </button>
+  );
+};
+```
+
+- `to` is a route pattern (e.g. `/posts/[slug]`, `/docs/[...path]`). `params` is required when the pattern has slugs and is typed from it; a catch-all takes a `string[]`.
+- `search` accepts an object, a query string, or `URLSearchParams`. `hash` is optional.
+- The plain string form (`router.push('/posts/hello')`) keeps working.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -57,6 +57,7 @@ export default defineConfig(
       ],
       'react/prop-types': 'off',
       curly: ['error', 'all'],
+      eqeqeq: ['error', 'always'],
       'sort-imports': [
         'error',
         {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -463,7 +463,11 @@ export function Link({
     if (props.target && props.target.toLowerCase() !== '_self') {
       console.warn('[Link] `target` is discouraged. Use `<a>` for this case.');
     }
-    if (props.download != null && props.download !== false) {
+    if (
+      props.download !== undefined &&
+      props.download !== null &&
+      props.download !== false
+    ) {
       console.warn(
         '[Link] `download` is discouraged. Use `<a>` for this case.',
       );

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -35,6 +35,11 @@ import {
   useRefetch,
 } from '../minimal/client.js';
 import type { RouteConfig } from './base-types.js';
+import { buildRouteHref } from './common-utils/build-route-href.js';
+import type {
+  BuildRouteHrefTarget,
+  RoutePattern,
+} from './common-utils/build-route-href.js';
 import {
   ETAG_ID_PREFIX,
   HAS404_ID,
@@ -65,6 +70,24 @@ type InferredPaths = RouteConfig extends {
 }
   ? AllowPathDecorators<UserPaths>
   : string;
+
+type NavigateOptions = {
+  /**
+   * indicates if the link should scroll or not on navigation
+   * - `true`: always scroll
+   * - `false`: never scroll
+   * - `undefined`: scroll on path/hash change (not on query-only change)
+   */
+  scroll?: boolean;
+};
+
+type Navigate = {
+  (to: InferredPaths, options?: NavigateOptions): Promise<void>;
+  <Pattern extends RoutePattern>(
+    target: BuildRouteHrefTarget<Pattern>,
+    options?: NavigateOptions,
+  ): Promise<void>;
+};
 
 const pathnameToCurrentRoutePath = (pathname: string) =>
   pathnameToRoutePath(
@@ -228,19 +251,14 @@ export function useRouter() {
   const { route, changeRoute, prefetchRoute } = router;
   const push = useCallback(
     async (
-      to: InferredPaths,
-      options?: {
-        /**
-         * indicates if the link should scroll or not on navigation
-         * - `true`: always scroll
-         * - `false`: never scroll
-         * - `undefined`: scroll on path/hash change (not on query-only change)
-         */
-        scroll?: boolean;
-      },
+      to: InferredPaths | BuildRouteHrefTarget<RoutePattern>,
+      options?: NavigateOptions,
     ) => {
-      to = addBase(to, import.meta.env.WAKU_CONFIG_BASE_PATH);
-      const url = new URL(to, window.location.href);
+      const href = typeof to === 'string' ? to : buildRouteHref(to);
+      const url = new URL(
+        addBase(href, import.meta.env.WAKU_CONFIG_BASE_PATH),
+        window.location.href,
+      );
       await changeRoute(parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
         mode: 'push',
@@ -248,22 +266,17 @@ export function useRouter() {
       });
     },
     [changeRoute],
-  );
+  ) as Navigate;
   const replace = useCallback(
     async (
-      to: InferredPaths,
-      options?: {
-        /**
-         * indicates if the link should scroll or not on navigation
-         * - `true`: always scroll
-         * - `false`: never scroll
-         * - `undefined`: scroll on path/hash change (not on query-only change)
-         */
-        scroll?: boolean;
-      },
+      to: InferredPaths | BuildRouteHrefTarget<RoutePattern>,
+      options?: NavigateOptions,
     ) => {
-      to = addBase(to, import.meta.env.WAKU_CONFIG_BASE_PATH);
-      const url = new URL(to, window.location.href);
+      const href = typeof to === 'string' ? to : buildRouteHref(to);
+      const url = new URL(
+        addBase(href, import.meta.env.WAKU_CONFIG_BASE_PATH),
+        window.location.href,
+      );
       await changeRoute(parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
         mode: 'replace',
@@ -271,7 +284,7 @@ export function useRouter() {
       });
     },
     [changeRoute],
-  );
+  ) as Navigate;
   const reload = useCallback(async () => {
     const url = new URL(window.location.href);
     await changeRoute(parseRoute(url), { shouldScroll: true, refetch: true });

--- a/packages/waku/src/router/common-utils/build-route-href.ts
+++ b/packages/waku/src/router/common-utils/build-route-href.ts
@@ -16,18 +16,9 @@ type RouteParams<Pattern extends RoutePattern> = {
     : ApiParams<Pattern>[Key];
 };
 
-type SearchValue =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | readonly (string | number | boolean)[];
+type SearchValue = string | readonly string[] | undefined;
 
-type BuildRouteHrefSearch =
-  | string
-  | URLSearchParams
-  | Record<string, SearchValue>;
+type BuildRouteHrefSearch = Record<string, SearchValue>;
 
 export type BuildRouteHrefTarget<Pattern extends RoutePattern> = {
   to: Pattern;
@@ -38,26 +29,20 @@ export type BuildRouteHrefTarget<Pattern extends RoutePattern> = {
   : { params: RouteParams<Pattern> });
 
 const serializeSearch = (search: BuildRouteHrefSearch | undefined): string => {
-  if (search == null) {
+  if (search === undefined) {
     return '';
-  }
-  if (typeof search === 'string') {
-    return search.startsWith('?') ? search.slice(1) : search;
-  }
-  if (search instanceof URLSearchParams) {
-    return search.toString();
   }
   const searchParams = new URLSearchParams();
   for (const [key, value] of Object.entries(search)) {
-    if (value == null) {
+    if (value === undefined) {
       continue;
     }
     if (Array.isArray(value)) {
       for (const item of value) {
-        searchParams.append(key, String(item));
+        searchParams.append(key, item);
       }
     } else {
-      searchParams.append(key, String(value));
+      searchParams.append(key, value as string);
     }
   }
   return searchParams.toString();

--- a/packages/waku/src/router/common-utils/build-route-href.ts
+++ b/packages/waku/src/router/common-utils/build-route-href.ts
@@ -1,0 +1,115 @@
+import { getGrouplessPath } from '../../lib/utils/create-pages.js';
+import { getPathMapping, parsePathWithSlug } from '../../lib/utils/path.js';
+import type { CreatePagesConfig } from '../base-types.js';
+import type {
+  ApiParams,
+  PagePath,
+} from '../create-pages-utils/inferred-path-types.js';
+
+export type RoutePattern = [PagePath<CreatePagesConfig>] extends [never]
+  ? string
+  : PagePath<CreatePagesConfig>;
+
+type RouteParams<Pattern extends RoutePattern> = {
+  [Key in keyof ApiParams<Pattern>]: ApiParams<Pattern>[Key] extends string[]
+    ? readonly string[]
+    : ApiParams<Pattern>[Key];
+};
+
+type SearchValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | readonly (string | number | boolean)[];
+
+type BuildRouteHrefSearch =
+  | string
+  | URLSearchParams
+  | Record<string, SearchValue>;
+
+export type BuildRouteHrefTarget<Pattern extends RoutePattern> = {
+  to: Pattern;
+  search?: BuildRouteHrefSearch;
+  hash?: string;
+} & (keyof RouteParams<Pattern> extends never
+  ? { params?: never }
+  : { params: RouteParams<Pattern> });
+
+const serializeSearch = (search: BuildRouteHrefSearch | undefined): string => {
+  if (search == null) {
+    return '';
+  }
+  if (typeof search === 'string') {
+    return search.startsWith('?') ? search.slice(1) : search;
+  }
+  if (search instanceof URLSearchParams) {
+    return search.toString();
+  }
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(search)) {
+    if (value == null) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, String(item));
+      }
+    } else {
+      searchParams.append(key, String(value));
+    }
+  }
+  return searchParams.toString();
+};
+
+/**
+ * Build an href string from a route pattern, params, search, and hash.
+ *
+ * Route groups in the pattern are removed, path params are URL-encoded, and the
+ * result is validated against the route matcher; building a pathname that the
+ * pattern would not match (e.g. an empty array for a prefixed catch-all) throws.
+ */
+export const buildRouteHref = <Pattern extends RoutePattern>(
+  target: BuildRouteHrefTarget<Pattern>,
+): string => {
+  const { to, search, hash, params } = target as {
+    to: string;
+    search?: BuildRouteHrefSearch;
+    hash?: string;
+    params?: Record<string, string | readonly string[]>;
+  };
+  const pathSpec = parsePathWithSlug(getGrouplessPath(to));
+  const segments: string[] = [];
+  for (const item of pathSpec) {
+    if (item.type === 'literal') {
+      segments.push(item.name);
+    } else if (item.type === 'wildcard') {
+      const value = item.name ? params?.[item.name] : undefined;
+      if (!Array.isArray(value)) {
+        throw new Error(`Missing catch-all param "${item.name}" for "${to}"`);
+      }
+      for (const part of value) {
+        segments.push(encodeURIComponent(part));
+      }
+    } else {
+      const value = item.name ? params?.[item.name] : undefined;
+      if (typeof value !== 'string') {
+        throw new Error(`Missing param "${item.name}" for "${to}"`);
+      }
+      const prefix = item.prefix ?? '';
+      const suffix = item.suffix ?? '';
+      segments.push(prefix + encodeURIComponent(value) + suffix);
+    }
+  }
+  const pathname = '/' + segments.join('/');
+  if (!getPathMapping(pathSpec, pathname)) {
+    throw new Error(`Cannot build "${to}" with the given params`);
+  }
+  const query = serializeSearch(search);
+  return (
+    pathname +
+    (query ? '?' + query : '') +
+    (hash ? '#' + (hash.startsWith('#') ? hash.slice(1) : hash) : '')
+  );
+};

--- a/packages/waku/tests/build-route-href.test.ts
+++ b/packages/waku/tests/build-route-href.test.ts
@@ -46,25 +46,20 @@ describe('buildRouteHref', () => {
 
   test('serializes an object search', () => {
     expect(
-      buildRouteHref({ to: '/about', search: { page: 2, q: 'x', ok: true } }),
+      buildRouteHref({
+        to: '/about',
+        search: { page: '2', q: 'x', ok: 'true' },
+      }),
     ).toBe('/about?page=2&q=x&ok=true');
   });
 
-  test('omits null/undefined search and supports arrays', () => {
+  test('omits undefined search and supports arrays', () => {
     expect(
       buildRouteHref({
         to: '/about',
-        search: { a: null, b: undefined, tag: ['x', 'y'] },
+        search: { a: undefined, tag: ['x', 'y'] },
       }),
     ).toBe('/about?tag=x&tag=y');
-  });
-
-  test('accepts string and URLSearchParams search', () => {
-    expect(buildRouteHref({ to: '/about', search: '?a=1' })).toBe('/about?a=1');
-    expect(buildRouteHref({ to: '/about', search: 'a=1' })).toBe('/about?a=1');
-    expect(
-      buildRouteHref({ to: '/about', search: new URLSearchParams({ a: '1' }) }),
-    ).toBe('/about?a=1');
   });
 
   test('appends a hash with or without a leading #', () => {
@@ -103,6 +98,14 @@ describe('buildRouteHref types', () => {
       buildRouteHref({ to: '/about', params: { slug: 'a' } });
       // @ts-expect-error unknown param name
       buildRouteHref({ to: '/posts/[slug]', params: { id: 'a' } });
+      buildRouteHref({ to: '/about', search: { page: '2', tags: ['a', 'b'] } });
+      buildRouteHref({ to: '/about', search: { page: undefined } });
+      // @ts-expect-error search values must be strings, not numbers
+      buildRouteHref({ to: '/about', search: { page: 2 } });
+      // @ts-expect-error search values are not nullable (use undefined to omit)
+      buildRouteHref({ to: '/about', search: { page: null } });
+      // @ts-expect-error search must be an object, not a query string
+      buildRouteHref({ to: '/about', search: 'page=2' });
     };
     expect(typeof assertTypes).toBe('function');
   });

--- a/packages/waku/tests/build-route-href.test.ts
+++ b/packages/waku/tests/build-route-href.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest';
+import { buildRouteHref } from '../src/router/common-utils/build-route-href.js';
+
+describe('buildRouteHref', () => {
+  test('static routes', () => {
+    expect(buildRouteHref({ to: '/' })).toBe('/');
+    expect(buildRouteHref({ to: '/about' })).toBe('/about');
+  });
+
+  test('fills a slug and URL-encodes the value', () => {
+    expect(
+      buildRouteHref({ to: '/posts/[slug]', params: { slug: 'hello' } }),
+    ).toBe('/posts/hello');
+    expect(
+      buildRouteHref({ to: '/posts/[slug]', params: { slug: 'a b/c' } }),
+    ).toBe('/posts/a%20b%2Fc');
+  });
+
+  test('fills a prefixed slug', () => {
+    expect(buildRouteHref({ to: '/@[name]', params: { name: 'foo' } })).toBe(
+      '/@foo',
+    );
+  });
+
+  test('fills a catch-all', () => {
+    expect(
+      buildRouteHref({ to: '/docs/[...path]', params: { path: ['a', 'b'] } }),
+    ).toBe('/docs/a/b');
+  });
+
+  test('root catch-all allows an empty array (matches "/")', () => {
+    expect(buildRouteHref({ to: '/[...path]', params: { path: [] } })).toBe(
+      '/',
+    );
+  });
+
+  test('prefixed catch-all rejects an empty array (matches the matcher)', () => {
+    expect(() =>
+      buildRouteHref({ to: '/docs/[...path]', params: { path: [] } }),
+    ).toThrow();
+  });
+
+  test('removes route groups', () => {
+    expect(buildRouteHref({ to: '/(marketing)/about' })).toBe('/about');
+  });
+
+  test('serializes an object search', () => {
+    expect(
+      buildRouteHref({ to: '/about', search: { page: 2, q: 'x', ok: true } }),
+    ).toBe('/about?page=2&q=x&ok=true');
+  });
+
+  test('omits null/undefined search and supports arrays', () => {
+    expect(
+      buildRouteHref({
+        to: '/about',
+        search: { a: null, b: undefined, tag: ['x', 'y'] },
+      }),
+    ).toBe('/about?tag=x&tag=y');
+  });
+
+  test('accepts string and URLSearchParams search', () => {
+    expect(buildRouteHref({ to: '/about', search: '?a=1' })).toBe('/about?a=1');
+    expect(buildRouteHref({ to: '/about', search: 'a=1' })).toBe('/about?a=1');
+    expect(
+      buildRouteHref({ to: '/about', search: new URLSearchParams({ a: '1' }) }),
+    ).toBe('/about?a=1');
+  });
+
+  test('appends a hash with or without a leading #', () => {
+    expect(buildRouteHref({ to: '/about', hash: 'top' })).toBe('/about#top');
+    expect(buildRouteHref({ to: '/about', hash: '#top' })).toBe('/about#top');
+  });
+
+  test('combines params, search, and hash', () => {
+    expect(
+      buildRouteHref({
+        to: '/posts/[slug]',
+        params: { slug: 'hello' },
+        search: { tab: 'comments' },
+        hash: 'reply',
+      }),
+    ).toBe('/posts/hello?tab=comments#reply');
+  });
+
+  test('throws on a missing param', () => {
+    // @ts-expect-error params is required for a route with a slug
+    expect(() => buildRouteHref({ to: '/posts/[slug]' })).toThrow();
+  });
+});
+
+describe('buildRouteHref types', () => {
+  test('params are derived from the route pattern', () => {
+    // Type-level assertions; the closure is never invoked, so the invalid
+    // calls do not run.
+    const assertTypes = () => {
+      buildRouteHref({ to: '/posts/[slug]', params: { slug: 'a' } });
+      buildRouteHref({ to: '/docs/[...path]', params: { path: ['a', 'b'] } });
+      buildRouteHref({ to: '/about' });
+      // @ts-expect-error missing required slug param
+      buildRouteHref({ to: '/posts/[slug]', params: {} });
+      // @ts-expect-error a static route accepts no params
+      buildRouteHref({ to: '/about', params: { slug: 'a' } });
+      // @ts-expect-error unknown param name
+      buildRouteHref({ to: '/posts/[slug]', params: { id: 'a' } });
+    };
+    expect(typeof assertTypes).toBe('function');
+  });
+});

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -451,6 +451,76 @@ describe('useRouter + Link with context', () => {
     view.unmount();
   });
 
+  test('push/replace execute a structured target through changeRoute', async () => {
+    const capture = { router: null as RouterApi | null };
+    const setRouter = (router: RouterApi) => {
+      capture.router = router;
+    };
+    const changeRoute = vi.fn(async () => {});
+
+    const Probe = () => {
+      setRouter(useRouter() as unknown as RouterApi);
+      return null;
+    };
+
+    const view = await renderApp(
+      <RouterContext
+        value={{
+          route: { path: '/start', query: '', hash: '' },
+          changeRoute,
+          prefetchRoute: vi.fn(),
+          routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set(),
+        }}
+      >
+        <Probe />
+      </RouterContext>,
+    );
+
+    if (!capture.router) {
+      throw new Error('router was not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push({
+        to: '/posts/[slug]',
+        params: { slug: 'a b/c' },
+        search: { tab: 'comments' },
+        hash: 'top',
+      });
+      await capture.router!.replace({
+        to: '/posts/[slug]',
+        params: { slug: 'a b/c' },
+        search: { tab: 'comments' },
+        hash: 'top',
+      });
+    });
+
+    const expectedRoute = {
+      path: '/posts/a%20b%2Fc',
+      query: 'tab=comments',
+      hash: '#top',
+    };
+    expect(changeRoute).toHaveBeenNthCalledWith(
+      1,
+      expectedRoute,
+      expect.objectContaining({ mode: 'push', url: expect.any(URL) }),
+    );
+    expect(changeRoute).toHaveBeenNthCalledWith(
+      2,
+      expectedRoute,
+      expect.objectContaining({ mode: 'replace', url: expect.any(URL) }),
+    );
+    const pushedUrl = (
+      (changeRoute.mock.calls[0] as unknown[] | undefined)?.[1] as
+        | { url?: URL }
+        | undefined
+    )?.url;
+    expect(pushedUrl?.href).toContain('/posts/a%20b%2Fc?tab=comments#top');
+
+    view.unmount();
+  });
+
   test('Link intercepts normal click and skips alt/defaultPrevented clicks', async () => {
     const changeRoute = vi.fn(async () => {});
     const prefetchRoute = vi.fn();

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2231,7 +2231,7 @@ describe('Router integration', () => {
       };
       const skipStr = fetchSpy.mock.calls
         .map((call) => readHeader(call[1], SKIP_HEADER))
-        .find((value) => value != null);
+        .find((value) => value !== null && value !== undefined);
       expect(skipStr).toBeTypeOf('string');
       const skipped = JSON.parse(skipStr!) as Record<string, string>;
       expect(skipped.foo).toBe('etag-foo');

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -261,13 +261,21 @@ afterEach(() => {
 });
 
 describe('router navigation method path typing', () => {
-  test('prefetch accepts the same path type as push and replace', () => {
+  test('prefetch is string-only; push/replace also accept structured targets', () => {
     type PrefetchArg = Parameters<RouterApi['prefetch']>[0];
-    type PushArg = Parameters<RouterApi['push']>[0];
-    type ReplaceArg = Parameters<RouterApi['replace']>[0];
     expectType<TypeEqual<PrefetchArg, Unstable_InferredPaths>>(true);
-    expectType<TypeEqual<PrefetchArg, PushArg>>(true);
-    expectType<TypeEqual<PrefetchArg, ReplaceArg>>(true);
+
+    // Type-level assertions; the closure is never invoked.
+    const assertTypes = (router: RouterApi) => {
+      void router.prefetch('/x');
+      void router.push('/x');
+      void router.replace('/x');
+      void router.push({ to: '/posts/[slug]', params: { slug: 'a' } });
+      void router.replace({ to: '/posts/[slug]', params: { slug: 'a' } });
+      // @ts-expect-error prefetch does not accept a structured target
+      void router.prefetch({ to: '/posts/[slug]', params: { slug: 'a' } });
+    };
+    expect(typeof assertTypes).toBe('function');
   });
 });
 
@@ -1158,6 +1166,47 @@ describe('Router integration', () => {
     expect(capture.router.path).toBe('/next');
     expect(capture.router.query).toBe('x=1');
     expect(capture.router.hash).toBe('#h');
+
+    view.unmount();
+  });
+
+  test('push accepts a structured target and builds the href', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/posts/hello')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      {
+        initialRoute: { path: '/start', query: '', hash: '' },
+      },
+      elements,
+    );
+
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+    const refetch = getRefetchMock();
+
+    await act(async () => {
+      await capture.router!.push({
+        to: '/posts/[slug]',
+        params: { slug: 'hello' },
+        search: { tab: 'comments' },
+      });
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(refetch.mock.calls[0]?.[0]).toBe(
+      unstable_encodeRoutePath('/posts/hello'),
+    );
+    expect(capture.router.path).toBe('/posts/hello');
+    expect(capture.router.query).toBe('tab=comments');
 
     view.unmount();
   });


### PR DESCRIPTION

## Motivation

Navigating to a dynamic route was string-only (`router.push('/posts/' + slug)`), with no slug type-checking and manual interpolation/encoding.

## API

`router.push` and `router.replace` now also accept a structured target (the string form is unchanged):

```ts
router.push({
  to: '/posts/[slug]',
  params: { slug },
  search: { tab: 'comments' },
  hash: 'top',
});
```

`params` is type-checked against the route pattern (a catch-all takes `string[]`). `search` is an object of string query values (an array for repeated keys). The href is built by an internal `buildRouteHref` helper (not a public export). New guide: `docs/guides/typed-routes.mdx`.
