### PR TITLE
refactor: static etag

### DIFF
--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -51,6 +51,7 @@ import {
   IS_STATIC_ID,
   ROUTE_ID,
   SKIP_HEADER,
+  STATIC_ETAG,
   encodeRoutePath,
   encodeSliceId,
   pathnameToRoutePath,
@@ -152,7 +153,7 @@ const createRscParams = (query: string): URLSearchParams => {
 };
 
 const createSkipHeaderEnhancer =
-  (cachedEtagsRef: { current: Record<string, string> }) =>
+  (cachedEtagsRef: { current: Record<string, string | typeof STATIC_ETAG> }) =>
   (fetchFn: typeof fetch) =>
   (input: RequestInfo | URL, init: RequestInit = {}) => {
     const skipStr = JSON.stringify(cachedEtagsRef.current);
@@ -860,8 +861,7 @@ export function Slice({
   const needsToFetchSlice =
     props.lazy &&
     (!(slotId in elements) ||
-      // FIXME: hard-coded for now
-      elements[IS_STATIC_ID + ':' + slotId] !== true);
+      elements[ETAG_ID_PREFIX + slotId] !== STATIC_ETAG);
   useEffect(() => {
     // FIXME this works because of subtle timing behavior.
     if (needsToFetchSlice && !fetchingSlices.has(id)) {
@@ -944,7 +944,9 @@ const useElementsMetadata = (
 ) => {
   const [has404, setHas404] = useState(false);
   const staticPathSetRef = useRef(new Set<string>());
-  const cachedEtagsRef = useRef<Record<string, string>>({});
+  const cachedEtagsRef = useRef<Record<string, string | typeof STATIC_ETAG>>(
+    {},
+  );
   useEffect(() => {
     elementsPromise.then(
       (elements) => {
@@ -962,13 +964,14 @@ const useElementsMetadata = (
             staticPathSetRef.current.add(path);
           }
         }
-        const etags: Record<string, string> = {};
+        const etags: Record<string, string | typeof STATIC_ETAG> = {};
         for (const [key, value] of Object.entries(elements)) {
-          // Drop empty (clear signal) and non-Latin1 (breaks fetch) tags.
+          // Keep the static sentinel; for string tags drop empty (clear
+          // signal) and non-Latin1 (breaks fetch).
           if (
             key.startsWith(ETAG_ID_PREFIX) &&
-            typeof value === 'string' &&
-            /^[\u0020-\u00ff]+$/.test(value)
+            (value === STATIC_ETAG ||
+              (typeof value === 'string' && /^[\u0020-\u00ff]+$/.test(value)))
           ) {
             etags[key.slice(ETAG_ID_PREFIX.length)] = value;
           }

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -25,6 +25,7 @@ import {
   IS_STATIC_ID,
   ROUTE_ID,
   SKIP_HEADER,
+  STATIC_ETAG,
   decodeRoutePath,
   decodeSliceId,
   encodeRoutePath,
@@ -37,11 +38,13 @@ export type ApiHandler = (
   apiContext: { params: Record<string, string | string[]> },
 ) => Promise<Response>;
 
-const isStringRecord = (x: unknown): x is Record<string, string> =>
+const isEtagRecord = (
+  x: unknown,
+): x is Record<string, string | typeof STATIC_ETAG> =>
   typeof x === 'object' &&
   x !== null &&
   !Array.isArray(x) &&
-  Object.values(x).every((v) => typeof v === 'string');
+  Object.values(x).every((v) => typeof v === 'string' || v === STATIC_ETAG);
 
 const safeJsonParse = (text: string): unknown => {
   try {
@@ -207,9 +210,6 @@ type SlotId = string;
 const ROOT_SLOT_ID = 'root';
 const ROUTE_SLOT_ID_PREFIX = 'route:';
 const SLICE_SLOT_ID_PREFIX = 'slice:';
-
-// The element tag (etag) used for every static slot; known without rendering.
-const STATIC_ETAG = 'static';
 
 type CacheId = string;
 
@@ -735,9 +735,8 @@ export function unstable_defineRouter(fns: {
     const parsedEtags = safeJsonParse(
       headers[SKIP_HEADER.toLowerCase()] || '{}',
     );
-    const clientEtags: Record<string, string> = isStringRecord(parsedEtags)
-      ? parsedEtags
-      : {};
+    const clientEtags: Record<string, string | typeof STATIC_ETAG> =
+      isEtagRecord(parsedEtags) ? parsedEtags : {};
     const { query } = parseRscParams(rscParams);
     const routeId = ROUTE_SLOT_ID_PREFIX + routePath;
     const routeTemplateCacheId = getPathSpecCacheId(pathConfigItem.path);
@@ -839,12 +838,6 @@ export function unstable_defineRouter(fns: {
     ]);
     entries[ROUTE_ID] = [routePath, query];
     entries[IS_STATIC_ID] = pathConfigItem.isStatic;
-    sliceConfigMap.forEach((sliceConfig, sliceId) => {
-      if (sliceConfig.isStatic) {
-        // FIXME: hard-coded for now
-        entries[IS_STATIC_ID + ':' + SLICE_SLOT_ID_PREFIX + sliceId] = true;
-      }
-    });
     if (has404()) {
       entries[HAS404_ID] = true;
     }
@@ -947,12 +940,6 @@ export function unstable_defineRouter(fns: {
           );
           return renderRsc({
             [SLICE_SLOT_ID_PREFIX + sliceId]: sliceElement,
-            ...(sliceConfig.isStatic
-              ? {
-                  // FIXME: hard-coded for now
-                  [IS_STATIC_ID + ':' + SLICE_SLOT_ID_PREFIX + sliceId]: true,
-                }
-              : {}),
             ...(sliceEtag !== undefined
               ? { [ETAG_ID_PREFIX + SLICE_SLOT_ID_PREFIX + sliceId]: sliceEtag }
               : {}),
@@ -1295,8 +1282,6 @@ export function unstable_defineRouter(fns: {
           const sliceElement = await getSliceElement(item, buildElementCache);
           const body = await renderRsc({
             [SLICE_SLOT_ID_PREFIX + item.id]: sliceElement,
-            // FIXME: hard-coded for now
-            [IS_STATIC_ID + ':' + SLICE_SLOT_ID_PREFIX + item.id]: true,
             [ETAG_ID_PREFIX + SLICE_SLOT_ID_PREFIX + item.id]: STATIC_ETAG,
           });
           await generateFile(rscPath2pathname(rscPath), body);

--- a/packages/waku/src/router/isomorphic-utils/route-path.ts
+++ b/packages/waku/src/router/isomorphic-utils/route-path.ts
@@ -85,6 +85,9 @@ export const ROUTE_ID = 'ROUTE';
 export const IS_STATIC_ID = 'IS_STATIC';
 export const HAS404_ID = 'HAS404';
 export const ETAG_ID_PREFIX = 'ETAG:';
+// Etag for any static slot, known without rendering. A number, never a string,
+// so it cannot equal a user `unstable_getEtag` value.
+export const STATIC_ETAG = 1;
 
 // For HTTP header
 export const SKIP_HEADER = 'X-Waku-Router-Skip';

--- a/packages/waku/tests/define-router-etag.test.ts
+++ b/packages/waku/tests/define-router-etag.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { unstable_defineRouter } from '../src/router/define-router.js';
 import {
   ETAG_ID_PREFIX,
+  IS_STATIC_ID,
   SKIP_HEADER,
+  STATIC_ETAG,
   encodeRoutePath,
   encodeSliceId,
 } from '../src/router/isomorphic-utils/route-path.js';
@@ -77,7 +79,7 @@ const drive = async (
 
 const getEntries = (
   router: ReturnType<typeof unstable_defineRouter>,
-  clientEtags?: Record<string, string>,
+  clientEtags?: Record<string, string | typeof STATIC_ETAG>,
 ): Promise<Record<string, unknown>> =>
   drive(
     router,
@@ -170,21 +172,21 @@ describe('define-router etags (element tag skip)', () => {
     expect(entries[etagKey('page')]).toBe('');
   });
 
-  it('uses the constant "static" etag for static slots and omits on match', async () => {
+  it('uses the static sentinel etag for static slots and omits on match', async () => {
     const router = buildRouter({
       page: { isStatic: true, renderer: () => createElement('div') },
     });
 
     const first = await getEntries(router);
     expect('page' in first).toBe(true);
-    expect(first[etagKey('page')]).toBe('static');
+    expect(first[etagKey('page')]).toBe(STATIC_ETAG);
 
-    const second = await getEntries(router, { page: 'static' });
+    const second = await getEntries(router, { page: STATIC_ETAG });
     expect('page' in second).toBe(false);
     expect(etagKey('page') in second).toBe(false);
   });
 
-  it('ignores a getEtag on a static slot (tag stays "static")', async () => {
+  it('ignores a getEtag on a static slot (tag stays the sentinel)', async () => {
     const router = buildRouter({
       page: {
         isStatic: true,
@@ -194,7 +196,7 @@ describe('define-router etags (element tag skip)', () => {
     });
 
     const entries = await getEntries(router);
-    expect(entries[etagKey('page')]).toBe('static');
+    expect(entries[etagKey('page')]).toBe(STATIC_ETAG);
   });
 
   it('passes the element option to getEtag', async () => {
@@ -359,6 +361,39 @@ describe('define-router etags (element tag skip)', () => {
     expect(entries[etagKey('slice:mySlice')]).toBe(''); // cleared
   });
 
+  it('marks a static slice by the etag sentinel, not an IS_STATIC marker', async () => {
+    const router = unstable_defineRouter({
+      getConfigs: async () => [
+        {
+          type: 'route' as const,
+          path: [{ type: 'literal' as const, name: 'foo' }],
+          isStatic: false,
+          rootElement: { isStatic: false, renderer: () => 'root' },
+          routeElement: { isStatic: false, renderer: () => 'route' },
+          elements: {
+            page: {
+              isStatic: false,
+              renderer: () => createElement('div', null, 'page'),
+            },
+          },
+          slices: ['mySlice'],
+        },
+        {
+          type: 'slice' as const,
+          id: 'mySlice',
+          isStatic: true,
+          renderer: async () => createElement('div', null, 'slice'),
+        },
+      ],
+    });
+
+    const entries = await getEntries(router);
+    expect(entries['slice:mySlice']).toBeDefined();
+    expect(entries[etagKey('slice:mySlice')]).toBe(STATIC_ETAG);
+    // the etag is the only static signal; no IS_STATIC:<slot> marker
+    expect(`${IS_STATIC_ID}:slice:mySlice` in entries).toBe(false);
+  });
+
   it('ignores a legacy, malformed, or non-string skip header', async () => {
     const build = () =>
       buildRouter({
@@ -369,11 +404,11 @@ describe('define-router etags (element tag skip)', () => {
     for (const header of [
       JSON.stringify(['page']), // legacy array of ids
       'not json',
-      JSON.stringify({ page: 123 }), // non-string value
+      JSON.stringify({ page: 123 }), // non-string value other than the sentinel
     ]) {
       const entries = await getEntriesWithSkipHeader(build(), header);
       expect('page' in entries).toBe(true);
-      expect(entries[etagKey('page')]).toBe('static');
+      expect(entries[etagKey('page')]).toBe(STATIC_ETAG);
     }
   });
 });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -49,6 +49,7 @@ import {
   IS_STATIC_ID,
   ROUTE_ID,
   SKIP_HEADER,
+  STATIC_ETAG,
 } from '../src/router/isomorphic-utils/route-path.js';
 
 const postsSearchCodec = {
@@ -1194,7 +1195,7 @@ describe('Slice', () => {
     const slotId = unstable_getSliceSlotId('slice-1');
     const elements = {
       [slotId]: <div>loaded</div>,
-      [`${IS_STATIC_ID}:${slotId}`]: true,
+      [`${ETAG_ID_PREFIX}${slotId}`]: STATIC_ETAG,
     };
 
     const view = await renderWithMinimalRoot(
@@ -1223,7 +1224,7 @@ describe('Slice', () => {
     const slotId = unstable_getSliceSlotId('slice-1');
     const elements = {
       [slotId]: <div>loaded</div>,
-      [`${IS_STATIC_ID}:${slotId}`]: false,
+      [`${ETAG_ID_PREFIX}${slotId}`]: 'v1',
     };
 
     const view = await renderWithMinimalRoot(


### PR DESCRIPTION
## Motivation
  
Static-ness was encoded as the etag value "static", which a user unstable_getEtag can also return, so the two collided. Static slices also carried a redundant IS_STATIC:<slot> marker (flagged by a FIXME).

## Summary
  
STATIC_ETAG becomes the number 1, so a user etag string can never equal it. Every slot, slices included, now reads static-ness from the etag, so the IS_STATIC:<slot> marker is deleted. The route-level IS_STATIC flag is the only one left, so its name is no longer overloaded.
