### PR TITLE
feat(router): type-safe redirect

### DIFF
--- a/docs/guides/redirects-and-not-found.mdx
+++ b/docs/guides/redirects-and-not-found.mdx
@@ -46,6 +46,15 @@ export default async function AccountPage() {
 
 The default is `307`.
 
+`redirect` also accepts the same typed target as `router.push` / `router.replace` — a structured `{ to, params, search, hash }` — so a dynamic route's params and a route's typed `search` are checked and serialized for you:
+
+```tsx
+redirect({ to: '/posts/[slug]', params: { slug: post.slug } });
+redirect({ to: '/products', search: { q: 'waku', page: 1 } }, 303);
+```
+
+`search` is serialized with that route's search codec (see the [Typed Routes](/guides/typed-routes) guide).
+
 ## Redirect After a Server Action
 
 For form submissions and mutations, use `303` when the next page should be loaded with a `GET` request:

--- a/docs/guides/redirects-and-not-found.mdx
+++ b/docs/guides/redirects-and-not-found.mdx
@@ -46,7 +46,7 @@ export default async function AccountPage() {
 
 The default is `307`.
 
-`redirect` also accepts the same typed target as `router.push` / `router.replace` — a structured `{ to, params, search, hash }` — so a dynamic route's params and a route's typed `search` are checked and serialized for you:
+`redirect` also accepts the same typed target as `router.push` / `router.replace`: a structured `{ to, params, search, hash }`, so a dynamic route's params and a route's typed `search` are checked and serialized for you:
 
 ```tsx
 redirect({ to: '/posts/[slug]', params: { slug: post.slug } });

--- a/e2e/base-path.spec.ts
+++ b/e2e/base-path.spec.ts
@@ -73,6 +73,17 @@ test.describe(`base-path`, () => {
     });
   });
 
+  test('redirect Location carries basePath', async ({ request }) => {
+    // unstable_redirect('/static') must emit a base-prefixed Location so the
+    // browser stays within the app (the redirect is built app-relative)
+    const res = await request.get(
+      `http://localhost:${port}/custom/base/redirect`,
+      { maxRedirects: 0 },
+    );
+    expect(res.status()).toBe(307);
+    expect(res.headers()['location']).toBe('/custom/base/static');
+  });
+
   test('router', async ({ page }) => {
     const baseUrl = `http://localhost:${port}/custom/base/`;
     await page.goto(baseUrl);

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -199,6 +199,20 @@ test.describe(`create-pages`, () => {
     expect(html).toContain('/search?q=linked');
   });
 
+  test('search params (typed structured redirect serializes search via server codec)', async ({
+    page,
+  }) => {
+    // unstable_redirect({ to: '/search', search }) is typed against /search's
+    // codec and serialized server-side via the codec-instance registry; the
+    // browser follows the 307 to the built href.
+    await page.goto(`http://localhost:${port}/redirect-to-search`);
+    await waitForHydration(page);
+    await expect(page).toHaveURL(/\/search\?q=hi&page=2$/);
+    await expect(page.getByTestId('server-search')).toHaveText(
+      '{"q":"hi","page":2}',
+    );
+  });
+
   test('dynamic', async ({ page }) => {
     await page.goto(`http://localhost:${port}/dynamic`);
     await expect(page.getByRole('navigation')).toHaveText('Dynamic Layout');

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -213,6 +213,19 @@ test.describe(`create-pages`, () => {
     );
   });
 
+  test('search params (typed structured redirect to a dynamic route with a codec)', async ({
+    request,
+  }) => {
+    // resolves the codec for a dynamic route (/items/[id]) and serializes both
+    // params and search into the Location (catches a route-key normalization
+    // mismatch, which would otherwise throw instead of redirecting)
+    const res = await request.get(`http://localhost:${port}/redirect-to-item`, {
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(307);
+    expect(res.headers()['location']).toBe('/items/7?q=hi&page=2');
+  });
+
   test('dynamic', async ({ page }) => {
     await page.goto(`http://localhost:${port}/dynamic`);
     await expect(page.getByRole('navigation')).toHaveText('Dynamic Layout');

--- a/e2e/fixtures/base-path/src/pages/redirect.tsx
+++ b/e2e/fixtures/base-path/src/pages/redirect.tsx
@@ -1,0 +1,7 @@
+import { unstable_redirect as redirect } from 'waku/router/server';
+
+export default function RedirectPage() {
+  return redirect('/static');
+}
+
+export const getConfig = async () => ({ render: 'dynamic' as const });

--- a/e2e/fixtures/create-pages/src/components/RedirectToSearchPage.tsx
+++ b/e2e/fixtures/create-pages/src/components/RedirectToSearchPage.tsx
@@ -1,0 +1,7 @@
+import { unstable_redirect as redirect } from 'waku/router/server';
+
+export default function RedirectToSearchPage() {
+  // Typed structured target: `search` is checked against /search's codec and
+  // serialized server-side, exercising the server codec-instance registry.
+  return redirect({ to: '/search', search: { q: 'hi', page: 2 } });
+}

--- a/e2e/fixtures/create-pages/src/lib/search.ts
+++ b/e2e/fixtures/create-pages/src/lib/search.ts
@@ -18,5 +18,6 @@ demoSearchCodec satisfies Unstable_SearchCodec<DemoSearch>;
 declare module 'waku/router' {
   interface SearchCodecsConfig {
     '/search': typeof demoSearchCodec;
+    '/items/[id]': typeof demoSearchCodec;
   }
 }

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { Slice } from 'waku';
 import adapter from 'waku/adapters/default';
 import type { PathsForPages } from 'waku/router';
-import { createPages } from 'waku/router/server';
+import { createPages, unstable_redirect as redirect } from 'waku/router/server';
 import { DeeplyNestedLayout } from './components/DeeplyNestedLayout.js';
 import DynamicLayout from './components/DynamicLayout.js';
 import ErrorPage from './components/ErrorPage.js';
@@ -75,6 +75,26 @@ const pages: ReturnType<typeof createPages> = createPages(
       render: 'dynamic',
       path: '/redirect-to-search',
       component: RedirectToSearchPage,
+    }),
+
+    // a dynamic route that also has a search codec, to exercise the codec
+    // resolver for a slug route end to end (see /redirect-to-item)
+    createPage({
+      render: 'dynamic',
+      path: '/items/[id]',
+      component: () => <p>Item</p>,
+      unstable_searchCodec: demoSearchCodec,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/redirect-to-item',
+      component: () =>
+        redirect({
+          to: '/items/[id]',
+          params: { id: '7' },
+          search: { q: 'hi', page: 2 },
+        }),
     }),
 
     createPage({

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -17,6 +17,7 @@ import {
 import NestedBazPage from './components/NestedBazPage.js';
 import NestedLayout from './components/NestedLayout.js';
 import NoSsr from './components/NoSsr.js';
+import RedirectToSearchPage from './components/RedirectToSearchPage.js';
 import { RerenderActionPage } from './components/RerenderActionPage.js';
 import SearchPage from './components/SearchPage.js';
 import { Slice001 } from './components/slice001.js';
@@ -68,6 +69,12 @@ const pages: ReturnType<typeof createPages> = createPages(
       path: '/search',
       component: SearchPage,
       unstable_searchCodec: demoSearchCodec,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/redirect-to-search',
+      component: RedirectToSearchPage,
     }),
 
     createPage({

--- a/packages/waku/src/lib/vite-rsc/handler.ts
+++ b/packages/waku/src/lib/vite-rsc/handler.ts
@@ -89,9 +89,6 @@ const toProcessRequest =
       const body = stringToStream(message);
       const headers: { location?: string } = {};
       if (info?.location) {
-        // `unstable_redirect` returns an app-relative location; add basePath so
-        // it stays within the app (symmetric with removeBase on the incoming
-        // pathname). addBase is a no-op when basePath is '/'.
         headers.location = addBase(info.location, config.basePath);
       }
       return new Response(body, { status, headers });

--- a/packages/waku/src/lib/vite-rsc/handler.ts
+++ b/packages/waku/src/lib/vite-rsc/handler.ts
@@ -21,7 +21,7 @@ import type {
 } from '../types.js';
 import { getErrorInfo } from '../utils/custom-errors.js';
 import { sanitizeLog } from '../utils/log.js';
-import { joinPath } from '../utils/path.js';
+import { addBase, joinPath } from '../utils/path.js';
 import { DEBUG_ID_HEADER } from '../utils/react-debug-channel.js';
 import { createRenderUtils } from '../utils/render.js';
 import { getInput } from '../utils/request.js';
@@ -89,7 +89,10 @@ const toProcessRequest =
       const body = stringToStream(message);
       const headers: { location?: string } = {};
       if (info?.location) {
-        headers.location = info.location;
+        // `unstable_redirect` returns an app-relative location; add basePath so
+        // it stays within the app (symmetric with removeBase on the incoming
+        // pathname). addBase is a no-op when basePath is '/'.
+        headers.location = addBase(info.location, config.basePath);
       }
       return new Response(body, { status, headers });
     }

--- a/packages/waku/src/router/client-utils/match-route-params.ts
+++ b/packages/waku/src/router/client-utils/match-route-params.ts
@@ -1,7 +1,7 @@
 import { getGrouplessPath } from '../../lib/utils/create-pages.js';
 import { getPathMapping, parsePathWithSlug } from '../../lib/utils/path.js';
+import type { RoutePath } from '../common-utils/build-route-href.js';
 import type { RouteParams } from '../create-pages-utils/inferred-path-types.js';
-import type { RoutePath } from './build-route-href.js';
 
 const safeDecodeURIComponent = (value: string): string | null => {
   try {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -34,18 +34,18 @@ import {
   useElementsPromise_UNSTABLE as useElementsPromise,
   useRefetch,
 } from '../minimal/client.js';
-import type { RouteConfig } from './base-types.js';
-import { buildRouteHref } from './client-utils/build-route-href.js';
-import type {
-  BuildRouteHrefTarget,
-  RoutePath,
-} from './client-utils/build-route-href.js';
 import { matchRouteParams } from './client-utils/match-route-params.js';
 import {
   type AnyCodec,
   getRouteSearchCodecId,
   isCodec,
 } from './client-utils/search-codec-registry.js';
+import { buildRouteHref } from './common-utils/build-route-href.js';
+import type {
+  BuildRouteHrefTarget,
+  RouteHref,
+  RoutePath,
+} from './common-utils/build-route-href.js';
 import {
   ETAG_ID_PREFIX,
   HAS404_ID,
@@ -61,25 +61,6 @@ import type {
   RouteParams,
   RouteSearch,
 } from './create-pages-utils/inferred-path-types.js';
-
-type AllowTrailingSlash<Path extends string> = Path extends '/'
-  ? Path
-  : Path | `${Path}/`;
-
-type AllowPathDecorators<Path extends string> = Path extends unknown
-  ?
-      | AllowTrailingSlash<Path>
-      | `${AllowTrailingSlash<Path>}?${string}`
-      | `${AllowTrailingSlash<Path>}#${string}`
-      | `?${string}`
-      | `#${string}`
-  : never;
-
-type RouteHref = RouteConfig extends {
-  paths: infer UserPaths extends string;
-}
-  ? AllowPathDecorators<UserPaths>
-  : string;
 
 type NavigateOptions = {
   /**

--- a/packages/waku/src/router/common-utils/build-route-href.ts
+++ b/packages/waku/src/router/common-utils/build-route-href.ts
@@ -1,6 +1,6 @@
 import { getGrouplessPath } from '../../lib/utils/create-pages.js';
 import { getPathMapping, parsePathWithSlug } from '../../lib/utils/path.js';
-import type { CreatePagesConfig } from '../base-types.js';
+import type { CreatePagesConfig, RouteConfig } from '../base-types.js';
 import type {
   PagePath,
   RouteParams,
@@ -11,6 +11,25 @@ import type {
 export type RoutePath = [PagePath<CreatePagesConfig>] extends [never]
   ? string
   : PagePath<CreatePagesConfig>;
+
+type AllowTrailingSlash<Path extends string> = Path extends '/'
+  ? Path
+  : Path | `${Path}/`;
+
+type AllowPathDecorators<Path extends string> = Path extends unknown
+  ?
+      | AllowTrailingSlash<Path>
+      | `${AllowTrailingSlash<Path>}?${string}`
+      | `${AllowTrailingSlash<Path>}#${string}`
+      | `?${string}`
+      | `#${string}`
+  : never;
+
+export type RouteHref = RouteConfig extends {
+  paths: infer UserPaths extends string;
+}
+  ? AllowPathDecorators<UserPaths>
+  : string;
 
 type RouteParamsInput<Path extends RoutePath> = {
   [Key in keyof RouteParams<Path>]: RouteParams<Path>[Key] extends string[]

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -1169,7 +1169,7 @@ export const createPages = <
             elements,
             noSsr,
           ),
-          ...(searchCodec ? { searchCodecId: searchCodec.id } : {}),
+          ...(searchCodec ? { searchCodec } : {}),
         };
       };
       const buildDynamicRouteConfigs = () =>

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -12,6 +12,12 @@ import { createTaskRunner } from '../lib/utils/task-runner.js';
 import { unstable_defineHandlers as defineHandlers } from '../minimal/server.js';
 import { deserializeRsc, serializeRsc } from '../server.js';
 import { INTERNAL_ServerRouter } from './client.js';
+import { buildRouteHref } from './common-utils/build-route-href.js';
+import type {
+  BuildRouteHrefTarget,
+  RouteHref,
+  RoutePath,
+} from './common-utils/build-route-href.js';
 import {
   ETAG_ID_PREFIX,
   HAS404_ID,
@@ -24,6 +30,7 @@ import {
   encodeSliceId,
   pathnameToRoutePath,
 } from './common-utils/route-path.js';
+import type { Unstable_SearchCodec } from './create-pages-utils/inferred-path-types.js';
 
 export type ApiHandler = (
   req: Request,
@@ -70,6 +77,9 @@ type RouterStore = {
   rscParams?: unknown;
   rerender?: Rerender;
   nonce?: string;
+  resolveSearchCodec?: (
+    routePath: string,
+  ) => Unstable_SearchCodec<any> | undefined;
 };
 const routerStorage = new AsyncLocalStorage<RouterStore>();
 
@@ -167,13 +177,19 @@ export function unstable_notFound(): never {
 }
 
 /**
- * Redirect to a path in the current application.
- * The `location` must start with a single `/`.
+ * Redirect within the current application. Accepts the same target as
+ * `router.push` / `router.replace`: a typed route href, a structured
+ * `{ to, params, search, hash }`, or an arbitrary string. The resolved
+ * location must start with a single `/`.
  */
-export function unstable_redirect(
-  location: string,
+export function unstable_redirect<Path extends RoutePath = RoutePath>(
+  to: RouteHref | BuildRouteHrefTarget<Path> | (string & {}),
   status: 303 | 307 | 308 = 307,
 ): never {
+  const location =
+    typeof to === 'string'
+      ? to
+      : buildRouteHref(to, routerStorage.getStore()?.resolveSearchCodec);
   if (!location.startsWith('/') || location.startsWith('//')) {
     throw new Error('Invalid redirect location');
   }
@@ -285,7 +301,10 @@ type RouteConfig = {
   >;
   noSsr?: boolean;
   slices?: string[];
-  searchCodecId?: string;
+  // The codec instance (runtime-only; never serialized). The route -> codec-id
+  // map derives the id from `searchCodec.id`; the server `unstable_redirect`
+  // uses the instance to serialize a target route's `search`.
+  searchCodec?: Unstable_SearchCodec<any>;
 };
 
 type ApiConfig = {
@@ -310,7 +329,7 @@ type RuntimeConfig = RouteConfig | ApiConfig | SliceConfig;
 
 type SerializableRouteConfig = Omit<
   RouteConfig,
-  'rootElement' | 'routeElement' | 'elements'
+  'rootElement' | 'routeElement' | 'elements' | 'searchCodec'
 > & {
   rootElement: Omit<
     RouteConfig['rootElement'],
@@ -340,7 +359,13 @@ type SerializableConfig =
 
 const toSerializable = (c: RuntimeConfig): SerializableConfig => {
   if (c.type === 'route') {
-    const { rootElement, routeElement, elements, ...rest } = c;
+    const {
+      rootElement,
+      routeElement,
+      elements,
+      searchCodec: _searchCodec,
+      ...rest
+    } = c;
     const {
       renderer: _rootRenderer,
       getEtagFromOption: _rootGetEtag,
@@ -465,8 +490,8 @@ const mergeWithRuntimeConfigs = (
         elements,
         ...(c.noSsr !== undefined ? { noSsr: c.noSsr } : {}),
         ...(c.slices !== undefined ? { slices: c.slices } : {}),
-        ...(c.searchCodecId !== undefined
-          ? { searchCodecId: c.searchCodecId }
+        ...(runtimeItem?.searchCodec !== undefined
+          ? { searchCodec: runtimeItem.searchCodec }
           : {}),
       };
     }
@@ -525,9 +550,9 @@ const buildRoutePath2searchCodecId = (
 ): Record<string, string> => {
   const routePath2searchCodecId: Record<string, string> = {};
   for (const item of configs) {
-    if (item.type === 'route' && item.searchCodecId !== undefined) {
+    if (item.type === 'route' && item.searchCodec !== undefined) {
       routePath2searchCodecId[pathSpecAsString(item.pathPattern ?? item.path)] =
-        item.searchCodecId;
+        item.searchCodec.id;
     }
   }
   return routePath2searchCodecId;
@@ -563,7 +588,7 @@ export function unstable_defineRouter(fns: {
 }) {
   const runHandled = <T,>(req: Request, fn: () => Promise<T>): Promise<T> =>
     routerStorage.run(
-      { req },
+      { req, resolveSearchCodec },
       (fns.unstable_interceptors ?? []).reduceRight(
         (next, interceptor) => () => interceptor(next),
         fn,
@@ -610,6 +635,26 @@ export function unstable_defineRouter(fns: {
       throw new Error('defineRouter: configs not initialized');
     }
     return cachedConfigs;
+  };
+
+  let cachedRoutePath2searchCodec:
+    | Map<string, Unstable_SearchCodec<any>>
+    | undefined;
+  const resolveSearchCodec = (
+    routePath: string,
+  ): Unstable_SearchCodec<any> | undefined => {
+    if (!cachedRoutePath2searchCodec) {
+      cachedRoutePath2searchCodec = new Map();
+      for (const item of getCachedConfigs()) {
+        if (item.type === 'route' && item.searchCodec) {
+          cachedRoutePath2searchCodec.set(
+            pathSpecAsString(item.pathPattern ?? item.path),
+            item.searchCodec,
+          );
+        }
+      }
+    }
+    return cachedRoutePath2searchCodec.get(routePath);
   };
 
   const has404 = (): boolean => {

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -190,9 +190,6 @@ export function unstable_redirect<Path extends RoutePath = RoutePath>(
     typeof to === 'string'
       ? to
       : buildRouteHref(to, routerStorage.getStore()?.resolveSearchCodec);
-  // JSON.stringify escapes control chars (e.g. newlines) and quotes the value,
-  // so an attacker-controlled `location` can't forge log lines if the thrown
-  // Error is logged downstream (the rejected value often contains control chars).
   if (!location.startsWith('/') || location.startsWith('//')) {
     throw new Error(`Invalid redirect location: ${JSON.stringify(location)}`);
   }
@@ -304,9 +301,6 @@ type RouteConfig = {
   >;
   noSsr?: boolean;
   slices?: string[];
-  // The codec instance (runtime-only; never serialized). The route -> codec-id
-  // map derives the id from `searchCodec.id`; the server `unstable_redirect`
-  // uses the instance to serialize a target route's `search`.
   searchCodec?: Unstable_SearchCodec<any>;
 };
 

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -190,13 +190,16 @@ export function unstable_redirect<Path extends RoutePath = RoutePath>(
     typeof to === 'string'
       ? to
       : buildRouteHref(to, routerStorage.getStore()?.resolveSearchCodec);
+  // JSON.stringify escapes control chars (e.g. newlines) and quotes the value,
+  // so an attacker-controlled `location` can't forge log lines if the thrown
+  // Error is logged downstream (the rejected value often contains control chars).
   if (!location.startsWith('/') || location.startsWith('//')) {
-    throw new Error('Invalid redirect location');
+    throw new Error(`Invalid redirect location: ${JSON.stringify(location)}`);
   }
   for (let i = 0; i < location.length; ++i) {
     const charCode = location.charCodeAt(i);
     if (charCode < 0x20 || charCode === 0x7f || charCode === 0x5c) {
-      throw new Error('Invalid redirect location');
+      throw new Error(`Invalid redirect location: ${JSON.stringify(location)}`);
     }
   }
   throw createCustomError('Redirect', { status, location });

--- a/packages/waku/tests/build-route-href.test.ts
+++ b/packages/waku/tests/build-route-href.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { buildRouteHref } from '../src/router/client-utils/build-route-href.js';
+import { buildRouteHref } from '../src/router/common-utils/build-route-href.js';
 
 type Search = { tab: string; page: number };
 

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -3351,10 +3351,10 @@ describe('createPages search codec', () => {
       (config) =>
         config.type === 'route' && config.path?.[0]?.name === 'search-test',
     );
-    // the codec id rides the route config; the client resolves it via the
-    // route -> codec id map (__WAKU_ROUTER_SEARCH_CODECS__) for both the search
-    // hooks and push/Link
-    expect(routeConfig.searchCodecId).toBe('search-test');
+    // the codec instance rides the route config; its id feeds the
+    // route -> codec id map (__WAKU_ROUTER_SEARCH_CODECS__) that the client uses
+    // for the search hooks and push/Link
+    expect(routeConfig.searchCodec?.id).toBe('search-test');
     const pageEl = routeConfig.elements['page:/search-test'];
     // parsed search is injected from the query
     expect(

--- a/packages/waku/tests/define-router-action.test.ts
+++ b/packages/waku/tests/define-router-action.test.ts
@@ -344,4 +344,26 @@ describe('unstable_redirect', () => {
       'Invalid redirect location',
     );
   });
+
+  // The structured form serializes server-side via buildRouteHref; `to` is cast
+  // because this test file declares no routes (RouteSearch<string> is `never`).
+  const getStructuredRedirectInfo = (to: unknown) => {
+    try {
+      unstable_redirect(to as never, 303);
+    } catch (e) {
+      return getErrorInfo(e);
+    }
+  };
+
+  it('serializes a structured target with params', () => {
+    expect(
+      getStructuredRedirectInfo({
+        to: '/posts/[slug]',
+        params: { slug: 'hello world' },
+      }),
+    ).toEqual({ status: 303, location: '/posts/hello%20world' });
+  });
+
+  // Search serialization needs the per-request router store (codec resolver),
+  // so it is covered end to end by the create-pages e2e (/redirect-to-search).
 });

--- a/packages/waku/tests/match-route-params.test.ts
+++ b/packages/waku/tests/match-route-params.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { buildRouteHref } from '../src/router/client-utils/build-route-href.js';
 import { matchRouteParams } from '../src/router/client-utils/match-route-params.js';
+import { buildRouteHref } from '../src/router/common-utils/build-route-href.js';
 
 describe('matchRouteParams', () => {
   test('matches a static route', () => {

--- a/packages/waku/tests/search-params-types.test.ts
+++ b/packages/waku/tests/search-params-types.test.ts
@@ -1,11 +1,19 @@
 import { expectType } from 'ts-expect';
 import type { TypeEqual } from 'ts-expect';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { buildRouteHref } from '../src/router/common-utils/build-route-href.js';
 import type {
   PropsForPages,
   RouteSearch,
 } from '../src/router/create-pages-utils/inferred-path-types.js';
+import { unstable_redirect } from '../src/router/define-router.js';
+
+// define-router pulls in server.js (react-server-dom-webpack); mock it so this
+// pure type/codec test loads without the `react-server` condition.
+vi.mock('../src/server.js', () => ({
+  deserializeRsc: vi.fn().mockResolvedValue(null),
+  serializeRsc: vi.fn().mockResolvedValue(new Uint8Array([1])),
+}));
 
 type Search = { page: number; nested: { a: string } };
 
@@ -67,6 +75,33 @@ describe('search params type foundation', () => {
       });
     };
     expect(typeof assertPush).toBe('function');
+
+    // 4. unstable_redirect is typed by `to`, exactly like push (arrows avoid the
+    // `never` return making later statements unreachable)
+    const assertRedirect = [
+      () =>
+        unstable_redirect({
+          to: '/typed-search/[id]',
+          params: { id: 'x' },
+          search: { page: 2, nested: { a: 'y' } },
+        }),
+      () =>
+        unstable_redirect({
+          to: '/typed-search/[id]',
+          params: { id: 'x' },
+          // @ts-expect-error search must match the route's codec
+          search: { page: 'two' },
+        }),
+      () =>
+        unstable_redirect({
+          to: '/no-codec',
+          // @ts-expect-error a route without a codec cannot pass search
+          search: { page: 2 },
+        }),
+      // the string escape hatch is still accepted
+      () => unstable_redirect('/anything?ref=home'),
+    ];
+    expect(assertRedirect).toHaveLength(4);
 
     // runtime: the same codec round-trips
     expect(typedSearchCodec.parse('page=2&a=x')).toEqual({

--- a/packages/waku/tests/search-params-types.test.ts
+++ b/packages/waku/tests/search-params-types.test.ts
@@ -1,7 +1,7 @@
 import { expectType } from 'ts-expect';
 import type { TypeEqual } from 'ts-expect';
 import { describe, expect, it } from 'vitest';
-import { buildRouteHref } from '../src/router/client-utils/build-route-href.js';
+import { buildRouteHref } from '../src/router/common-utils/build-route-href.js';
 import type {
   PropsForPages,
   RouteSearch,


### PR DESCRIPTION
- Accepts a typed route href, a structured `{ to, params, search, hash }`, or    any string (escape hatch; existing redirects unaffected).
- Structured `search` is serialized server-side via the route's codec,
 resolved through `defineRouter`'s request store (dropped the redundant `searchCodecId` field).
- Moves the isomorphic `build-route-href` from `client-utils` to `common-utils`.
- Fix: redirect `Location` now honors `basePath` (was app-relative; pre-existing bug, reviewer catch).
