### PR TITLE
fix(router): loosen prefetch typing

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -56,6 +56,8 @@ export const DashboardButton = () => {
 };
 ```
 
+`router.prefetch()` accepts a route href (autocompleted from your routes) or any string, so a computed href such as `/posts/${slug}` works too.
+
 For navigating to dynamic routes with typed params, see [Typed Routes](/guides/typed-routes).
 
 ## Link Prefetching

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -307,7 +307,7 @@ export function useRouter() {
     window.history.forward();
   }, []);
   const prefetch = useCallback(
-    (to: RouteHref) => {
+    (to: RouteHref | (string & {})) => {
       const url = new URL(to, window.location.href);
       prefetchRoute(parseRoute(url));
     },

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -288,13 +288,20 @@ afterEach(() => {
 });
 
 describe('router navigation method path typing', () => {
-  test('prefetch is string-only; push/replace also accept structured targets', () => {
+  test('prefetch takes a route href or any string; push/replace also accept structured targets', () => {
+    // prefetch accepts a typed route href plus a `(string & {})` escape hatch
+    // (so computed/dynamic hrefs work). The escape hatch only widens the type
+    // when routes are augmented and RouteHref is a literal union; in this test
+    // RouteConfig.paths is not augmented, so RouteHref is `string`.
     type PrefetchArg = Parameters<RouterApi['prefetch']>[0];
-    expectType<TypeEqual<PrefetchArg, Unstable_RouteHref>>(true);
+    expectType<TypeEqual<PrefetchArg, Unstable_RouteHref | (string & {})>>(
+      true,
+    );
 
     // Type-level assertions; the closure is never invoked.
-    const assertTypes = (router: RouterApi) => {
+    const assertTypes = (router: RouterApi, computed: string) => {
       void router.prefetch('/x');
+      void router.prefetch(computed); // escape hatch: any string href
       void router.push('/x');
       void router.replace('/x');
       void router.push({ to: '/posts/[slug]', params: { slug: 'a' } });


### PR DESCRIPTION
`router.prefetch()` only accepted known route paths, so a computed URL like `/posts/${slug}` was a type error (even though it worked at runtime). It now also accepts any string, while keeping autocomplete for known routes. Still href-only (no structured `{ to, params }` form).
