### PR TITLE
feat(router): typed search params

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,8 @@ This allows you to have a `dynamic` slice component while keeping the rest of th
 
 The `<Link />` component should be used for internal links. It accepts a `to` prop for the destination and handles client-side navigation through Waku's router.
 
+`to` is either a route string, or a structured `{ to, params, search, hash }` target for typed navigation (the same shape `router.push` accepts; see [Typed Routes](https://github.com/wakujs/waku/blob/main/docs/guides/typed-routes.mdx)).
+
 ```tsx
 // ./src/pages/index.tsx
 import { Link } from 'waku';
@@ -770,6 +772,7 @@ export default async function HomePage() {
     <>
       <h1>Home</h1>
       <Link to="/about">About</Link>
+      <Link to={{ to: '/search', search: { q: 'waku' } }}>Search</Link>
     </>
   );
 }

--- a/docs/guides/typed-routes.mdx
+++ b/docs/guides/typed-routes.mdx
@@ -164,6 +164,8 @@ export const SearchCodecs = ({ children }: { children: ReactNode }) => (
 );
 ```
 
+Pass only codecs. `import * as` works when the module exports just codecs (types are erased); if the module also has non-codec exports, list the codecs explicitly instead, e.g. `searchCodecs={[searchCodec]}`. Non-codec values are ignored with a warning.
+
 Render it in your root layout so it wraps every page:
 
 ```tsx

--- a/docs/guides/typed-routes.mdx
+++ b/docs/guides/typed-routes.mdx
@@ -29,7 +29,6 @@ export const PostButton = ({ slug }: { slug: string }) => {
         router.push({
           to: '/posts/[slug]',
           params: { slug },
-          search: { tab: 'comments' },
           hash: 'top',
         })
       }
@@ -41,7 +40,7 @@ export const PostButton = ({ slug }: { slug: string }) => {
 ```
 
 - `to` is a route pattern (e.g. `/posts/[slug]`, `/docs/[...path]`). `params` is required when the pattern has slugs and is typed from it; a catch-all takes a `string[]`.
-- `search` is an object of string query values (use an array for repeated keys); `undefined` values are omitted. `hash` is optional.
+- `hash` is optional. `search` is typed per route by a search codec — see [Search Params](#search-params).
 - The plain string form (`router.push('/posts/hello')`) keeps working.
 
 ## Reading Route Params
@@ -66,3 +65,156 @@ export const PostTitle = () => {
 - Values are URL-decoded, mirroring how `router.push` encodes them.
 - It re-renders when the current route path changes.
 - Page components already receive their params through props; `useParams()` is for client and shared components that do not.
+
+## Search Params
+
+Waku types the URL search params (the query string) per route with a **search codec** you provide. The codec converts the query string to a typed object and back, so server components, client hooks, and navigation share one typed shape. Waku ships the contract; you bring the implementation (hand-written, or wrapping a library).
+
+### Define a codec
+
+A codec is a plain object with a stable `id`, a `parse`, and a `serialize`:
+
+```ts
+// ./src/lib/search.ts
+import type { Unstable_SearchCodec } from 'waku/router';
+
+export type Search = { q: string; page: number };
+
+export const searchCodec = {
+  id: 'search',
+  parse: (query: string): Search => {
+    const params = new URLSearchParams(query);
+    return { q: params.get('q') ?? '', page: Number(params.get('page')) || 1 };
+  },
+  serialize: ({ q, page }: Search) =>
+    new URLSearchParams({ q, page: String(page) }).toString(),
+} as const satisfies Unstable_SearchCodec<Search>;
+```
+
+`parse` may throw to reject a malformed query; Waku turns that into a 400.
+
+### Attach the codec to a route
+
+Set it on the route's config, and map the route to the codec for typing.
+
+With `createPages`, pass `unstable_searchCodec` and declare the mapping:
+
+```tsx
+import { searchCodec } from './lib/search';
+
+declare module 'waku/router' {
+  interface SearchCodecsConfig {
+    '/search': typeof searchCodec;
+  }
+}
+
+// inside createPages(...)
+createPage({
+  render: 'dynamic',
+  path: '/search',
+  component: SearchPage,
+  unstable_searchCodec: searchCodec,
+});
+```
+
+With the file-system router, export it from `getConfig` and the types are generated for you:
+
+```tsx
+// ./src/pages/search.tsx
+import { searchCodec } from '../lib/search';
+
+export const getConfig = async () => ({
+  render: 'dynamic',
+  unstable_searchCodec: searchCodec,
+});
+```
+
+### Read search on the server
+
+The page component receives a typed `search` prop:
+
+```tsx
+import type { PageProps } from 'waku/router';
+
+export default function SearchPage({ search }: PageProps<'/search'>) {
+  return (
+    <p>
+      {search.q} (page {search.page})
+    </p>
+  );
+}
+```
+
+### Provide codecs on the client
+
+To read, update, or navigate with search on the client, the codec has to be available there. Wrap your app with `Unstable_SearchCodecsProvider`. Because codecs hold functions, the provider must be rendered from a `'use client'` module that imports them:
+
+```tsx
+// ./src/components/search-codecs.tsx
+'use client';
+
+import type { ReactNode } from 'react';
+import { Unstable_SearchCodecsProvider } from 'waku/router/client';
+import * as searchCodecs from '../lib/search';
+
+export const SearchCodecs = ({ children }: { children: ReactNode }) => (
+  <Unstable_SearchCodecsProvider searchCodecs={searchCodecs}>
+    {children}
+  </Unstable_SearchCodecsProvider>
+);
+```
+
+Render it in your root layout so it wraps every page:
+
+```tsx
+// ./src/pages/_layout.tsx (fs-router root layout)
+import type { ReactNode } from 'react';
+import { SearchCodecs } from '../components/search-codecs';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return <SearchCodecs>{children}</SearchCodecs>;
+}
+```
+
+With `createPages`, wrap your root layout (or root) component's children the same way.
+
+> **Provide codecs app-wide, not per route.** A codec must be available on the page you navigate **from**. If a link on your home page does `push({ to: '/search', search })`, the home page needs `/search`'s codec to serialize the URL — so a provider only around `/search` is not enough. Wrapping your root layout covers every page.
+
+### Read and update search on the client
+
+```tsx
+'use client';
+
+import {
+  useSearch_UNSTABLE as useSearch,
+  useSetSearch_UNSTABLE as useSetSearch,
+} from 'waku/router/client';
+
+export const Pager = () => {
+  const search = useSearch({ from: '/search' });
+  const setSearch = useSetSearch({ from: '/search' });
+  if (!search) {
+    return null;
+  }
+  return (
+    <button onClick={() => setSearch((prev) => ({ page: prev.page + 1 }))}>
+      page {search.page}
+    </button>
+  );
+};
+```
+
+- `useSearch` returns the typed `search`, or `null` when the current path does not match `from`.
+- `setSearch` takes a partial or an updater, serializes with the codec, and navigates (push by default, or `{ history: 'replace' }`).
+
+### Navigate with search
+
+`push`, `replace`, and `Link` accept a typed `search` for the target route:
+
+```tsx
+router.push({ to: '/search', search: { q: 'waku', page: 1 } });
+
+<Link to={{ to: '/search', search: { q: 'waku', page: 1 } }}>Search</Link>;
+```
+
+A route without a codec takes no `search` (its `search` is `never`); use the plain string form (`push('/foo?ref=home')`) for ad-hoc queries.

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -130,6 +130,75 @@ test.describe(`create-pages`, () => {
     await expect(page.getByRole('heading', { name: 'Foo' })).toBeVisible();
   });
 
+  test('search params (props.search + useSearch + setSearch)', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/search?q=hi&page=2`);
+    await waitForHydration(page);
+    // server component received the parsed, typed search
+    await expect(page.getByTestId('server-search')).toHaveText(
+      '{"q":"hi","page":2}',
+    );
+    // client useSearch resolved the same codec by id and re-parsed the query
+    await expect(page.getByTestId('client-search')).toHaveText(
+      '{"q":"hi","page":2}',
+    );
+    // setSearch serializes with the codec, navigates, and the route re-renders
+    await page.getByTestId('next-page').click();
+    await expect(page).toHaveURL(/[?&]page=3(&|$)/);
+    await expect(page.getByTestId('client-search')).toHaveText(
+      '{"q":"hi","page":3}',
+    );
+    await expect(page.getByTestId('server-search')).toHaveText(
+      '{"q":"hi","page":3}',
+    );
+  });
+
+  test('search params (cross-route push with typed search)', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/`);
+    await waitForHydration(page);
+    // push({ to: '/search', search }) serializes via the target route's codec,
+    // resolved from the route -> codec id map shipped to the client
+    await page.getByTestId('home-to-search').click();
+    await expect(page).toHaveURL(/\/search\?q=hello&page=5$/);
+    await expect(page.getByTestId('server-search')).toHaveText(
+      '{"q":"hello","page":5}',
+    );
+    await expect(page.getByTestId('client-search')).toHaveText(
+      '{"q":"hello","page":5}',
+    );
+  });
+
+  test('search params (cross-route Link with typed search)', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/`);
+    await waitForHydration(page);
+    // <Link to={{ to: '/search', search }}> serializes via the target codec too
+    await page.getByTestId('home-to-search-link').click();
+    await expect(page).toHaveURL(/\/search\?q=linked&page=7$/);
+    await expect(page.getByTestId('server-search')).toHaveText(
+      '{"q":"linked","page":7}',
+    );
+    await expect(page.getByTestId('client-search')).toHaveText(
+      '{"q":"linked","page":7}',
+    );
+  });
+
+  test('search params (cross-route Link serializes its href during SSR)', async () => {
+    // The cross-route <Link to={{ to: '/search', search }}> serializes its href
+    // on the server. This requires the route -> codec id map to be available
+    // during SSR (not only the browser-injected global), otherwise the link
+    // throws while rendering and its href is missing from the server HTML.
+    const res = await fetch(`http://localhost:${port}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('data-testid="home-to-search-link"');
+    expect(html).toContain('/search?q=linked');
+  });
+
   test('dynamic', async ({ page }) => {
     await page.goto(`http://localhost:${port}/dynamic`);
     await expect(page.getByRole('navigation')).toHaveText('Dynamic Layout');

--- a/e2e/fixtures/base-path/src/components/router.tsx
+++ b/e2e/fixtures/base-path/src/components/router.tsx
@@ -7,13 +7,15 @@ export function ClickLink(
   props: ComponentProps<typeof Link> & { replace?: boolean },
 ) {
   const router = useRouter();
+  const { to } = props;
+  const navigate = props.replace ? router.replace : router.push;
   return (
     <button
       onClick={async () => {
-        if (props.replace) {
-          await router.replace(props.to);
+        if (typeof to === 'string') {
+          await navigate(to);
         } else {
-          await router.push(props.to);
+          await navigate(to);
         }
       }}
     >

--- a/e2e/fixtures/create-pages/src/components/AppSearchCodecs.tsx
+++ b/e2e/fixtures/create-pages/src/components/AppSearchCodecs.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Unstable_SearchCodecsProvider } from 'waku/router/client';
+import * as searchCodecs from '../lib/search.js';
+
+export function AppSearchCodecs({ children }: { children: ReactNode }) {
+  return (
+    <Unstable_SearchCodecsProvider searchCodecs={searchCodecs}>
+      {children}
+    </Unstable_SearchCodecsProvider>
+  );
+}

--- a/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
+++ b/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
+import { AppSearchCodecs } from './AppSearchCodecs';
 import { Pending } from './pending';
 
 import '../styles.css';
@@ -9,59 +10,61 @@ let renderCount = 0;
 const HomeLayout = ({ children }: { children: ReactNode }) => {
   ++renderCount;
   return (
-    <div>
-      <title>Waku</title>
-      <ul>
-        <li>
-          <Link to="/">
-            Home
-            <Pending />
-          </Link>
-        </li>
-        <li>
-          <Link to="/foo">
-            Foo
-            <Pending />
-          </Link>
-        </li>
-        <li>
-          <Link to="/bar" unstable_prefetchOnEnter>
-            Bar
-          </Link>
-        </li>
-        <li>
-          <Link to="/baz">Baz</Link>
-        </li>
-        <li>
-          <Link to="/nested/foo">Nested / Foo</Link>
-        </li>
-        <li>
-          <Link to="/nested/bar">Nested / Bar</Link>
-        </li>
-        <li>
-          <Link to="/nested/baz">Nested / Baz</Link>
-        </li>
-        <li>
-          <Link to="/nested/qux">Nested / Qux</Link>
-        </li>
-        <li>
-          <Link to="/error">Error</Link>
-        </li>
-        <li>
-          <Link to="/exact/[slug]/[...wild]">Exact Path</Link>
-        </li>
-        <li>
-          <Link to="/nested-layouts">Nested Layouts</Link>
-        </li>
-        <li>
-          <Link to="/slices">Slices</Link>
-        </li>
-      </ul>
-      {children}
-      <h4 data-testid="home-layout-render-count">
-        Render Count: {renderCount}
-      </h4>
-    </div>
+    <AppSearchCodecs>
+      <div>
+        <title>Waku</title>
+        <ul>
+          <li>
+            <Link to="/">
+              Home
+              <Pending />
+            </Link>
+          </li>
+          <li>
+            <Link to="/foo">
+              Foo
+              <Pending />
+            </Link>
+          </li>
+          <li>
+            <Link to="/bar" unstable_prefetchOnEnter>
+              Bar
+            </Link>
+          </li>
+          <li>
+            <Link to="/baz">Baz</Link>
+          </li>
+          <li>
+            <Link to="/nested/foo">Nested / Foo</Link>
+          </li>
+          <li>
+            <Link to="/nested/bar">Nested / Bar</Link>
+          </li>
+          <li>
+            <Link to="/nested/baz">Nested / Baz</Link>
+          </li>
+          <li>
+            <Link to="/nested/qux">Nested / Qux</Link>
+          </li>
+          <li>
+            <Link to="/error">Error</Link>
+          </li>
+          <li>
+            <Link to="/exact/[slug]/[...wild]">Exact Path</Link>
+          </li>
+          <li>
+            <Link to="/nested-layouts">Nested Layouts</Link>
+          </li>
+          <li>
+            <Link to="/slices">Slices</Link>
+          </li>
+        </ul>
+        {children}
+        <h4 data-testid="home-layout-render-count">
+          Render Count: {renderCount}
+        </h4>
+      </div>
+    </AppSearchCodecs>
   );
 };
 

--- a/e2e/fixtures/create-pages/src/components/HomePage.tsx
+++ b/e2e/fixtures/create-pages/src/components/HomePage.tsx
@@ -1,7 +1,10 @@
+import { HomeSearchLink } from './HomeSearchLink.js';
+
 const Home = () => (
   <div>
     <h2>Home</h2>
     <p>This is the home page.</p>
+    <HomeSearchLink />
   </div>
 );
 

--- a/e2e/fixtures/create-pages/src/components/HomeSearchLink.tsx
+++ b/e2e/fixtures/create-pages/src/components/HomeSearchLink.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Link, useRouter } from 'waku/router/client';
+
+export function HomeSearchLink() {
+  const router = useRouter();
+  return (
+    <div>
+      <button
+        data-testid="home-to-search"
+        onClick={() =>
+          router.push({ to: '/search', search: { q: 'hello', page: 5 } })
+        }
+      >
+        to search
+      </button>
+      <Link
+        to={{ to: '/search', search: { q: 'linked', page: 7 } }}
+        data-testid="home-to-search-link"
+      >
+        to search (link)
+      </Link>
+    </div>
+  );
+}

--- a/e2e/fixtures/create-pages/src/components/SearchControls.tsx
+++ b/e2e/fixtures/create-pages/src/components/SearchControls.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useSearch_UNSTABLE, useSetSearch_UNSTABLE } from 'waku/router/client';
+
+export function SearchControls() {
+  const search = useSearch_UNSTABLE({ from: '/search' });
+  const setSearch = useSetSearch_UNSTABLE({ from: '/search' });
+  return (
+    <div>
+      <p data-testid="client-search">{JSON.stringify(search)}</p>
+      <button
+        data-testid="next-page"
+        onClick={() => setSearch((prev) => ({ page: prev.page + 1 }))}
+      >
+        next
+      </button>
+    </div>
+  );
+}

--- a/e2e/fixtures/create-pages/src/components/SearchPage.tsx
+++ b/e2e/fixtures/create-pages/src/components/SearchPage.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'waku';
+import type { PageProps } from 'waku/router';
+import { SearchControls } from './SearchControls.js';
+
+export default function SearchPage({ search }: PageProps<'/search'>) {
+  return (
+    <div>
+      <h1>Search</h1>
+      <p data-testid="server-search">{JSON.stringify(search)}</p>
+      <SearchControls />
+      <Link to="/" data-testid="search-to-home">
+        Home
+      </Link>
+    </div>
+  );
+}

--- a/e2e/fixtures/create-pages/src/lib/search.ts
+++ b/e2e/fixtures/create-pages/src/lib/search.ts
@@ -1,0 +1,22 @@
+import type { Unstable_SearchCodec } from 'waku/router';
+
+export type DemoSearch = { q: string; page: number };
+
+export const demoSearchCodec = {
+  id: 'demo',
+  parse: (query: string): DemoSearch => {
+    const sp = new URLSearchParams(query);
+    return { q: sp.get('q') ?? '', page: Number(sp.get('page')) || 1 };
+  },
+  serialize: (search: DemoSearch): string =>
+    new URLSearchParams({ q: search.q, page: String(search.page) }).toString(),
+} as const;
+
+// Make `Unstable_SearchCodec` a used import so the type is exercised here too.
+demoSearchCodec satisfies Unstable_SearchCodec<DemoSearch>;
+
+declare module 'waku/router' {
+  interface SearchCodecsConfig {
+    '/search': typeof demoSearchCodec;
+  }
+}

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -18,9 +18,11 @@ import NestedBazPage from './components/NestedBazPage.js';
 import NestedLayout from './components/NestedLayout.js';
 import NoSsr from './components/NoSsr.js';
 import { RerenderActionPage } from './components/RerenderActionPage.js';
+import SearchPage from './components/SearchPage.js';
 import { Slice001 } from './components/slice001.js';
 import { Slice002 } from './components/slice002.js';
 import { Slice003 } from './components/slice003.js';
+import { demoSearchCodec } from './lib/search.js';
 
 const renderLayoutProps = (title: string, testIdPrefix: string, props: any) => (
   <div>
@@ -59,6 +61,13 @@ const pages: ReturnType<typeof createPages> = createPages(
       render: 'static',
       path: '/foo',
       component: FooPage,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/search',
+      component: SearchPage,
+      unstable_searchCodec: demoSearchCodec,
     }),
 
     createPage({

--- a/e2e/fixtures/fs-router/package.json
+++ b/e2e/fixtures/fs-router/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "waku dev",
     "build": "waku build",
-    "start": "waku start"
+    "start": "waku start",
+    "typegen": "waku router typegen"
   },
   "dependencies": {
     "react": "~19.2.6",

--- a/e2e/fixtures/fs-router/src/components/grouped-search-controls.tsx
+++ b/e2e/fixtures/fs-router/src/components/grouped-search-controls.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useSearch_UNSTABLE as useSearch } from 'waku/router/client';
+
+export function GroupedSearchControls() {
+  const search = useSearch({ from: '/grouped-search' });
+  return <p data-testid="grouped-client-search">{JSON.stringify(search)}</p>;
+}

--- a/e2e/fixtures/fs-router/src/components/search-codecs.tsx
+++ b/e2e/fixtures/fs-router/src/components/search-codecs.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Unstable_SearchCodecsProvider } from 'waku/router/client';
+import * as searchCodecs from '../lib/search.js';
+
+export function SearchCodecs({ children }: { children: ReactNode }) {
+  return (
+    <Unstable_SearchCodecsProvider searchCodecs={searchCodecs}>
+      {children}
+    </Unstable_SearchCodecsProvider>
+  );
+}

--- a/e2e/fixtures/fs-router/src/components/search-controls.tsx
+++ b/e2e/fixtures/fs-router/src/components/search-controls.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import {
+  useSearch_UNSTABLE as useSearch,
+  useSetSearch_UNSTABLE as useSetSearch,
+} from 'waku/router/client';
+
+export function SearchControls() {
+  const search = useSearch({ from: '/search' });
+  const setSearch = useSetSearch({ from: '/search' });
+  return (
+    <div>
+      <p data-testid="client-search">{JSON.stringify(search)}</p>
+      <button
+        data-testid="next-page"
+        onClick={() => setSearch((prev) => ({ page: prev.page + 1 }))}
+      >
+        next
+      </button>
+    </div>
+  );
+}

--- a/e2e/fixtures/fs-router/src/lib/search.ts
+++ b/e2e/fixtures/fs-router/src/lib/search.ts
@@ -1,0 +1,13 @@
+import type { Unstable_SearchCodec } from 'waku/router';
+
+export type DemoSearch = { q: string; page: number };
+
+export const demoSearchCodec = {
+  id: 'fs-demo',
+  parse: (query: string): DemoSearch => {
+    const sp = new URLSearchParams(query);
+    return { q: sp.get('q') ?? '', page: Number(sp.get('page')) || 1 };
+  },
+  serialize: (search: DemoSearch): string =>
+    new URLSearchParams({ q: search.q, page: String(search.page) }).toString(),
+} as const satisfies Unstable_SearchCodec<DemoSearch>;

--- a/e2e/fixtures/fs-router/src/pages/(search-group)/grouped-search.tsx
+++ b/e2e/fixtures/fs-router/src/pages/(search-group)/grouped-search.tsx
@@ -1,0 +1,22 @@
+import type { PageProps } from 'waku/router';
+import { GroupedSearchControls } from '../../components/grouped-search-controls';
+import { demoSearchCodec } from '../../lib/search';
+
+export default function GroupedSearchPage({
+  search,
+}: PageProps<'/grouped-search'>) {
+  return (
+    <div>
+      <h2>Grouped Search</h2>
+      <p data-testid="grouped-server-search">{JSON.stringify(search)}</p>
+      <GroupedSearchControls />
+    </div>
+  );
+}
+
+export const getConfig = () => {
+  return {
+    render: 'dynamic',
+    unstable_searchCodec: demoSearchCodec,
+  } as const;
+};

--- a/e2e/fixtures/fs-router/src/pages/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/_layout.tsx
@@ -1,84 +1,87 @@
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
 import { Pending } from '../components/pending';
+import { SearchCodecs } from '../components/search-codecs';
 
 const HomeLayout = ({ children }: { children: ReactNode }) => (
-  <div>
-    <title>Waku</title>
-    <ul>
-      <li>
-        <Link to="/">
-          Home
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/foo">
-          Foo
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/bar" unstable_prefetchOnEnter>
-          Bar
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/nested/baz">
-          Nested / Baz
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/nested/qux">
-          Nested / Qux
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/nested/encoded%20path">
-          Nested / Encoded Path
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/nested/encoded%E6%B8%AC%E8%A9%A6path">
-          Nested / Encoded Unicode Path
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/static-nested/encoded%20path">
-          Nested / Static Encoded Path
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/static-nested/encoded%E6%B8%AC%E8%A9%A6path">
-          Nested / Static Encoded Unicode Path
-          <Pending />
-        </Link>
-      </li>
-      <li>
-        <Link to="/page-with-slices">Page with Slices</Link>
-      </li>
-      <li>
-        <Link to="/css-split">Css split</Link>
-      </li>
-      <li>
-        <Link to="/page-with-segment/introducing-waku">
-          Page with Segment / Introducing Waku
-        </Link>
-      </li>
-      <li>
-        <Link to="/page-with-segment/article/introducing-waku">
-          Page with Segment / Article / Introducing Waku
-        </Link>
-      </li>
-    </ul>
-    {children}
-  </div>
+  <SearchCodecs>
+    <div>
+      <title>Waku</title>
+      <ul>
+        <li>
+          <Link to="/">
+            Home
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/foo">
+            Foo
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/bar" unstable_prefetchOnEnter>
+            Bar
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/nested/baz">
+            Nested / Baz
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/nested/qux">
+            Nested / Qux
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/nested/encoded%20path">
+            Nested / Encoded Path
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/nested/encoded%E6%B8%AC%E8%A9%A6path">
+            Nested / Encoded Unicode Path
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/static-nested/encoded%20path">
+            Nested / Static Encoded Path
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/static-nested/encoded%E6%B8%AC%E8%A9%A6path">
+            Nested / Static Encoded Unicode Path
+            <Pending />
+          </Link>
+        </li>
+        <li>
+          <Link to="/page-with-slices">Page with Slices</Link>
+        </li>
+        <li>
+          <Link to="/css-split">Css split</Link>
+        </li>
+        <li>
+          <Link to="/page-with-segment/introducing-waku">
+            Page with Segment / Introducing Waku
+          </Link>
+        </li>
+        <li>
+          <Link to="/page-with-segment/article/introducing-waku">
+            Page with Segment / Article / Introducing Waku
+          </Link>
+        </li>
+      </ul>
+      {children}
+    </div>
+  </SearchCodecs>
 );
 
 export default HomeLayout;

--- a/e2e/fixtures/fs-router/src/pages/search.tsx
+++ b/e2e/fixtures/fs-router/src/pages/search.tsx
@@ -1,0 +1,20 @@
+import type { PageProps } from 'waku/router';
+import { SearchControls } from '../components/search-controls';
+import { demoSearchCodec } from '../lib/search';
+
+export default function SearchPage({ search }: PageProps<'/search'>) {
+  return (
+    <div>
+      <h2>Search</h2>
+      <p data-testid="server-search">{JSON.stringify(search)}</p>
+      <SearchControls />
+    </div>
+  );
+}
+
+export const getConfig = () => {
+  return {
+    render: 'dynamic',
+    unstable_searchCodec: demoSearchCodec,
+  } as const;
+};

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -99,6 +99,30 @@ test.describe('fs-router', () => {
     ).toBeVisible();
   });
 
+  test('search params (fs-router getConfig codec, typegen)', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/search?q=hi&page=2`);
+    await waitForHydration(page);
+    // props.search parsed on the server by the route's getConfig codec
+    await expect(page.getByTestId('server-search')).toHaveText(
+      '{"q":"hi","page":2}',
+    );
+    // useSearch resolves the same codec on the client (provider in _layout)
+    await expect(page.getByTestId('client-search')).toHaveText(
+      '{"q":"hi","page":2}',
+    );
+    // setSearch serializes with the codec and navigates
+    await page.getByTestId('next-page').click();
+    await expect(page).toHaveURL(/[?&]page=3(&|$)/);
+    await expect(page.getByTestId('client-search')).toHaveText(
+      '{"q":"hi","page":3}',
+    );
+    await expect(page.getByTestId('server-search')).toHaveText(
+      '{"q":"hi","page":3}',
+    );
+  });
+
   test('static-nested encoded path with trailing slash', async ({ page }) => {
     await page.goto(`http://localhost:${port}/static-nested/encoded%20path/`);
     await expect(

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -123,6 +123,22 @@ test.describe('fs-router', () => {
     );
   });
 
+  test('search params (grouped route, normalized path keys)', async ({
+    page,
+  }) => {
+    // a route inside a (group) is keyed by its groupless path everywhere; the
+    // client useSearch must resolve via the same normalized key in the
+    // route -> codec id map (the codec is shared with /search by id)
+    await page.goto(`http://localhost:${port}/grouped-search?q=hi&page=2`);
+    await waitForHydration(page);
+    await expect(page.getByTestId('grouped-server-search')).toHaveText(
+      '{"q":"hi","page":2}',
+    );
+    await expect(page.getByTestId('grouped-client-search')).toHaveText(
+      '{"q":"hi","page":2}',
+    );
+  });
+
   test('static-nested encoded path with trailing slash', async ({ page }) => {
     await page.goto(`http://localhost:${port}/static-nested/encoded%20path/`);
     await expect(

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:lint": "prettier -c . && eslint . && tsc -b && pnpm run tsc-templates",
     "test:unit": "pnpm run -r test",
     "test-vite-ecosystem-ci": "VITE_EXPERIMENTAL_WAKU_ROUTER=true pnpm run -r --filter='!create-waku' test && VITE_EXPERIMENTAL_WAKU_ROUTER=true playwright test --project=chromium-prd --project=chromium-dev",
-    "tsc-templates": "tsc -b ./templates/*/tsconfig.json ./e2e/fixtures/*/tsconfig.json ./e2e/fixtures/monorepo/packages/waku-project/tsconfig.json",
+    "tsc-templates": "pnpm --filter fs-router run typegen && tsc -b ./templates/*/tsconfig.json ./e2e/fixtures/*/tsconfig.json ./e2e/fixtures/monorepo/packages/waku-project/tsconfig.json",
     "e2e": "playwright test",
     "e2e-dev": "playwright test --project=chromium-dev",
     "e2e-prd": "playwright test --project=chromium-prd",

--- a/packages/waku/src/lib/vite-plugins/fs-router-typegen.ts
+++ b/packages/waku/src/lib/vite-plugins/fs-router-typegen.ts
@@ -270,7 +270,7 @@ export async function generateFsRouterTypes(pagesDir: string) {
       '// biome-ignore format: generated types do not need formatting',
       '// prettier-ignore',
       hasAnyGetConfig
-        ? "import type { PathsForPages, GetConfigResponse } from 'waku/router';"
+        ? "import type { PathsForPages, GetConfigResponse, SearchCodecsForPages } from 'waku/router';"
         : "import type { PathsForPages } from 'waku/router';",
     ];
 
@@ -311,6 +311,11 @@ export async function generateFsRouterTypes(pagesDir: string) {
       '  interface CreatePagesConfig {',
       '    pages: Page;',
       '  }',
+      ...(hasAnyGetConfig
+        ? [
+            '  interface SearchCodecsConfig extends SearchCodecsForPages<Page> {}',
+          ]
+        : []),
       '}',
       '',
     );

--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -9,6 +9,8 @@ export type {
   ApiContext,
   PathsForPages,
   GetConfigResponse,
+  Unstable_SearchCodec,
+  SearchCodecsForPages,
 } from './create-pages-utils/inferred-path-types.js';
 
 export interface RouteConfig {
@@ -17,6 +19,10 @@ export interface RouteConfig {
 
 export interface CreatePagesConfig {
   // routes to be overridden by users
+}
+
+export interface SearchCodecsConfig {
+  // route path -> search codec, to be overridden by users (or fs-router typegen)
 }
 
 /** Props for pages when using `createPages` */

--- a/packages/waku/src/router/client-utils/build-route-href.ts
+++ b/packages/waku/src/router/client-utils/build-route-href.ts
@@ -4,6 +4,8 @@ import type { CreatePagesConfig } from '../base-types.js';
 import type {
   PagePath,
   RouteParams,
+  RouteSearch,
+  Unstable_SearchCodec,
 } from '../create-pages-utils/inferred-path-types.js';
 
 export type RoutePath = [PagePath<CreatePagesConfig>] extends [never]
@@ -16,37 +18,13 @@ type RouteParamsInput<Path extends RoutePath> = {
     : RouteParams<Path>[Key];
 };
 
-type SearchValue = string | readonly string[] | undefined;
-
-type BuildRouteHrefSearch = Record<string, SearchValue>;
-
 export type BuildRouteHrefTarget<Path extends RoutePath> = {
   to: Path;
-  search?: BuildRouteHrefSearch;
+  search?: RouteSearch<Path>;
   hash?: string;
 } & (keyof RouteParamsInput<Path> extends never
   ? { params?: never }
   : { params: RouteParamsInput<Path> });
-
-const serializeSearch = (search: BuildRouteHrefSearch | undefined): string => {
-  if (search === undefined) {
-    return '';
-  }
-  const searchParams = new URLSearchParams();
-  for (const [key, value] of Object.entries(search)) {
-    if (value === undefined) {
-      continue;
-    }
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        searchParams.append(key, item);
-      }
-    } else {
-      searchParams.append(key, value as string);
-    }
-  }
-  return searchParams.toString();
-};
 
 /**
  * Build an href string from a route path, params, search, and hash.
@@ -57,10 +35,11 @@ const serializeSearch = (search: BuildRouteHrefSearch | undefined): string => {
  */
 export const buildRouteHref = <Path extends RoutePath>(
   target: BuildRouteHrefTarget<Path>,
+  resolveCodec?: (routePath: string) => Unstable_SearchCodec<any> | undefined,
 ): string => {
   const { to, search, hash, params } = target as {
     to: string;
-    search?: BuildRouteHrefSearch;
+    search?: Record<string, unknown>;
     hash?: string;
     params?: Record<string, string | readonly string[]>;
   };
@@ -91,7 +70,16 @@ export const buildRouteHref = <Path extends RoutePath>(
   if (!getPathMapping(pathSpec, pathname)) {
     throw new Error(`Cannot build "${to}" with the given params`);
   }
-  const query = serializeSearch(search);
+  let query = '';
+  if (search !== undefined) {
+    const codec = resolveCodec?.(to);
+    if (!codec) {
+      throw new Error(
+        `Cannot serialize "search" for "${to}": no search codec resolved. Provide it via <Unstable_SearchCodecsProvider> in a module rendered on every page (e.g. your root layout) so navigation can serialize it.`,
+      );
+    }
+    query = codec.serialize(search);
+  }
   return (
     pathname +
     (query ? '?' + query : '') +

--- a/packages/waku/src/router/client-utils/search-codec-registry.ts
+++ b/packages/waku/src/router/client-utils/search-codec-registry.ts
@@ -1,0 +1,26 @@
+import type { Unstable_SearchCodec } from '../create-pages-utils/inferred-path-types.js';
+
+export type AnyCodec = Unstable_SearchCodec<any>;
+
+export const isCodec = (value: unknown): value is AnyCodec =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as AnyCodec).id === 'string' &&
+  typeof (value as AnyCodec).parse === 'function' &&
+  typeof (value as AnyCodec).serialize === 'function';
+
+/**
+ * Resolve a route path to its search codec id, using the `route -> codec id`
+ * map that define-router ships as `globalThis.__WAKU_ROUTER_SEARCH_CODECS__`.
+ * Lets `push`/`Link` serialize `search` for any route, not just the current one.
+ */
+export const getRouteSearchCodecId = (
+  routePath: string,
+): string | undefined => {
+  const map = (
+    globalThis as {
+      __WAKU_ROUTER_SEARCH_CODECS__?: Record<string, string>;
+    }
+  ).__WAKU_ROUTER_SEARCH_CODECS__;
+  return map?.[routePath];
+};

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -42,6 +42,11 @@ import type {
 } from './client-utils/build-route-href.js';
 import { matchRouteParams } from './client-utils/match-route-params.js';
 import {
+  type AnyCodec,
+  getRouteSearchCodecId,
+  isCodec,
+} from './client-utils/search-codec-registry.js';
+import {
   ETAG_ID_PREFIX,
   HAS404_ID,
   IS_STATIC_ID,
@@ -52,7 +57,10 @@ import {
   pathnameToRoutePath,
 } from './common-utils/route-path.js';
 import type { RouteProps } from './common-utils/route-path.js';
-import type { RouteParams } from './create-pages-utils/inferred-path-types.js';
+import type {
+  RouteParams,
+  RouteSearch,
+} from './create-pages-utils/inferred-path-types.js';
 
 type AllowTrailingSlash<Path extends string> = Path extends '/'
   ? Path
@@ -244,6 +252,21 @@ const RouterContext = createContext<{
   fetchingSlices: Set<SliceId>;
 } | null>(null);
 
+const SearchCodecsContext = createContext<ReadonlyMap<string, AnyCodec>>(
+  new Map(),
+);
+
+const useResolveSearchCodec = () => {
+  const codecs = useContext(SearchCodecsContext);
+  return useCallback(
+    (routePath: string): AnyCodec | undefined => {
+      const id = getRouteSearchCodecId(routePath);
+      return id !== undefined ? codecs.get(id) : undefined;
+    },
+    [codecs],
+  );
+};
+
 export function useRouter() {
   const router = useContext(RouterContext);
   if (!router) {
@@ -251,12 +274,14 @@ export function useRouter() {
   }
 
   const { route, changeRoute, prefetchRoute } = router;
+  const resolveCodec = useResolveSearchCodec();
   const push = useCallback(
     async (
       to: InferredPaths | BuildRouteHrefTarget<RoutePath>,
       options?: NavigateOptions,
     ) => {
-      const href = typeof to === 'string' ? to : buildRouteHref(to);
+      const href =
+        typeof to === 'string' ? to : buildRouteHref(to, resolveCodec);
       const url = new URL(
         addBase(href, import.meta.env.WAKU_CONFIG_BASE_PATH),
         window.location.href,
@@ -267,14 +292,15 @@ export function useRouter() {
         url,
       });
     },
-    [changeRoute],
+    [changeRoute, resolveCodec],
   ) as Navigate;
   const replace = useCallback(
     async (
       to: InferredPaths | BuildRouteHrefTarget<RoutePath>,
       options?: NavigateOptions,
     ) => {
-      const href = typeof to === 'string' ? to : buildRouteHref(to);
+      const href =
+        typeof to === 'string' ? to : buildRouteHref(to, resolveCodec);
       const url = new URL(
         addBase(href, import.meta.env.WAKU_CONFIG_BASE_PATH),
         window.location.href,
@@ -285,7 +311,7 @@ export function useRouter() {
         url,
       });
     },
-    [changeRoute],
+    [changeRoute, resolveCodec],
   ) as Navigate;
   const reload = useCallback(async () => {
     const url = new URL(window.location.href);
@@ -332,6 +358,107 @@ export function useParams_UNSTABLE<Path extends RoutePath>({
 }): RouteParams<Path> | null {
   const { path } = useRouter();
   return useMemo(() => matchRouteParams(from, path), [from, path]);
+}
+
+/**
+ * Provide search codecs to `useSearch_UNSTABLE`, `useSetSearch_UNSTABLE`,
+ * `push`, and `Link`. Render it in your root layout so the codecs are present in
+ * both the SSR render and the browser. Accepts a module namespace, a record, or
+ * an array; only codec-shaped values are kept.
+ */
+export function Unstable_SearchCodecsProvider({
+  searchCodecs,
+  children,
+}: {
+  searchCodecs: Record<string, unknown> | readonly unknown[];
+  children: ReactNode;
+}): ReactElement {
+  const codecs = useMemo(() => {
+    const map = new Map<string, AnyCodec>();
+    const values = Array.isArray(searchCodecs)
+      ? searchCodecs
+      : Object.values(searchCodecs);
+    for (const value of values) {
+      if (isCodec(value)) {
+        map.set(value.id, value);
+      }
+    }
+    return map;
+  }, [searchCodecs]);
+  return <SearchCodecsContext value={codecs}>{children}</SearchCodecsContext>;
+}
+
+/**
+ * Read the current route's typed `search`, parsed client-side with the route's
+ * codec (provided via `Unstable_SearchCodecsProvider`), or null when the current
+ * path does not match `from` or the route has no codec. Re-renders when the
+ * query changes.
+ */
+export function useSearch_UNSTABLE<Path extends RoutePath>({
+  from,
+}: {
+  from: Path;
+}): RouteSearch<Path> | null {
+  const { path, query } = useRouter();
+  const codecs = useContext(SearchCodecsContext);
+  return useMemo(() => {
+    if (matchRouteParams(from, path) === null) {
+      return null;
+    }
+    const codecId = getRouteSearchCodecId(from);
+    const codec = codecId !== undefined ? codecs.get(codecId) : undefined;
+    return codec ? (codec.parse(query) as RouteSearch<Path>) : null;
+  }, [from, path, query, codecs]);
+}
+
+type SetSearch<Path extends RoutePath> = (
+  update:
+    | Partial<RouteSearch<Path>>
+    | ((prev: RouteSearch<Path>) => Partial<RouteSearch<Path>>),
+  options?: { history?: 'push' | 'replace'; scroll?: boolean },
+) => Promise<void>;
+
+/**
+ * Returns a setter for the current route's `search`, serialized client-side with
+ * the route's codec (provided via `Unstable_SearchCodecsProvider`). Accepts a
+ * partial or an updater of the current search and navigates (push by default, or
+ * replace) to the same path. A no-op when the current path does not match `from`
+ * or has no codec.
+ */
+export function useSetSearch_UNSTABLE<Path extends RoutePath>({
+  from,
+}: {
+  from: Path;
+}): SetSearch<Path> {
+  const router = useContext(RouterContext);
+  if (!router) {
+    throw new Error('Missing Router');
+  }
+  const { route, changeRoute } = router;
+  const codecs = useContext(SearchCodecsContext);
+  return useCallback<SetSearch<Path>>(
+    async (update, options) => {
+      if (matchRouteParams(from, route.path) === null) {
+        return;
+      }
+      const codecId = getRouteSearchCodecId(from);
+      const codec = codecId !== undefined ? codecs.get(codecId) : undefined;
+      if (!codec) {
+        return;
+      }
+      const prev = codec.parse(route.query) as RouteSearch<Path>;
+      const partial = typeof update === 'function' ? update(prev) : update;
+      const nextQuery = codec.serialize({ ...prev, ...partial });
+      const url = new URL(window.location.href);
+      url.search = nextQuery;
+      await changeRoute(parseRoute(url), {
+        shouldScroll: options?.scroll ?? false,
+        mode: options?.history ?? 'push',
+        url,
+      });
+    },
+    [from, route.path, route.query, codecs, changeRoute],
+  );
 }
 
 function useSharedRef<T>(
@@ -384,8 +511,8 @@ const NavigationStatusContext = createContext<NavigationStatus>({});
 export const useNavigationStatus_UNSTABLE = (): NavigationStatus =>
   useContext(NavigationStatusContext);
 
-export type LinkProps = {
-  to: InferredPaths;
+export type LinkProps<Path extends RoutePath> = {
+  to: InferredPaths | BuildRouteHrefTarget<Path>;
   children: ReactNode;
   /**
    * indicates if the link should scroll or not on navigation
@@ -406,7 +533,7 @@ export type LinkProps = {
   ref?: Ref<HTMLAnchorElement> | undefined;
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
 
-export function Link({
+export function Link<Path extends RoutePath>({
   to,
   children,
   scroll,
@@ -415,8 +542,10 @@ export function Link({
   unstable_startTransition,
   ref: refProp,
   ...props
-}: LinkProps): ReactElement {
-  const resolvedTo = addBase(to, import.meta.env.WAKU_CONFIG_BASE_PATH);
+}: LinkProps<Path>): ReactElement {
+  const resolveCodec = useResolveSearchCodec();
+  const href = typeof to === 'string' ? to : buildRouteHref(to, resolveCodec);
+  const resolvedTo = addBase(href, import.meta.env.WAKU_CONFIG_BASE_PATH);
   const router = useContext(RouterContext);
   const changeRoute = router
     ? router.changeRoute

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -363,8 +363,10 @@ export function useParams_UNSTABLE<Path extends RoutePath>({
 /**
  * Provide search codecs to `useSearch_UNSTABLE`, `useSetSearch_UNSTABLE`,
  * `push`, and `Link`. Render it in your root layout so the codecs are present in
- * both the SSR render and the browser. Accepts a module namespace, a record, or
- * an array; only codec-shaped values are kept.
+ * both the SSR render and the browser. Pass only search codecs: a codec-only
+ * module (via `import * as`), a record, or an array. A value that is not a codec
+ * is ignored with a warning, so keep helpers and constants out of the module you
+ * pass (or list the codecs explicitly).
  */
 export function Unstable_SearchCodecsProvider({
   searchCodecs,
@@ -379,13 +381,18 @@ export function Unstable_SearchCodecsProvider({
       ? searchCodecs
       : Object.values(searchCodecs);
     for (const value of values) {
-      if (isCodec(value)) {
-        const existing = map.get(value.id);
-        if (existing && existing !== value) {
-          throw new Error(`Duplicate search codec id: "${value.id}"`);
-        }
-        map.set(value.id, value);
+      if (!isCodec(value)) {
+        console.warn(
+          'Unstable_SearchCodecsProvider ignored a value that is not a search codec; pass only codecs (a codec-only module or an explicit array).',
+          value,
+        );
+        continue;
       }
+      const existing = map.get(value.id);
+      if (existing && existing !== value) {
+        throw new Error(`Duplicate search codec id: "${value.id}"`);
+      }
+      map.set(value.id, value);
     }
     return map;
   }, [searchCodecs]);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -380,6 +380,10 @@ export function Unstable_SearchCodecsProvider({
       : Object.values(searchCodecs);
     for (const value of values) {
       if (isCodec(value)) {
+        const existing = map.get(value.id);
+        if (existing && existing !== value) {
+          throw new Error(`Duplicate search codec id: "${value.id}"`);
+        }
         map.set(value.id, value);
       }
     }

--- a/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
+++ b/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
@@ -1,3 +1,4 @@
+import type { SearchCodecsConfig } from '../base-types.js';
 import type { RouteProps } from '../common-utils/route-path.js';
 import type { PathWithoutSlug } from '../create-pages.js';
 import type { Join, Prettify, ReplaceAll, Split } from './util-types.js';
@@ -199,7 +200,7 @@ type SlugTypes<Path extends string> =
       }
     : never;
 
-/** Extracts route parameters from a route path pattern. */
+/** Extracts route parameters from a route path. */
 export type RouteParams<Path extends string> = Prettify<SlugTypes<Path>>;
 
 /** Context object passed to API route handlers with typed route parameters. */
@@ -207,9 +208,51 @@ export interface ApiContext<Path extends string> {
   readonly params: RouteParams<Path>;
 }
 
+/**
+ * Bring-your-own search-params codec: converts the URL's `query` string to a
+ * typed `search` object and back, identified by a stable `id`. Waku provides
+ * this contract and the integration; the implementation (a library, an adapter
+ * for nuqs/zod, or a hand-written object) lives outside core. `parse` may throw
+ * to reject a malformed query (the framework turns it into a 400).
+ */
+export type Unstable_SearchCodec<Search extends Record<string, unknown>> = {
+  id: string;
+  parse: (query: string) => Search;
+  serialize: (search: Search) => string;
+};
+
+/** The typed `search` for a route path, or `never` if none. */
+export type RouteSearch<Path extends string> =
+  Path extends keyof SearchCodecsConfig
+    ? SearchCodecsConfig[Path] extends Unstable_SearchCodec<infer Search>
+      ? Search
+      : never
+    : never;
+
+/**
+ * Builds the `SearchCodecsConfig` augmentation from a `Page` union: maps each
+ * page that declared `unstable_searchCodec` in getConfig to its codec, keyed by
+ * path. Used by the fs-router typegen.
+ */
+export type SearchCodecsForPages<Pages> = {
+  [Page in Extract<Pages, { unstable_searchCodec: unknown }> as Page extends {
+    path: infer Path extends string;
+  }
+    ? Path
+    : never]: Page extends { unstable_searchCodec: infer Codec }
+    ? Codec
+    : never;
+};
+
+/** A `search` prop, present only when the route has a search codec. */
+type SearchProps<Path extends string> = [RouteSearch<Path>] extends [never]
+  ? {}
+  : { search: RouteSearch<Path> };
+
 export type PropsForPages<Path extends string> = Prettify<
   Omit<RouteProps<ReplaceAll<Path, `[${string}]`, string>>, 'hash'> &
-    SlugTypes<Path>
+    SlugTypes<Path> &
+    SearchProps<Path>
 >;
 
 type GetResponseType<Response extends { render: string }> =

--- a/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
+++ b/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
@@ -213,7 +213,9 @@ export interface ApiContext<Path extends string> {
  * typed `search` object and back, identified by a stable `id`. Waku provides
  * this contract and the integration; the implementation (a library, an adapter
  * for nuqs/zod, or a hand-written object) lives outside core. `parse` may throw
- * to reject a malformed query (the framework turns it into a 400).
+ * to reject a malformed query (the framework turns it into a 400). `serialize`
+ * must return an already URL-encoded query string (e.g. via
+ * `URLSearchParams.toString()`); it is placed after `?` in the href as-is.
  */
 export type Unstable_SearchCodec<Search extends Record<string, unknown>> = {
   id: string;

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import type { FunctionComponent, ReactElement, ReactNode } from 'react';
 import { getGrouplessPath } from '../lib/utils/create-pages.js';
+import { createCustomError } from '../lib/utils/custom-errors.js';
 import {
   countSlugsAndWildcards,
   getPathMapping,
@@ -17,6 +18,7 @@ import type {
   AnyPage,
   GetSlugs,
   PropsForPages,
+  Unstable_SearchCodec,
 } from './create-pages-utils/inferred-path-types.js';
 import { unstable_defineRouter } from './define-router.js';
 import type { ApiHandler, HandlerInterceptor } from './define-router.js';
@@ -66,6 +68,17 @@ const assertStaticPathArity = (
 
 const getPageSlotId = (routePath: string) => `page:${routePath}`;
 const getLayoutSlotId = (layoutIdPath: string) => `layout:${layoutIdPath}`;
+
+const parseSearchOrThrow = (
+  codec: Unstable_SearchCodec<any>,
+  query: string,
+): Record<string, unknown> => {
+  try {
+    return codec.parse(query);
+  } catch {
+    throw createCustomError('Bad Request', { status: 400 });
+  }
+};
 
 const forEachConcreteStaticPath = (
   routePathSpec: PathSpec,
@@ -228,6 +241,14 @@ export type CreatePage = <
      * pages.
      */
     unstable_getEtag?: GetEtag<PropsForPages<Path>>;
+    /**
+     * Bring-your-own search-params codec for this route. The server parses the
+     * `query` with it (rejecting a malformed query as 400 and injecting a typed
+     * `search` prop); its `id` is sent to the client to resolve the same codec
+     * for `useSearch`/`push`. The route's `search` type is declared separately
+     * via the `SearchCodecsConfig` augmentation (or fs-router typegen).
+     */
+    unstable_searchCodec?: Unstable_SearchCodec<any>;
   },
 ) => Omit<
   Extract<
@@ -485,6 +506,7 @@ export const createPages = <
     noSsr: boolean;
     sourceFile?: string | undefined;
     getEtag?: GetEtag<Props> | undefined;
+    searchCodec?: Unstable_SearchCodec<any> | undefined;
   };
   type LayoutEntry<Props = any> = {
     routePathSpec: PathSpec;
@@ -621,6 +643,7 @@ export const createPages = <
     const slices = page.slices || [];
     const sourceFile = page.unstable_sourceFile;
     const getEtag = page.unstable_getEtag;
+    const searchCodec = page.unstable_searchCodec;
 
     const registerPageWithExactPath = () => {
       const routePath = pageRoutePath;
@@ -640,6 +663,7 @@ export const createPages = <
           noSsr,
           sourceFile,
           getEtag,
+          searchCodec,
         });
       }
       sliceIdsByRoutePath.set(routePath, slices);
@@ -702,6 +726,7 @@ export const createPages = <
         noSsr,
         sourceFile,
         getEtag,
+        searchCodec,
       });
       sliceIdsByRoutePath.set(routePath, slices);
     };
@@ -717,6 +742,7 @@ export const createPages = <
         noSsr,
         sourceFile,
         getEtag,
+        searchCodec,
       });
       sliceIdsByRoutePath.set(routePath, slices);
     };
@@ -1021,6 +1047,7 @@ export const createPages = <
         isStatic: boolean,
         sourceFile?: string,
         getEtag?: GetEtag<Props>,
+        searchCodec?: Unstable_SearchCodec<any>,
       ): ElementSpec =>
         buildElementSpec(
           component,
@@ -1028,6 +1055,11 @@ export const createPages = <
             ({
               ...getPropsMapping(option.routePath),
               ...(option.query ? { query: option.query } : {}),
+              ...(searchCodec
+                ? {
+                    search: parseSearchOrThrow(searchCodec, option.query ?? ''),
+                  }
+                : {}),
               path: option.routePath,
             }) as unknown as Props,
           isStatic,
@@ -1107,6 +1139,7 @@ export const createPages = <
           noSsr,
           sourceFile,
           getEtag,
+          searchCodec,
         }: DynamicPageEntry,
       ) => {
         const layouts = collectLayoutMatches(routePathSpec);
@@ -1119,14 +1152,18 @@ export const createPages = <
           false,
           sourceFile,
           getEtag,
+          searchCodec,
         );
-        return buildRouteConfigBase(
-          routePath,
-          routePathSpec,
-          layouts,
-          elements,
-          noSsr,
-        );
+        return {
+          ...buildRouteConfigBase(
+            routePath,
+            routePathSpec,
+            layouts,
+            elements,
+            noSsr,
+          ),
+          ...(searchCodec ? { searchCodecId: searchCodec.id } : {}),
+        };
       };
       const buildDynamicRouteConfigs = () =>
         Array.from(dynamicPageEntryByRoutePath, ([routePath, entry]) =>

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -75,8 +75,10 @@ const parseSearchOrThrow = (
 ): Record<string, unknown> => {
   try {
     return codec.parse(query);
-  } catch {
-    throw createCustomError('Bad Request', { status: 400 });
+  } catch (cause) {
+    const err = createCustomError('Bad Request', { status: 400 });
+    err.cause = cause;
+    throw err;
   }
 };
 
@@ -644,6 +646,11 @@ export const createPages = <
     const sourceFile = page.unstable_sourceFile;
     const getEtag = page.unstable_getEtag;
     const searchCodec = page.unstable_searchCodec;
+    if (searchCodec && page.render === 'static') {
+      throw new Error(
+        `unstable_searchCodec is not supported on a static route (${page.path}); search params need a per-request query, so use render: 'dynamic'.`,
+      );
+    }
 
     const registerPageWithExactPath = () => {
       const routePath = pageRoutePath;

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -549,8 +549,10 @@ const setupRouterSearchCodecs = (configs: readonly RuntimeConfig[]) => {
   (
     globalThis as { __WAKU_ROUTER_SEARCH_CODECS__?: Record<string, string> }
   ).__WAKU_ROUTER_SEARCH_CODECS__ = routePath2searchCodecId;
+  // escape `<` so the value cannot break out of the inline <script>
+  const json = JSON.stringify(routePath2searchCodecId).replace(/</g, '\\u003c');
   return `
-globalThis.__WAKU_ROUTER_SEARCH_CODECS__ = ${JSON.stringify(routePath2searchCodecId)};
+globalThis.__WAKU_ROUTER_SEARCH_CODECS__ = ${json};
 `;
 };
 

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -285,6 +285,7 @@ type RouteConfig = {
   >;
   noSsr?: boolean;
   slices?: string[];
+  searchCodecId?: string;
 };
 
 type ApiConfig = {
@@ -464,6 +465,9 @@ const mergeWithRuntimeConfigs = (
         elements,
         ...(c.noSsr !== undefined ? { noSsr: c.noSsr } : {}),
         ...(c.slices !== undefined ? { slices: c.slices } : {}),
+        ...(c.searchCodecId !== undefined
+          ? { searchCodecId: c.searchCodecId }
+          : {}),
       };
     }
     if (c.type === 'api') {
@@ -513,6 +517,40 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path, callback) => {
     callback(ids[idx]);
   }
 };
+`;
+};
+
+const buildRoutePath2searchCodecId = (
+  configs: readonly RuntimeConfig[],
+): Record<string, string> => {
+  const routePath2searchCodecId: Record<string, string> = {};
+  for (const item of configs) {
+    if (item.type === 'route' && item.searchCodecId !== undefined) {
+      routePath2searchCodecId[pathSpecAsString(item.pathPattern ?? item.path)] =
+        item.searchCodecId;
+    }
+  }
+  return routePath2searchCodecId;
+};
+
+// Sets the `route -> search codec id` map on the server's globalThis AND returns
+// the browser script that sets it client-side. The server copy is needed because
+// a cross-route <Link> serializes its href during SSR, where the injected
+// browser script has not run yet.
+//
+// NOTE: this assumes the `rsc` and `ssr` environments share one process global
+// (true for the default single-process runtime). An adapter that runs them in
+// separate isolates would not see this server copy during SSR.
+const setupRouterSearchCodecs = (configs: readonly RuntimeConfig[]) => {
+  const routePath2searchCodecId = buildRoutePath2searchCodecId(configs);
+  if (Object.keys(routePath2searchCodecId).length === 0) {
+    return '';
+  }
+  (
+    globalThis as { __WAKU_ROUTER_SEARCH_CODECS__?: Record<string, string> }
+  ).__WAKU_ROUTER_SEARCH_CODECS__ = routePath2searchCodecId;
+  return `
+globalThis.__WAKU_ROUTER_SEARCH_CODECS__ = ${JSON.stringify(routePath2searchCodecId)};
 `;
 };
 
@@ -958,7 +996,9 @@ export function unstable_defineRouter(fns: {
             formState,
             status,
             ...(nonce ? { nonce } : {}),
-            unstable_extraScriptContent: getRouterPrefetchCode(path2moduleIds),
+            unstable_extraScriptContent:
+              getRouterPrefetchCode(path2moduleIds) +
+              setupRouterSearchCodecs(getCachedConfigs()),
           });
         };
         const query = url.searchParams.toString();
@@ -1157,7 +1197,8 @@ export function unstable_defineRouter(fns: {
               const res = await renderHtml(stream2, html, {
                 rscPath,
                 unstable_extraScriptContent:
-                  getRouterPrefetchCode(path2moduleIds),
+                  getRouterPrefetchCode(path2moduleIds) +
+                  setupRouterSearchCodecs(configs),
               });
               await generateFile(
                 routePathToHtmlFilePath(routePath),

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -1,6 +1,7 @@
 import type { FunctionComponent, ReactNode } from 'react';
 import type { ImportGlobFunction } from 'vite/types/importGlob.d.ts';
 import { isIgnoredPath } from '../lib/utils/fs-router.js';
+import type { Unstable_SearchCodec } from './create-pages-utils/inferred-path-types.js';
 import { METHODS, createPages } from './create-pages.js';
 import type { Method } from './create-pages.js';
 import type { HandlerInterceptor } from './define-router.js';
@@ -90,6 +91,7 @@ export function fsRouter(
           getConfig?: () => Promise<{
             render?: 'static' | 'dynamic';
             unstable_getEtag?: (props?: any) => Promise<string | undefined>;
+            unstable_searchCodec?: Unstable_SearchCodec<any>;
           }>;
           GET?: (req: Request) => Promise<Response>;
         };

--- a/packages/waku/tests/build-route-href.test.ts
+++ b/packages/waku/tests/build-route-href.test.ts
@@ -1,6 +1,32 @@
 import { describe, expect, test } from 'vitest';
 import { buildRouteHref } from '../src/router/client-utils/build-route-href.js';
 
+type Search = { tab: string; page: number };
+
+const codec = {
+  id: 'href-test',
+  parse: (query: string): Search => {
+    const sp = new URLSearchParams(query);
+    return { tab: sp.get('tab') ?? '', page: Number(sp.get('page')) || 1 };
+  },
+  serialize: (search: Search) =>
+    new URLSearchParams({
+      tab: search.tab,
+      page: String(search.page),
+    }).toString(),
+} as const;
+
+declare module '../src/router/base-types.js' {
+  interface SearchCodecsConfig {
+    '/href-search': typeof codec;
+    '/p/[slug]': typeof codec;
+  }
+}
+
+// A codec resolver, as push/Link build it from <Unstable_SearchCodecsProvider>.
+const resolveCodec = (routePath: string) =>
+  routePath === '/href-search' || routePath === '/p/[slug]' ? codec : undefined;
+
 describe('buildRouteHref', () => {
   test('static routes', () => {
     expect(buildRouteHref({ to: '/' })).toBe('/');
@@ -44,22 +70,26 @@ describe('buildRouteHref', () => {
     expect(buildRouteHref({ to: '/(marketing)/about' })).toBe('/about');
   });
 
-  test('serializes an object search', () => {
+  test('serializes search via the resolved codec', () => {
     expect(
-      buildRouteHref({
-        to: '/about',
-        search: { page: '2', q: 'x', ok: 'true' },
-      }),
-    ).toBe('/about?page=2&q=x&ok=true');
+      buildRouteHref(
+        { to: '/href-search', search: { tab: 'x', page: 2 } },
+        resolveCodec,
+      ),
+    ).toBe('/href-search?tab=x&page=2');
   });
 
-  test('omits undefined search and supports arrays', () => {
-    expect(
-      buildRouteHref({
-        to: '/about',
-        search: { a: undefined, tag: ['x', 'y'] },
-      }),
-    ).toBe('/about?tag=x&tag=y');
+  test('throws when search is passed but no codec resolves', () => {
+    expect(() =>
+      buildRouteHref(
+        {
+          to: '/about',
+          // @ts-expect-error a route without a codec cannot pass search
+          search: { a: '1' },
+        },
+        resolveCodec,
+      ),
+    ).toThrow(/no search codec/);
   });
 
   test('appends a hash with or without a leading #', () => {
@@ -69,13 +99,16 @@ describe('buildRouteHref', () => {
 
   test('combines params, search, and hash', () => {
     expect(
-      buildRouteHref({
-        to: '/posts/[slug]',
-        params: { slug: 'hello' },
-        search: { tab: 'comments' },
-        hash: 'reply',
-      }),
-    ).toBe('/posts/hello?tab=comments#reply');
+      buildRouteHref(
+        {
+          to: '/p/[slug]',
+          params: { slug: 'hello' },
+          search: { tab: 'comments', page: 1 },
+          hash: 'reply',
+        },
+        resolveCodec,
+      ),
+    ).toBe('/p/hello?tab=comments&page=1#reply');
   });
 
   test('throws on a missing param', () => {
@@ -98,14 +131,23 @@ describe('buildRouteHref types', () => {
       buildRouteHref({ to: '/about', params: { slug: 'a' } });
       // @ts-expect-error unknown param name
       buildRouteHref({ to: '/posts/[slug]', params: { id: 'a' } });
-      buildRouteHref({ to: '/about', search: { page: '2', tags: ['a', 'b'] } });
-      buildRouteHref({ to: '/about', search: { page: undefined } });
-      // @ts-expect-error search values must be strings, not numbers
-      buildRouteHref({ to: '/about', search: { page: 2 } });
-      // @ts-expect-error search values are not nullable (use undefined to omit)
-      buildRouteHref({ to: '/about', search: { page: null } });
-      // @ts-expect-error search must be an object, not a query string
-      buildRouteHref({ to: '/about', search: 'page=2' });
+    };
+    expect(typeof assertTypes).toBe('function');
+  });
+
+  test('search is typed by the route codec', () => {
+    const assertTypes = () => {
+      buildRouteHref({ to: '/href-search', search: { tab: 'x', page: 2 } });
+      buildRouteHref({
+        to: '/href-search',
+        // @ts-expect-error search must match the codec's shape
+        search: { tab: 'x' },
+      });
+      buildRouteHref({
+        to: '/about',
+        // @ts-expect-error a route without a codec cannot pass search
+        search: { a: '1' },
+      });
     };
     expect(typeof assertTypes).toBe('function');
   });

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -3,6 +3,7 @@ import { expectType } from 'ts-expect';
 import type { TypeEqual } from 'ts-expect';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MockedFunction } from 'vitest';
+import { getErrorInfo } from '../src/lib/utils/custom-errors.js';
 import { parsePathWithSlug } from '../src/lib/utils/path.js';
 import { Children } from '../src/minimal/client.js';
 import type { PathsForPages } from '../src/router/base-types.js';
@@ -3319,6 +3320,60 @@ describe('createPages - grouped paths', () => {
     expect(element.props.section).toBe('docs');
     expect(element.props.slug).toBeUndefined();
     expect(element.props.children.type).toBe(Children);
+  });
+});
+
+describe('createPages search codec', () => {
+  it('injects parsed props.search and 400s on a malformed query', async () => {
+    type S = { page: number };
+    const codec = {
+      id: 'search-test',
+      parse: (query: string): S => {
+        const v = new URLSearchParams(query).get('page');
+        if (v === 'bad') {
+          throw new Error('invalid');
+        }
+        return { page: Number(v) || 1 };
+      },
+      serialize: (s: S) => `page=${s.page}`,
+    } as const;
+    createPages(async ({ createPage }) => [
+      createPage({
+        render: 'dynamic',
+        path: '/search-test',
+        component: () => null,
+        unstable_searchCodec: codec,
+      }),
+    ]);
+    const { getConfigs } = injectedFunctions();
+    const configs = Array.from(await getConfigs()) as any[];
+    const routeConfig = configs.find(
+      (config) =>
+        config.type === 'route' && config.path?.[0]?.name === 'search-test',
+    );
+    // the codec id rides the route config; the client resolves it via the
+    // route -> codec id map (__WAKU_ROUTER_SEARCH_CODECS__) for both the search
+    // hooks and push/Link
+    expect(routeConfig.searchCodecId).toBe('search-test');
+    const pageEl = routeConfig.elements['page:/search-test'];
+    // parsed search is injected from the query
+    expect(
+      pageEl.renderer({ routePath: '/search-test', query: 'page=2' }).props
+        .search,
+    ).toEqual({ page: 2 });
+    // default search when there is no query
+    expect(
+      pageEl.renderer({ routePath: '/search-test', query: undefined }).props
+        .search,
+    ).toEqual({ page: 1 });
+    // a thrown parse becomes a 400
+    let thrown: unknown;
+    try {
+      pageEl.renderer({ routePath: '/search-test', query: 'page=bad' });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(getErrorInfo(thrown)?.status).toBe(400);
   });
 });
 

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -3374,6 +3374,29 @@ describe('createPages search codec', () => {
       thrown = e;
     }
     expect(getErrorInfo(thrown)?.status).toBe(400);
+    // the original parse error is preserved as the cause
+    expect((thrown as { cause?: Error }).cause?.message).toBe('invalid');
+  });
+
+  it('rejects unstable_searchCodec on a static route', async () => {
+    const codec = {
+      id: 'static-codec',
+      parse: () => ({}),
+      serialize: () => '',
+    } as const;
+    createPages(
+      async ({ createPage }) =>
+        [
+          createPage({
+            render: 'static',
+            path: '/static-search',
+            component: () => null,
+            unstable_searchCodec: codec,
+          }),
+        ] as never,
+    );
+    const { getConfigs } = injectedFunctions();
+    await expect(getConfigs()).rejects.toThrow(/static route/);
   });
 });
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -307,6 +307,22 @@ describe('router navigation method path typing', () => {
 });
 
 describe('router/client utilities', () => {
+  test('SearchCodecsProvider throws on a duplicate codec id', async () => {
+    const a = { id: 'dup', parse: () => ({}), serialize: () => '' } as const;
+    const b = {
+      id: 'dup',
+      parse: () => ({ x: 1 }),
+      serialize: () => '',
+    } as const;
+    await expect(
+      renderApp(
+        <Unstable_SearchCodecsProvider searchCodecs={[a, b]}>
+          <div />
+        </Unstable_SearchCodecsProvider>,
+      ),
+    ).rejects.toThrow(/Duplicate search codec id/);
+  });
+
   test('parses route path/query/hash and canonicalizes path from pathname', () => {
     const route = unstable_parseRoute(
       new URL('http://localhost/foo/index.html?count=2#hash'),

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -32,6 +32,7 @@ import {
   Router,
   unstable_RouterContext as RouterContext,
   Slice,
+  Unstable_SearchCodecsProvider,
   unstable_encodeRoutePath,
   unstable_encodeSliceId,
   unstable_getRouteSlotId,
@@ -49,6 +50,25 @@ import {
   ROUTE_ID,
   SKIP_HEADER,
 } from '../src/router/common-utils/route-path.js';
+
+const postsSearchCodec = {
+  id: 'posts-test',
+  parse: (query: string) => ({
+    tab: new URLSearchParams(query).get('tab') ?? '',
+  }),
+  serialize: (search: { tab: string }) =>
+    new URLSearchParams({ tab: search.tab }).toString(),
+} as const;
+
+declare module '../src/router/base-types.js' {
+  interface SearchCodecsConfig {
+    '/posts/[slug]': typeof postsSearchCodec;
+  }
+}
+
+(
+  globalThis as { __WAKU_ROUTER_SEARCH_CODECS__?: Record<string, string> }
+).__WAKU_ROUTER_SEARCH_CODECS__ = { '/posts/[slug]': 'posts-test' };
 
 type ElementsMap = Record<string, unknown>;
 type RouterApi = ReturnType<typeof useRouter>;
@@ -182,7 +202,11 @@ const renderRouter = async (
   elements: ElementsMap,
 ) => {
   testHoisted.elements = elements;
-  return renderApp(<Router {...(props || {})} />);
+  return renderApp(
+    <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+      <Router {...(props || {})} />
+    </Unstable_SearchCodecsProvider>,
+  );
 };
 
 const renderRouterInStrictMode = async (
@@ -192,7 +216,9 @@ const renderRouterInStrictMode = async (
   testHoisted.elements = elements;
   return renderApp(
     <StrictMode>
-      <Router {...(props || {})} />
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <Router {...(props || {})} />
+      </Unstable_SearchCodecsProvider>
     </StrictMode>,
   );
 };
@@ -465,17 +491,19 @@ describe('useRouter + Link with context', () => {
     };
 
     const view = await renderApp(
-      <RouterContext
-        value={{
-          route: { path: '/start', query: '', hash: '' },
-          changeRoute,
-          prefetchRoute: vi.fn(),
-          routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
-        }}
-      >
-        <Probe />
-      </RouterContext>,
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <RouterContext
+          value={{
+            route: { path: '/start', query: '', hash: '' },
+            changeRoute,
+            prefetchRoute: vi.fn(),
+            routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+            fetchingSlices: new Set(),
+          }}
+        >
+          <Probe />
+        </RouterContext>
+      </Unstable_SearchCodecsProvider>,
     );
 
     if (!capture.router) {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -323,6 +323,27 @@ describe('router/client utilities', () => {
     ).rejects.toThrow(/Duplicate search codec id/);
   });
 
+  test('SearchCodecsProvider warns on and ignores non-codec values', async () => {
+    const codec = {
+      id: 'real',
+      parse: () => ({}),
+      serialize: () => '',
+    } as const;
+    const notCodec = { id: 3, first: 'react', last: 'js' };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={{ codec, notCodec }}>
+        <div />
+      </Unstable_SearchCodecsProvider>,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('not a search codec'),
+      notCodec,
+    );
+    warn.mockRestore();
+    view.unmount();
+  });
+
   test('parses route path/query/hash and canonicalizes path from pathname', () => {
     const route = unstable_parseRoute(
       new URL('http://localhost/foo/index.html?count=2#hash'),

--- a/packages/waku/tests/search-params-types.test.ts
+++ b/packages/waku/tests/search-params-types.test.ts
@@ -1,0 +1,80 @@
+import { expectType } from 'ts-expect';
+import type { TypeEqual } from 'ts-expect';
+import { describe, expect, it } from 'vitest';
+import { buildRouteHref } from '../src/router/client-utils/build-route-href.js';
+import type {
+  PropsForPages,
+  RouteSearch,
+} from '../src/router/create-pages-utils/inferred-path-types.js';
+
+type Search = { page: number; nested: { a: string } };
+
+// A codec defined exactly as a user would: a plain object + `as const`.
+const typedSearchCodec = {
+  id: 'typed-search',
+  parse: (query: string): Search => ({
+    page: Number(new URLSearchParams(query).get('page')) || 1,
+    nested: { a: new URLSearchParams(query).get('a') ?? '' },
+  }),
+  serialize: (search: Search) =>
+    new URLSearchParams({
+      page: String(search.page),
+      a: search.nested.a,
+    }).toString(),
+} as const;
+
+// Registry populated from the codec's type (a hand-kept registry, or fs-router
+// typegen). A unique pattern avoids colliding with other tests.
+declare module '../src/router/base-types.js' {
+  interface SearchCodecsConfig {
+    '/typed-search/[id]': typeof typedSearchCodec;
+  }
+}
+
+describe('search params type foundation', () => {
+  it('an `as const` codec drives lookup, props.search, and push.search', () => {
+    // 1. lookup — Search extracted from the `as const` (readonly + literal id) codec
+    expectType<TypeEqual<RouteSearch<'/typed-search/[id]'>, Search>>(true);
+    expectType<TypeEqual<RouteSearch<'/no-codec'>, never>>(true);
+
+    // 2. props.search: a codec route's PropsForPages gains a typed `search`
+    type Props = PropsForPages<'/typed-search/[id]'>;
+    expectType<TypeEqual<Props['search'], Search>>(true);
+    expectType<TypeEqual<Props['id'], string>>(true);
+    // a codec-less route has no `search` key at all
+    type Plain = PropsForPages<'/plain/[id]'>;
+    expectType<TypeEqual<'search' extends keyof Plain ? true : false, false>>(
+      true,
+    );
+
+    // 3. push.search typed by `to`
+    const assertPush = () => {
+      buildRouteHref({
+        to: '/typed-search/[id]',
+        params: { id: 'x' },
+        search: { page: 2, nested: { a: 'y' } },
+      });
+      buildRouteHref({
+        to: '/typed-search/[id]',
+        params: { id: 'x' },
+        // @ts-expect-error search must match the route's codec
+        search: { page: 'two' },
+      });
+      buildRouteHref({
+        to: '/no-codec',
+        // @ts-expect-error a route without a codec cannot pass search
+        search: { page: 2 },
+      });
+    };
+    expect(typeof assertPush).toBe('function');
+
+    // runtime: the same codec round-trips
+    expect(typedSearchCodec.parse('page=2&a=x')).toEqual({
+      page: 2,
+      nested: { a: 'x' },
+    });
+    expect(
+      typedSearchCodec.serialize({ page: 2, nested: { a: 'x' } }),
+    ).toContain('page=2');
+  });
+});

--- a/packages/waku/tests/vite-plugin-fs-router-typegen.test.ts
+++ b/packages/waku/tests/vite-plugin-fs-router-typegen.test.ts
@@ -79,6 +79,11 @@ import type { getConfig as File_OneTwoThree_2_getConfig } from './pages/one_two_
 // prettier-ignore
 import type { getConfig as File_ØnéTwoThree_getConfig } from './pages/øné_two_three';`,
     );
+    // search codecs are derived from getConfig and augmented automatically
+    expect(generated).toContain('SearchCodecsForPages');
+    expect(generated).toContain(
+      'interface SearchCodecsConfig extends SearchCodecsForPages<Page> {}',
+    );
   });
 
   test('generates types when waku.server uses fsRouter (managed mode)', async () => {
@@ -161,6 +166,7 @@ import type { getConfig as File_ØnéTwoThree_getConfig } from './pages/øné_tw
 
     expect(generated).not.toContain('GetConfigResponse');
     expect(generated).not.toContain('_getConfig');
+    expect(generated).not.toContain('SearchCodecsConfig');
     expect(generated).not.toContain('\n\n\n');
     expect(generated).toContain("| { path: '/'; render: 'static' }");
     expect(generated).toContain("| { path: '/about'; render: 'static' }");


### PR DESCRIPTION
## Motivation

  The router already gives typed routes and params, but search params (the query string) stay untyped strings, so reading and writing them means hand-parsing and hand-serializing in every component and link, with no shared source of truth for a route's search shape. Apps also disagree on how search should be (de)serialized (plain strings, numbers, arrays, zod, nuqs-style), so a single built-in parser would not fit. This gives one typed shape per route across server, client, and navigation, while leaving the (de)serialization to a codec the app owns.

## Summary

Adds opt-in, type-safe URL search params to the router. A route declares a bring-your-own "search codec" that converts the URL's query string to a typed object and back. That single typed shape then flows everywhere the route's search is used: server components receive a parsed props.search (a rejected query becomes a 400), client components read and update it with useSearch_UNSTABLE / useSetSearch_UNSTABLE, and push / replace / Link accept a typed search for the target route. Routes without a codec have no search (it is never), and the plain URL string form still works for ad-hoc queries.

The codec is yours to implement (hand-written, or wrapping a library); Waku provides only the contract and the wiring. Types come from a SearchCodecsConfig augmentation that createPages users write by hand and fsRouter users get generated. All surface is unstable_ / _UNSTABLE.