### PR TITLE
refactor(router): route path rename

### DIFF
--- a/packages/waku/src/router/client-utils/build-route-href.ts
+++ b/packages/waku/src/router/client-utils/build-route-href.ts
@@ -6,27 +6,27 @@ import type {
   RouteParams,
 } from '../create-pages-utils/inferred-path-types.js';
 
-export type RoutePattern = [PagePath<CreatePagesConfig>] extends [never]
+export type RoutePath = [PagePath<CreatePagesConfig>] extends [never]
   ? string
   : PagePath<CreatePagesConfig>;
 
-type RouteParamsInput<Pattern extends RoutePattern> = {
-  [Key in keyof RouteParams<Pattern>]: RouteParams<Pattern>[Key] extends string[]
+type RouteParamsInput<Path extends RoutePath> = {
+  [Key in keyof RouteParams<Path>]: RouteParams<Path>[Key] extends string[]
     ? readonly string[]
-    : RouteParams<Pattern>[Key];
+    : RouteParams<Path>[Key];
 };
 
 type SearchValue = string | readonly string[] | undefined;
 
 type BuildRouteHrefSearch = Record<string, SearchValue>;
 
-export type BuildRouteHrefTarget<Pattern extends RoutePattern> = {
-  to: Pattern;
+export type BuildRouteHrefTarget<Path extends RoutePath> = {
+  to: Path;
   search?: BuildRouteHrefSearch;
   hash?: string;
-} & (keyof RouteParamsInput<Pattern> extends never
+} & (keyof RouteParamsInput<Path> extends never
   ? { params?: never }
-  : { params: RouteParamsInput<Pattern> });
+  : { params: RouteParamsInput<Path> });
 
 const serializeSearch = (search: BuildRouteHrefSearch | undefined): string => {
   if (search === undefined) {
@@ -49,14 +49,14 @@ const serializeSearch = (search: BuildRouteHrefSearch | undefined): string => {
 };
 
 /**
- * Build an href string from a route pattern, params, search, and hash.
+ * Build an href string from a route path, params, search, and hash.
  *
- * Route groups in the pattern are removed, path params are URL-encoded, and the
+ * Route groups in the path are removed, path params are URL-encoded, and the
  * result is validated against the route matcher; building a pathname that the
- * pattern would not match (e.g. an empty array for a prefixed catch-all) throws.
+ * path would not match (e.g. an empty array for a prefixed catch-all) throws.
  */
-export const buildRouteHref = <Pattern extends RoutePattern>(
-  target: BuildRouteHrefTarget<Pattern>,
+export const buildRouteHref = <Path extends RoutePath>(
+  target: BuildRouteHrefTarget<Path>,
 ): string => {
   const { to, search, hash, params } = target as {
     to: string;

--- a/packages/waku/src/router/client-utils/match-route-params.ts
+++ b/packages/waku/src/router/client-utils/match-route-params.ts
@@ -1,7 +1,7 @@
 import { getGrouplessPath } from '../../lib/utils/create-pages.js';
 import { getPathMapping, parsePathWithSlug } from '../../lib/utils/path.js';
 import type { RouteParams } from '../create-pages-utils/inferred-path-types.js';
-import type { RoutePattern } from './build-route-href.js';
+import type { RoutePath } from './build-route-href.js';
 
 const safeDecodeURIComponent = (value: string): string | null => {
   try {
@@ -12,7 +12,7 @@ const safeDecodeURIComponent = (value: string): string | null => {
 };
 
 /**
- * Match a concrete pathname against a route pattern and return its params, or
+ * Match a concrete pathname against a route path and return its params, or
  * null when the pathname does not match. This is the inverse of buildRouteHref:
  * route groups are stripped, the existing matcher decides the match, and each
  * matched segment is decoded once. The pathname must be the encoded form stored
@@ -22,11 +22,11 @@ const safeDecodeURIComponent = (value: string): string | null => {
  * router: a prefixed terminal catch-all (/docs/[...path]) does not match its
  * base (/docs), while a root catch-all (/[...path]) matches / as { path: [] }.
  */
-export const matchRouteParams = <Pattern extends RoutePattern>(
-  pattern: Pattern,
+export const matchRouteParams = <Path extends RoutePath>(
+  path: Path,
   pathname: string,
-): RouteParams<Pattern> | null => {
-  const pathSpec = parsePathWithSlug(getGrouplessPath(pattern));
+): RouteParams<Path> | null => {
+  const pathSpec = parsePathWithSlug(getGrouplessPath(path));
   const mapping = getPathMapping(pathSpec, pathname);
   if (mapping === null) {
     return null;
@@ -51,5 +51,5 @@ export const matchRouteParams = <Pattern extends RoutePattern>(
       params[key] = decodedValue;
     }
   }
-  return params as RouteParams<Pattern>;
+  return params as RouteParams<Path>;
 };

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -38,7 +38,7 @@ import type { RouteConfig } from './base-types.js';
 import { buildRouteHref } from './client-utils/build-route-href.js';
 import type {
   BuildRouteHrefTarget,
-  RoutePattern,
+  RoutePath,
 } from './client-utils/build-route-href.js';
 import { matchRouteParams } from './client-utils/match-route-params.js';
 import {
@@ -85,8 +85,8 @@ type NavigateOptions = {
 
 type Navigate = {
   (to: InferredPaths, options?: NavigateOptions): Promise<void>;
-  <Pattern extends RoutePattern>(
-    target: BuildRouteHrefTarget<Pattern>,
+  <Path extends RoutePath>(
+    target: BuildRouteHrefTarget<Path>,
     options?: NavigateOptions,
   ): Promise<void>;
 };
@@ -253,7 +253,7 @@ export function useRouter() {
   const { route, changeRoute, prefetchRoute } = router;
   const push = useCallback(
     async (
-      to: InferredPaths | BuildRouteHrefTarget<RoutePattern>,
+      to: InferredPaths | BuildRouteHrefTarget<RoutePath>,
       options?: NavigateOptions,
     ) => {
       const href = typeof to === 'string' ? to : buildRouteHref(to);
@@ -271,7 +271,7 @@ export function useRouter() {
   ) as Navigate;
   const replace = useCallback(
     async (
-      to: InferredPaths | BuildRouteHrefTarget<RoutePattern>,
+      to: InferredPaths | BuildRouteHrefTarget<RoutePath>,
       options?: NavigateOptions,
     ) => {
       const href = typeof to === 'string' ? to : buildRouteHref(to);
@@ -319,17 +319,17 @@ export function useRouter() {
 }
 
 /**
- * Read the current route's params, typed from the `from` pattern, or null when
+ * Read the current route's params, typed from the `from` path, or null when
  * the current path does not match it. Re-renders when the route path changes.
  * The result is memoized by path, so its identity changes on navigation to a
  * different path; read its fields rather than using the object itself as an
  * effect dependency.
  */
-export function useParams_UNSTABLE<Pattern extends RoutePattern>({
+export function useParams_UNSTABLE<Path extends RoutePath>({
   from,
 }: {
-  from: Pattern;
-}): RouteParams<Pattern> | null {
+  from: Path;
+}): RouteParams<Path> | null {
   const { path } = useRouter();
   return useMemo(() => matchRouteParams(from, path), [from, path]);
 }


### PR DESCRIPTION
routePath is the path that includes `[slug]`, so make the term consistent. Though, we may revisit the terminology later. related: #2150 #2151