### PR TITLE
Fix hanging when a server component returns an object with the key status and the value pending

### DIFF
--- a/packages/waku/src/lib/utils/rsc-stream.ts
+++ b/packages/waku/src/lib/utils/rsc-stream.ts
@@ -118,8 +118,9 @@ const collectFlightChunks = (root: unknown): FlightChunk[] => {
 
 export async function waitForRootPrerequisites(root: unknown): Promise<void> {
   while (true) {
-    const unresolvedChunks = collectFlightChunks(root).filter((chunk) =>
-      isPendingStatus(chunk.status),
+    const unresolvedChunks = collectFlightChunks(root).filter(
+      (chunk) =>
+        isPendingStatus(chunk.status) && typeof chunk.then === 'function',
     );
     if (unresolvedChunks.length === 0) {
       return;

--- a/packages/waku/tests/fixtures/rsc-stream-scenarios.ts
+++ b/packages/waku/tests/fixtures/rsc-stream-scenarios.ts
@@ -191,12 +191,38 @@ async function runBridgeChunkScenario() {
   };
 }
 
+async function runPlainPendingDataScenario() {
+  const root = {
+    props: {
+      children: [
+        {
+          id: '1',
+          hostname: 'a.example.com',
+          status: 'pending',
+          sslStatus: 'pending_validation',
+        },
+        { id: '2', hostname: 'b.example.com', status: 'blocked' },
+      ],
+    },
+  };
+
+  let settled = false;
+  await waitForRootPrerequisites(root).then(() => {
+    settled = true;
+  });
+
+  return { settled };
+}
+
 switch (scenarioName) {
   case 'bridge-chunk':
     console.log(JSON.stringify(await runBridgeChunkScenario()));
     break;
   case 'settled-root':
     console.log(JSON.stringify(await runSettledRootScenario()));
+    break;
+  case 'plain-pending-data':
+    console.log(JSON.stringify(await runPlainPendingDataScenario()));
     break;
   default:
     throw new Error(`Unknown scenario: ${scenarioName}`);

--- a/packages/waku/tests/rsc-stream.test.ts
+++ b/packages/waku/tests/rsc-stream.test.ts
@@ -94,4 +94,11 @@ describe('waitForRootPrerequisites', () => {
     expect(result.bridgePendingCountBeforeResolve).toBeGreaterThan(0);
     expect(result.bridgeWaitSettledBeforeResolve).toBe(false);
   });
+
+  test('settles on plain data whose status field is "pending"/"blocked"', async () => {
+    const result = await runNodeScenario<{ settled: boolean }>(
+      'plain-pending-data',
+    );
+    expect(result.settled).toBe(true);
+  });
 });


### PR DESCRIPTION
I had this very specific error that when using cloudflare the json response contained:

```
{
	"status": "pending"
}
```

And this would make my whole page non interactive and hang. This fix checks if when sometimes comes with this key and value it has a `.then` function attached to it.