### PR TITLE
refactor(minimal): move etag mechanism

### DIFF
--- a/e2e/router-client.spec.ts
+++ b/e2e/router-client.spec.ts
@@ -439,7 +439,7 @@ test.describe('router-client', () => {
     expect(lastScrollToCall?.top).toBeGreaterThan(100);
   });
 
-  test('route fetch includes X-Waku-Router-Skip header', async ({ page }) => {
+  test('route fetch sends the cached etags header', async ({ page }) => {
     await page.goto(`http://localhost:${port}/start`);
     await waitForHydration(page);
 
@@ -450,11 +450,11 @@ test.describe('router-client', () => {
     await page.getByTestId('go-next').click();
     const request = await nextRscRequestPromise;
 
-    const skipHeader = request.headers()['x-waku-router-skip'];
-    expect(skipHeader).toBeTruthy();
-    const skipped = JSON.parse(skipHeader as string) as Record<string, string>;
-    expect(Array.isArray(skipped)).toBe(false);
-    expect(Object.keys(skipped).length).toBeGreaterThan(0);
+    const etagsHeader = request.headers()['x-waku-etags'];
+    expect(etagsHeader).toBeTruthy();
+    const etags = JSON.parse(etagsHeader as string) as Record<string, unknown>;
+    expect(Array.isArray(etags)).toBe(false);
+    expect(Object.keys(etags).length).toBeGreaterThan(0);
 
     await expect(page.getByRole('heading', { name: 'Next' })).toBeVisible();
     await expect(page.getByTestId('route-path')).toHaveText('/next');
@@ -479,7 +479,7 @@ test.describe('router-client', () => {
       .toBe(true);
   });
 
-  test('skip header omits static layout payload on soft navigation', async ({
+  test('soft navigation omits the unchanged static layout payload', async ({
     page,
   }) => {
     await page.goto(`http://localhost:${port}/skip/a`);
@@ -502,12 +502,12 @@ test.describe('router-client', () => {
 
     const response = await rscResponsePromise;
     const request = response.request();
-    const skipHeader = request.headers()['x-waku-router-skip'];
+    const etagsHeader = request.headers()['x-waku-etags'];
 
-    expect(skipHeader).toBeTruthy();
-    const skipped = JSON.parse(skipHeader as string) as Record<string, string>;
-    expect(Array.isArray(skipped)).toBe(false);
-    expect('root' in skipped).toBe(true);
+    expect(etagsHeader).toBeTruthy();
+    const etags = JSON.parse(etagsHeader as string) as Record<string, unknown>;
+    expect(Array.isArray(etags)).toBe(false);
+    expect('root' in etags).toBe(true);
 
     const payload = await response.text();
     expect(payload).toContain('SKIP_B_PAGE_MARKER');

--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { Config } from '../config.js';
+import type { Etags } from './utils/etags.js';
 
 type Elements = Record<string, unknown>;
 
@@ -7,6 +8,7 @@ export type Unstable_RenderRsc = (
   elements: Elements,
   options?: {
     value?: unknown;
+    etags?: Etags;
     unstable_clientModuleCallback?: (ids: string[]) => void;
   },
 ) => Promise<ReadableStream>;
@@ -48,6 +50,7 @@ export type Unstable_HandleRequest = (
   ) & {
     pathname: string;
     req: Request;
+    etags?: Etags;
   },
   utils: {
     renderRsc: Unstable_RenderRsc;

--- a/packages/waku/src/lib/utils/etags.ts
+++ b/packages/waku/src/lib/utils/etags.ts
@@ -7,10 +7,12 @@ export const IMMUTABLE_ETAG = 1;
 export type Etag = string | typeof IMMUTABLE_ETAG;
 export type Etags = Record<string, Etag>;
 
-// '' clears a tag; a non-Latin1 string cannot ride in a header
+// '' clears a tag; only printable Latin-1 (no control chars) is header-safe
 export const isValidEtag = (value: unknown): value is Etag =>
   value === IMMUTABLE_ETAG ||
-  (typeof value === 'string' && value !== '' && /^[ -ÿ]+$/.test(value));
+  (typeof value === 'string' &&
+    value !== '' &&
+    /^[\x20-\x7e\xa0-\xff]+$/.test(value));
 
 export const parseClientEtags = (serialized: string | null): Etags => {
   if (!serialized) {

--- a/packages/waku/src/lib/utils/etags.ts
+++ b/packages/waku/src/lib/utils/etags.ts
@@ -1,0 +1,38 @@
+export const ETAG_ID_PREFIX = '_etag:';
+export const ETAGS_HEADER = 'X-Waku-Etags';
+
+// Non-string sentinel, so it cannot collide with a (string) content validator.
+export const IMMUTABLE_ETAG = 1;
+
+export type Etag = string | typeof IMMUTABLE_ETAG;
+export type Etags = Record<string, Etag>;
+
+// '' clears a tag; a non-Latin1 string cannot ride in a header
+export const isValidEtag = (value: unknown): value is Etag =>
+  value === IMMUTABLE_ETAG ||
+  (typeof value === 'string' && value !== '' && /^[ -ÿ]+$/.test(value));
+
+export const parseClientEtags = (serialized: string | null): Etags => {
+  if (!serialized) {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+  const etags: Etags = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (isValidEtag(value)) {
+      etags[key] = value;
+    }
+  }
+  return etags;
+};
+
+export const serializeClientEtags = (etags: Etags): string =>
+  JSON.stringify(etags);

--- a/packages/waku/src/lib/utils/render.ts
+++ b/packages/waku/src/lib/utils/render.ts
@@ -3,6 +3,7 @@ import type {
   Unstable_RenderHtml,
   Unstable_RenderRsc,
 } from '../types.js';
+import { ETAG_ID_PREFIX } from './etags.js';
 import { sanitizeLog } from './log.js';
 
 const validateRscElementIds = (elements: Record<string, unknown>) => {
@@ -57,6 +58,11 @@ export function createRenderUtils(
         : { ...elements };
       if (options && 'value' in options) {
         data._value = options.value;
+      }
+      if (options?.etags) {
+        for (const [slotId, etag] of Object.entries(options.etags)) {
+          data[ETAG_ID_PREFIX + slotId] = etag;
+        }
       }
       return renderToReadableStream(
         data,

--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -3,6 +3,7 @@ import type { Config } from '../../config.js';
 import type { Unstable_HandleRequest as HandleRequest } from '../types.js';
 import { decodeFuncId, decodeRscPath } from '../utils/rsc-path.js';
 import { createCustomError } from './custom-errors.js';
+import { ETAGS_HEADER, parseClientEtags } from './etags.js';
 import { removeBase } from './path.js';
 
 type HandleRequestInput = Parameters<HandleRequest>[0];
@@ -25,6 +26,7 @@ export async function getInput(
   const url = new URL(req.url);
   const pathname = removeBase(url.pathname, config.basePath);
   const rscPathPrefix = '/' + config.rscBase + '/';
+  const etags = parseClientEtags(req.headers.get(ETAGS_HEADER));
   let rscPath: string | undefined;
   let input: HandleRequestInput;
   if (pathname.startsWith(rscPathPrefix)) {
@@ -42,6 +44,7 @@ export async function getInput(
         args,
         pathname,
         req,
+        etags,
       };
     } else {
       // client RSC request
@@ -59,6 +62,7 @@ export async function getInput(
         rscParams,
         pathname,
         req,
+        etags,
       };
     }
   } else if (req.method === 'POST') {
@@ -79,6 +83,7 @@ export async function getInput(
         },
         pathname,
         req,
+        etags,
       };
     } else {
       // POST API request
@@ -86,6 +91,7 @@ export async function getInput(
         type: 'custom',
         pathname,
         req,
+        etags,
       };
     }
   } else {
@@ -94,6 +100,7 @@ export async function getInput(
       type: 'custom',
       pathname,
       req,
+      etags,
     };
   }
   return input;

--- a/packages/waku/src/minimal/client-utils/fetch-store.ts
+++ b/packages/waku/src/minimal/client-utils/fetch-store.ts
@@ -1,8 +1,11 @@
+import type { Etags } from '../../lib/utils/etags.js';
+
 export const ENTRY = 'e';
 export const SET_ELEMENTS = 's';
 export const FETCH_ENHANCERS = 'f';
 export const FETCH_RSC_INPUT_TRANSFORMERS = 't';
 export const CALL_SERVER_ELEMENTS_LISTENERS = 'l';
+export const CACHED_ETAGS = 'c';
 
 export type SetElements = (
   updater: (
@@ -34,6 +37,7 @@ export type FetchRscStore = {
   [FETCH_ENHANCERS]?: FetchEnhancers;
   [FETCH_RSC_INPUT_TRANSFORMERS]?: FetchRscInputTransformers;
   [CALL_SERVER_ELEMENTS_LISTENERS]?: CallServerElementsListeners;
+  [CACHED_ETAGS]?: Etags;
 };
 
 // Internal module-level RSC store. This module is intentionally absent from the

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -12,10 +12,19 @@ import {
 import type { ReactNode } from 'react';
 import RSDWClient from 'react-server-dom-webpack/client';
 import { createCustomError } from '../lib/utils/custom-errors.js';
+import {
+  ETAGS_HEADER,
+  ETAG_ID_PREFIX,
+  IMMUTABLE_ETAG,
+  isValidEtag,
+  serializeClientEtags,
+} from '../lib/utils/etags.js';
+import type { Etags } from '../lib/utils/etags.js';
 import { consumeInitialRscEntry } from '../lib/utils/initial-rsc.js';
 import { setupDebugChannel } from '../lib/utils/react-debug-channel.js';
 import { encodeFuncId, encodeRscPath } from '../lib/utils/rsc-path.js';
 import {
+  CACHED_ETAGS,
   CALL_SERVER_ELEMENTS_LISTENERS,
   ENTRY,
   FETCH_ENHANCERS,
@@ -71,6 +80,25 @@ const checkStatus = async (
 
 type Elements = Record<string, unknown>;
 
+const collectCachedEtags = (elements: Elements): Etags => {
+  const etags: Etags = {};
+  for (const [key, value] of Object.entries(elements)) {
+    if (key.startsWith(ETAG_ID_PREFIX) && isValidEtag(value)) {
+      etags[key.slice(ETAG_ID_PREFIX.length)] = value;
+    }
+  }
+  return etags;
+};
+
+const updateCachedEtags = (elements: Elements): void => {
+  fetchRscStore[CACHED_ETAGS] = collectCachedEtags(elements);
+};
+
+export const unstable_isImmutableElement = (
+  elements: Elements,
+  slotId: string,
+): boolean => elements[ETAG_ID_PREFIX + slotId] === IMMUTABLE_ETAG;
+
 // TODO(daishi) do we still this?
 const getCached = <T,>(c: () => T, m: WeakMap<WeakKey, T>, k: object): T =>
   (m.has(k) ? m : m.set(k, c())).get(k) as T;
@@ -95,9 +123,13 @@ const mergeElementsPromise = (
       delete base._value;
       return new Proxy(base, {
         get(target, key: string) {
+          // an _etag:<slot> key follows its slot's eagerness, not its own
+          const eager = key.startsWith(ETAG_ID_PREFIX)
+            ? isEager(key.slice(ETAG_ID_PREFIX.length))
+            : isEager(key);
           if (
             key !== '_value' &&
-            !isEager(key) &&
+            !eager &&
             // a lazy key still equal to aRes's value hasn't been streamed yet
             target[key] === aRes[key]
           ) {
@@ -152,7 +184,11 @@ const requestRsc = (
   signal: AbortSignal | undefined,
 ): Promise<Response> => {
   const url = BASE_RSC_PATH + encodeRscPath(rscPath);
-  const init: RequestInit = {};
+  const init: RequestInit = {
+    headers: {
+      [ETAGS_HEADER]: serializeClientEtags(fetchRscStore[CACHED_ETAGS] ?? {}),
+    },
+  };
   if (signal) {
     init.signal = signal;
   }
@@ -386,16 +422,20 @@ export const unstable_registerFetchRscInputTransformer = (
 };
 
 const registerHmrRefetch = (refetch: () => void) => {
+  const reload = () => {
+    fetchRscStore[CACHED_ETAGS] = {};
+    refetch();
+  };
   globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= [];
   const index = globalThis.__WAKU_RSC_RELOAD_LISTENERS__.indexOf(
     globalThis.__WAKU_REFETCH_RSC__!,
   );
   if (index !== -1) {
-    globalThis.__WAKU_RSC_RELOAD_LISTENERS__.splice(index, 1, refetch);
+    globalThis.__WAKU_RSC_RELOAD_LISTENERS__.splice(index, 1, reload);
   } else {
-    globalThis.__WAKU_RSC_RELOAD_LISTENERS__.push(refetch);
+    globalThis.__WAKU_RSC_RELOAD_LISTENERS__.push(reload);
   }
-  globalThis.__WAKU_REFETCH_RSC__ = refetch;
+  globalThis.__WAKU_REFETCH_RSC__ = reload;
 };
 
 /** Fetch elements for an RSC path, reusing a cached or prefetched result. */
@@ -455,6 +495,9 @@ export const Root = ({
   useEffect(() => {
     fetchRscStore[SET_ELEMENTS] = setElements;
   }, []);
+  useEffect(() => {
+    elements.then(updateCachedEtags, () => {});
+  }, [elements]);
   const refetch = useCallback<Refetch>(async (rscPath, rscParams, options) => {
     delete fetchRscStore[ENTRY];
     const data = unstable_fetchRsc(rscPath, rscParams, options);

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -99,7 +99,7 @@ export const unstable_isImmutableElement = (
   slotId: string,
 ): boolean => elements[ETAG_ID_PREFIX + slotId] === IMMUTABLE_ETAG;
 
-// TODO(daishi) do we still this?
+// TODO(daishi) do we still need this?
 const getCached = <T,>(c: () => T, m: WeakMap<WeakKey, T>, k: object): T =>
   (m.has(k) ? m : m.set(k, c())).get(k) as T;
 

--- a/packages/waku/src/minimal/server.ts
+++ b/packages/waku/src/minimal/server.ts
@@ -2,6 +2,8 @@ import type {
   Unstable_Handlers as Handlers,
   Unstable_ServerEntry as ServerEntry,
 } from '../lib/types.js';
+import { IMMUTABLE_ETAG } from '../lib/utils/etags.js';
+import type { Etags } from '../lib/utils/etags.js';
 
 export function unstable_defineHandlers(handlers: Handlers) {
   return handlers;
@@ -10,6 +12,45 @@ export function unstable_defineHandlers(handlers: Handlers) {
 export function unstable_defineServerEntry(fns: ServerEntry) {
   return fns;
 }
+
+export type Unstable_Etags = Etags;
+
+export type Unstable_ElementSource = {
+  immutable?: boolean;
+  getEtag?: (() => Promise<string | undefined>) | undefined;
+  render: () => unknown | Promise<unknown>;
+};
+
+export type Unstable_BuiltElements = {
+  elements: Record<string, unknown>;
+  etags: Etags;
+};
+
+export const unstable_buildElements = async (
+  clientEtags: Etags,
+  elementSources: Record<string, Unstable_ElementSource>,
+): Promise<Unstable_BuiltElements> => {
+  const elements: Record<string, unknown> = {};
+  const etags: Etags = {};
+  await Promise.all(
+    Object.entries(elementSources).map(async ([slotId, elementSource]) => {
+      const etag = elementSource.immutable
+        ? IMMUTABLE_ETAG
+        : await elementSource.getEtag?.();
+      if (etag !== undefined && etag === clientEtags[slotId]) {
+        return;
+      }
+      elements[slotId] = await elementSource.render();
+      if (etag !== undefined) {
+        etags[slotId] = etag;
+      } else if (clientEtags[slotId] !== undefined) {
+        // clear the client's now-stale tag
+        etags[slotId] = '';
+      }
+    }),
+  );
+  return { elements, etags };
+};
 
 // Expose internal APIs
 // Subject to change without notice

--- a/packages/waku/src/minimal/server.ts
+++ b/packages/waku/src/minimal/server.ts
@@ -34,9 +34,10 @@ export const unstable_buildElements = async (
   const etags: Etags = {};
   await Promise.all(
     Object.entries(elementSources).map(async ([slotId, elementSource]) => {
+      // '' is the reserved clear sentinel, so an empty getEtag means no etag
       const etag = elementSource.immutable
         ? IMMUTABLE_ETAG
-        : await elementSource.getEtag?.();
+        : (await elementSource.getEtag?.()) || undefined;
       if (etag !== undefined && etag === clientEtags[slotId]) {
         return;
       }

--- a/packages/waku/src/minimal/server.ts
+++ b/packages/waku/src/minimal/server.ts
@@ -2,7 +2,7 @@ import type {
   Unstable_Handlers as Handlers,
   Unstable_ServerEntry as ServerEntry,
 } from '../lib/types.js';
-import { IMMUTABLE_ETAG } from '../lib/utils/etags.js';
+import { IMMUTABLE_ETAG, isValidEtag } from '../lib/utils/etags.js';
 import type { Etags } from '../lib/utils/etags.js';
 
 export function unstable_defineHandlers(handlers: Handlers) {
@@ -34,10 +34,11 @@ export const unstable_buildElements = async (
   const etags: Etags = {};
   await Promise.all(
     Object.entries(elementSources).map(async ([slotId, elementSource]) => {
-      // '' is the reserved clear sentinel, so an empty getEtag means no etag
-      const etag = elementSource.immutable
+      // keep only header-safe etags; '' (the clear sentinel) and invalid mean no etag
+      const rawEtag = elementSource.immutable
         ? IMMUTABLE_ETAG
-        : (await elementSource.getEtag?.()) || undefined;
+        : await elementSource.getEtag?.();
+      const etag = isValidEtag(rawEtag) ? rawEtag : undefined;
       if (etag !== undefined && etag === clientEtags[slotId]) {
         return;
       }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -28,9 +28,9 @@ import {
   Slot,
   unstable_addBase as addBase,
   unstable_getErrorInfo as getErrorInfo,
+  unstable_isImmutableElement as isImmutableElement,
   unstable_prefetchRsc as prefetchRsc,
   unstable_registerCallServerElementsListener as registerCallServerElementsListener,
-  unstable_registerFetchEnhancer as registerFetchEnhancer,
   unstable_removeBase as removeBase,
   useElementsPromise_UNSTABLE as useElementsPromise,
   useRefetch,
@@ -47,12 +47,9 @@ import type {
 } from './isomorphic-utils/build-route-href.js';
 import { matchRouteParams } from './isomorphic-utils/match-route-params.js';
 import {
-  ETAG_ID_PREFIX,
   HAS404_ID,
   IS_STATIC_ID,
   ROUTE_ID,
-  SKIP_HEADER,
-  STATIC_ETAG,
   encodeRoutePath,
   encodeSliceId,
   pathnameToRoutePath,
@@ -130,10 +127,7 @@ const getRouteFromElements = (
 };
 
 const isMetaKey = (key: string) =>
-  key === ROUTE_ID ||
-  key === HAS404_ID ||
-  key.startsWith(IS_STATIC_ID) ||
-  key.startsWith(ETAG_ID_PREFIX);
+  key === ROUTE_ID || key === HAS404_ID || key.startsWith(IS_STATIC_ID);
 
 const shouldScrollByDefault = (url: URL) =>
   pathnameToCurrentRoutePath(url.pathname) !==
@@ -168,22 +162,6 @@ const createRscParams = (query: string): URLSearchParams => {
   savedRscParams = [query, rscParams];
   return rscParams;
 };
-
-const createSkipHeaderEnhancer =
-  (cachedEtagsRef: { current: Record<string, string | typeof STATIC_ETAG> }) =>
-  (fetchFn: typeof fetch) =>
-  (input: RequestInfo | URL, init: RequestInit = {}) => {
-    const skipStr = JSON.stringify(cachedEtagsRef.current);
-    const headers = (init.headers ||= {});
-    if (Array.isArray(headers)) {
-      headers.push([SKIP_HEADER, skipStr]);
-    } else if (headers instanceof Headers) {
-      headers.set(SKIP_HEADER, skipStr);
-    } else {
-      (headers as Record<string, string>)[SKIP_HEADER] = skipStr;
-    }
-    return fetchFn(input, init);
-  };
 
 type ChangeRouteOptions = {
   shouldScroll: boolean;
@@ -900,8 +878,7 @@ export function Slice({
   const elements = use(elementsPromise);
   const needsToFetchSlice =
     props.lazy &&
-    (!(slotId in elements) ||
-      elements[ETAG_ID_PREFIX + slotId] !== STATIC_ETAG);
+    (!(slotId in elements) || !isImmutableElement(elements, slotId));
   useEffect(() => {
     // FIXME this works because of subtle timing behavior.
     if (needsToFetchSlice && !fetchingSlices.has(id)) {
@@ -984,15 +961,12 @@ const useElementsMetadata = (
 ) => {
   const [has404, setHas404] = useState(false);
   const staticPathSetRef = useRef(new Set<string>());
-  const cachedEtagsRef = useRef<Record<string, string | typeof STATIC_ETAG>>(
-    {},
-  );
+  const resolvedElementsRef = useRef<Record<string, unknown>>({});
   useEffect(() => {
     elementsPromise.then(
       (elements) => {
-        // Under `unstable_instant` the eager merge serves static etags and
-        // ROUTE_ID from the previous bag; a dynamic slot's etag stays a hole,
-        // so it is skipped here until it resolves rather than going stale.
+        // plain copy: the live elements may be an eager-merge Proxy, and isStaticSlot reads this ref
+        resolvedElementsRef.current = { ...elements };
         const {
           [ROUTE_ID]: routeData,
           [IS_STATIC_ID]: isStatic,
@@ -1007,24 +981,11 @@ const useElementsMetadata = (
             staticPathSetRef.current.add(path);
           }
         }
-        const etags: Record<string, string | typeof STATIC_ETAG> = {};
-        for (const [key, value] of Object.entries(elements)) {
-          // Keep the static sentinel; for string tags drop empty (clear
-          // signal) and non-Latin1 (breaks fetch).
-          if (
-            key.startsWith(ETAG_ID_PREFIX) &&
-            (value === STATIC_ETAG ||
-              (typeof value === 'string' && /^[\u0020-\u00ff]+$/.test(value)))
-          ) {
-            etags[key.slice(ETAG_ID_PREFIX.length)] = value;
-          }
-        }
-        cachedEtagsRef.current = etags;
       },
       () => {},
     );
   }, [elementsPromise]);
-  return { has404, staticPathSetRef, cachedEtagsRef };
+  return { has404, staticPathSetRef, resolvedElementsRef };
 };
 
 const defaultRouteInterceptor = (route: RouteProps) => route;
@@ -1046,9 +1007,10 @@ const InnerRouter = ({
   const initialRouteRef = useRef(resolvedRoute);
 
   if (import.meta.hot) {
+    // The etag cache is cleared by minimal's own reload listener, which Root
+    // registers (via unstable_fetchRsc) ahead of this one, so it runs first.
     const refetchRoute = () => {
       staticPathSetRef.current.clear();
-      cachedEtagsRef.current = {};
       const rscPath = encodeRoutePath(route.path);
       const rscParams = createRscParams(route.query);
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -1061,12 +1023,12 @@ const InnerRouter = ({
     if (index !== -1) {
       globalThis.__WAKU_RSC_RELOAD_LISTENERS__.splice(index, 1, refetchRoute);
     } else {
-      globalThis.__WAKU_RSC_RELOAD_LISTENERS__.unshift(refetchRoute);
+      globalThis.__WAKU_RSC_RELOAD_LISTENERS__.push(refetchRoute);
     }
     globalThis.__WAKU_REFETCH_ROUTE__ = refetchRoute;
   }
 
-  const { has404, staticPathSetRef, cachedEtagsRef } =
+  const { has404, staticPathSetRef, resolvedElementsRef } =
     useElementsMetadata(elementsPromise);
   // FIXME this "fetchingSlices" hack feels suboptimal.
   const fetchingSlicesRef = useRef(new Set<SliceId>());
@@ -1142,7 +1104,7 @@ const InnerRouter = ({
         options.refetch ?? !isSameRoute(nextRoute, routeBeforeChange);
       const pathChanged = isPathChange(nextRoute, routeBeforeChange);
       const isStaticSlot = (key: string) =>
-        cachedEtagsRef.current[key] === STATIC_ETAG;
+        isImmutableElement(resolvedElementsRef.current, key);
       const commitRoute = (route: RouteProps) => {
         routeRef.current = route;
         setRoute(route);
@@ -1186,10 +1148,7 @@ const InnerRouter = ({
         window.location.reload();
       };
       if (options.instant && isStaticSlot(getRouteSlotId(nextRoute.path))) {
-        const isEager = (key: string) =>
-          key.startsWith(ETAG_ID_PREFIX)
-            ? isStaticSlot(key.slice(ETAG_ID_PREFIX.length))
-            : isMetaKey(key) || isStaticSlot(key);
+        const isEager = (key: string) => isMetaKey(key) || isStaticSlot(key);
         const dataPromise = refetch(rscPath, rscParams, {
           signal: abortController.signal,
           unstable_isEager: isEager,
@@ -1253,7 +1212,7 @@ const InnerRouter = ({
       }
       commitInTransition();
     },
-    [emitRouteChangeEvent, refetch, staticPathSetRef, cachedEtagsRef],
+    [emitRouteChangeEvent, refetch, staticPathSetRef, resolvedElementsRef],
   );
   const applyChangeRouteData = useCallback(
     async (routeData: unknown, isStatic: unknown) => {
@@ -1280,10 +1239,6 @@ const InnerRouter = ({
       });
     },
     [changeRoute],
-  );
-  useEffect(
-    () => registerFetchEnhancer(createSkipHeaderEnhancer(cachedEtagsRef)),
-    [cachedEtagsRef],
   );
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
@@ -1413,7 +1368,6 @@ export type Unstable_RouteProps = RouteProps;
 export const unstable_HAS404_ID = HAS404_ID;
 export const unstable_IS_STATIC_ID = IS_STATIC_ID;
 export const unstable_ROUTE_ID = ROUTE_ID;
-export const unstable_SKIP_HEADER = SKIP_HEADER;
 export const unstable_encodeRoutePath = encodeRoutePath;
 export const unstable_encodeSliceId = encodeSliceId;
 export const unstable_getRouteSlotId = getRouteSlotId;

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -185,7 +185,7 @@ export type PathWithWildcard<
  * - Opaque to Waku; compared with `===`.
  * - Must change whenever the rendered content would.
  * - Keep it a short ASCII string (a hash or version): the client echoes its
- *   tags in a header.
+ *   tags in a header. A non-header-safe or empty value is treated as no tag.
  * - Return `undefined` for no tag: the element is always sent, overriding the
  *   client's cache for the slot.
  */

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -2,10 +2,15 @@ import type { ReactNode } from 'react';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   unstable_base64ToBytes as base64ToBytes,
+  unstable_buildElements as buildElements,
   unstable_bytesToBase64 as bytesToBase64,
   unstable_createCustomError as createCustomError,
   unstable_defineHandlers as defineHandlers,
   unstable_getErrorInfo as getErrorInfo,
+} from '../minimal/server.js';
+import type {
+  Unstable_ElementSource as ElementSource,
+  Unstable_Etags as Etags,
 } from '../minimal/server.js';
 import { deserializeRsc, serializeRsc } from '../server.js';
 import { INTERNAL_ServerRouter } from './client.js';
@@ -24,12 +29,9 @@ import {
 } from './isomorphic-utils/path-spec.js';
 import type { PathSpec } from './isomorphic-utils/path-spec.js';
 import {
-  ETAG_ID_PREFIX,
   HAS404_ID,
   IS_STATIC_ID,
   ROUTE_ID,
-  SKIP_HEADER,
-  STATIC_ETAG,
   decodeRoutePath,
   decodeSliceId,
   encodeRoutePath,
@@ -41,22 +43,6 @@ export type ApiHandler = (
   req: Request,
   apiContext: { params: Record<string, string | string[]> },
 ) => Promise<Response>;
-
-const isEtagRecord = (
-  x: unknown,
-): x is Record<string, string | typeof STATIC_ETAG> =>
-  typeof x === 'object' &&
-  x !== null &&
-  !Array.isArray(x) &&
-  Object.values(x).every((v) => typeof v === 'string' || v === STATIC_ETAG);
-
-const safeJsonParse = (text: string): unknown => {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return undefined;
-  }
-};
 
 const parseRscParams = (
   rscParams: unknown,
@@ -211,6 +197,11 @@ export function unstable_redirect<Path extends RoutePath = RoutePath>(
 
 type SlotId = string;
 
+type RouteEntries = {
+  elements: Record<string, unknown>;
+  etags: Etags;
+};
+
 const ROOT_SLOT_ID = 'root';
 const ROUTE_SLOT_ID_PREFIX = 'route:';
 const SLICE_SLOT_ID_PREFIX = 'slice:';
@@ -277,6 +268,12 @@ type GetEtagFromOption = (
 type GetEtagFromParams = (
   params?: Record<string, string | string[]>,
 ) => Promise<string | undefined>;
+
+const bindEtag = <A,>(
+  getEtag: ((arg: A) => Promise<string | undefined>) | undefined,
+  arg: A,
+): (() => Promise<string | undefined>) | undefined =>
+  getEtag && (() => getEtag(arg));
 
 type RouteConfig = {
   type: 'route';
@@ -723,9 +720,9 @@ export function unstable_defineRouter(fns: {
   const getEntriesForRoute = async (
     rscPath: string,
     rscParams: unknown,
-    headers: Readonly<Record<string, string>>,
+    clientEtags: Etags,
     elementCache: ElementCache,
-  ) => {
+  ): Promise<RouteEntries | null> => {
     setRscPath(rscPath);
     setRscParams(rscParams);
     const routePath = decodeRoutePath(rscPath);
@@ -733,11 +730,6 @@ export function unstable_defineRouter(fns: {
     if (pathConfigItem?.type !== 'route') {
       return null;
     }
-    const parsedEtags = safeJsonParse(
-      headers[SKIP_HEADER.toLowerCase()] || '{}',
-    );
-    const clientEtags: Record<string, string | typeof STATIC_ETAG> =
-      isEtagRecord(parsedEtags) ? parsedEtags : {};
     const { query } = parseRscParams(rscParams);
     const routeId = ROUTE_SLOT_ID_PREFIX + routePath;
     const routeTemplateCacheId = getPathSpecCacheId(pathConfigItem.path);
@@ -767,82 +759,67 @@ export function unstable_defineRouter(fns: {
         });
       }
     });
-    const entries: Record<SlotId, unknown> = {};
-    const addEntry = async (
-      slotId: SlotId,
+    const makeElementSource = (
       isStatic: boolean,
       cacheId: CacheId,
       render: () => ReactNode | Promise<ReactNode>,
-      getEtag: () => Promise<string | undefined> | undefined,
-    ) => {
-      if (isStatic) {
-        if (clientEtags[slotId] === STATIC_ETAG) {
-          return;
-        }
-        if (!elementCache.get(cacheId)) {
-          await elementCache.set(cacheId, await render());
-        }
-        entries[slotId] = await elementCache.get(cacheId);
-        entries[ETAG_ID_PREFIX + slotId] = STATIC_ETAG;
-      } else {
-        const etag = await getEtag();
-        if (etag !== undefined && etag === clientEtags[slotId]) {
-          return;
-        }
-        entries[slotId] = await render();
-        if (etag !== undefined) {
-          entries[ETAG_ID_PREFIX + slotId] = etag;
-        } else if (clientEtags[slotId] !== undefined) {
-          // The slot no longer has a tag but the client still holds one; send
-          // an empty tag to clear it (the client drops empty tags).
-          entries[ETAG_ID_PREFIX + slotId] = '';
-        }
-      }
-    };
-    await Promise.all([
-      addEntry(
-        ROOT_SLOT_ID,
+      getEtag?: () => Promise<string | undefined>,
+    ): ElementSource =>
+      isStatic
+        ? {
+            immutable: true,
+            render: async () => {
+              if (!elementCache.get(cacheId)) {
+                await elementCache.set(cacheId, await render());
+              }
+              return elementCache.get(cacheId);
+            },
+          }
+        : { getEtag, render };
+    const elementSources: Record<SlotId, ElementSource> = {
+      [ROOT_SLOT_ID]: makeElementSource(
         pathConfigItem.rootElement.isStatic,
         getSlotCacheId(ROOT_SLOT_ID),
         () => pathConfigItem.rootElement.renderer(option),
-        () => pathConfigItem.rootElement.getEtagFromOption?.(option),
+        bindEtag(pathConfigItem.rootElement.getEtagFromOption, option),
       ),
-      addEntry(
-        routeId,
+      [routeId]: makeElementSource(
         pathConfigItem.routeElement.isStatic,
         routeTemplateCacheId,
         () => pathConfigItem.routeElement.renderer(option),
-        () => pathConfigItem.routeElement.getEtagFromOption?.(option),
+        bindEtag(pathConfigItem.routeElement.getEtagFromOption, option),
       ),
-      ...Object.entries(pathConfigItem.elements).map(([id, el]) =>
-        addEntry(
-          id,
-          el.isStatic,
-          getSlotCacheId(id),
-          () => el.renderer(option),
-          () => el.getEtagFromOption?.(option),
-        ),
-      ),
-      ...slices.map((sliceId) => {
-        const sliceConfig = sliceConfigMap.get(sliceId);
-        if (!sliceConfig) {
-          throw new Error(`Slice not found: ${sliceId}`);
-        }
-        return addEntry(
-          SLICE_SLOT_ID_PREFIX + sliceId,
-          sliceConfig.isStatic,
-          getSlotCacheId(SLICE_SLOT_ID_PREFIX + sliceId),
-          () => sliceConfig.renderer(sliceConfig.params),
-          () => sliceConfig.getEtagFromParams?.(sliceConfig.params),
-        );
-      }),
-    ]);
-    entries[ROUTE_ID] = [routePath, query];
-    entries[IS_STATIC_ID] = pathConfigItem.isStatic;
-    if (has404()) {
-      entries[HAS404_ID] = true;
+    };
+    for (const [id, el] of Object.entries(pathConfigItem.elements)) {
+      elementSources[id] = makeElementSource(
+        el.isStatic,
+        getSlotCacheId(id),
+        () => el.renderer(option),
+        bindEtag(el.getEtagFromOption, option),
+      );
     }
-    return entries;
+    for (const sliceId of slices) {
+      const sliceConfig = sliceConfigMap.get(sliceId);
+      if (!sliceConfig) {
+        throw new Error(`Slice not found: ${sliceId}`);
+      }
+      elementSources[SLICE_SLOT_ID_PREFIX + sliceId] = makeElementSource(
+        sliceConfig.isStatic,
+        getSlotCacheId(SLICE_SLOT_ID_PREFIX + sliceId),
+        () => sliceConfig.renderer(sliceConfig.params),
+        bindEtag(sliceConfig.getEtagFromParams, sliceConfig.params),
+      );
+    }
+    const { elements, etags } = await buildElements(
+      clientEtags,
+      elementSources,
+    );
+    elements[ROUTE_ID] = [routePath, query];
+    elements[IS_STATIC_ID] = pathConfigItem.isStatic;
+    if (has404()) {
+      elements[HAS404_ID] = true;
+    }
+    return { elements, etags };
   };
 
   type HandleRequest = Parameters<typeof defineHandlers>[0]['handleRequest'];
@@ -883,35 +860,40 @@ export function unstable_defineRouter(fns: {
         return cachedPath2moduleIds!;
       };
 
-      const headers = Object.fromEntries(input.req.headers.entries());
+      const clientEtags = input.etags ?? {};
       const withRerender = async <T,>(fn: () => Promise<T>) => {
-        let elementsPromise: Promise<Record<string, unknown>> = Promise.resolve(
-          {},
-        );
+        let entriesPromise: Promise<RouteEntries> = Promise.resolve({
+          elements: {},
+          etags: {},
+        });
         let rendered = false;
         const rerender = (rscPath: string, rscParams?: unknown) => {
           if (rendered) {
             throw new Error('already rendered');
           }
-          elementsPromise = Promise.all([
-            elementsPromise,
+          entriesPromise = Promise.all([
+            entriesPromise,
             getEntriesForRoute(
               rscPath,
               rscParams,
-              headers,
+              clientEtags,
               requestElementCache,
             ),
-          ]).then(([oldElements, newElements]) => {
-            if (newElements === null) {
+          ]).then(([oldEntries, newEntries]) => {
+            if (newEntries === null) {
               console.warn('getEntries returned null');
+              return oldEntries;
             }
-            return { ...oldElements, ...newElements };
+            return {
+              elements: { ...oldEntries.elements, ...newEntries.elements },
+              etags: { ...oldEntries.etags, ...newEntries.etags },
+            };
           });
         };
         setRerender(rerender);
         try {
           const value = await fn();
-          return { value, elements: await elementsPromise };
+          return { value, entries: await entriesPromise };
         } finally {
           rendered = true;
         }
@@ -930,40 +912,43 @@ export function unstable_defineRouter(fns: {
             return null;
           }
           const { sliceConfig, params: sliceParams } = found;
-          const sliceEtag = sliceConfig.isStatic
-            ? STATIC_ETAG
-            : await sliceConfig.getEtagFromParams?.(sliceParams);
-          const sliceElement = await getSliceElement(
-            sliceConfig,
-            requestElementCache,
-            sliceId,
-            sliceParams,
+          const sliceSlotId = SLICE_SLOT_ID_PREFIX + sliceId;
+          const { elements, etags } = await buildElements(
+            {},
+            {
+              [sliceSlotId]: {
+                immutable: sliceConfig.isStatic,
+                getEtag: bindEtag(sliceConfig.getEtagFromParams, sliceParams),
+                render: () =>
+                  getSliceElement(
+                    sliceConfig,
+                    requestElementCache,
+                    sliceId,
+                    sliceParams,
+                  ),
+              },
+            },
           );
-          return renderRsc({
-            [SLICE_SLOT_ID_PREFIX + sliceId]: sliceElement,
-            ...(sliceEtag !== undefined
-              ? { [ETAG_ID_PREFIX + SLICE_SLOT_ID_PREFIX + sliceId]: sliceEtag }
-              : {}),
-          });
+          return renderRsc(elements, { etags });
         }
         const entries = await getEntriesForRoute(
           input.rscPath,
           input.rscParams,
-          headers,
+          clientEtags,
           requestElementCache,
         );
         if (!entries) {
           return null;
         }
-        return renderRsc(entries);
+        return renderRsc(entries.elements, { etags: entries.etags });
       }
 
       if (input.type === 'function') {
         try {
-          const { value, elements } = await withRerender(() =>
+          const { value, entries } = await withRerender(() =>
             input.fn(...input.args),
           );
-          return renderRsc(elements, { value });
+          return renderRsc(entries.elements, { value, etags: entries.etags });
         } catch (e) {
           const info = getErrorInfo(e);
           if (info?.location) {
@@ -972,13 +957,13 @@ export function unstable_defineRouter(fns: {
             const entries = await getEntriesForRoute(
               rscPath,
               undefined,
-              headers,
+              clientEtags,
               requestElementCache,
             );
             if (!entries) {
               unstable_notFound();
             }
-            return renderRsc(entries);
+            return renderRsc(entries.elements, { etags: entries.etags });
           }
           throw e;
         }
@@ -1005,7 +990,7 @@ export function unstable_defineRouter(fns: {
           let entries = await getEntriesForRoute(
             rscPath,
             rscParams,
-            headers,
+            clientEtags,
             requestElementCache,
           );
           if (!entries) {
@@ -1017,19 +1002,28 @@ export function unstable_defineRouter(fns: {
           const html = <INTERNAL_ServerRouter route={route} />;
           let formState: unknown;
           if (input.type === 'action') {
-            const { value, elements } = await withRerender(() => input.fn());
+            const { value, entries: rerendered } = await withRerender(() =>
+              input.fn(),
+            );
             formState = value;
-            entries = { ...entries, ...elements };
+            entries = {
+              elements: { ...entries.elements, ...rerendered.elements },
+              etags: { ...entries.etags, ...rerendered.etags },
+            };
           }
-          return renderHtml(await renderRsc(entries), html, {
-            rscPath,
-            formState,
-            status,
-            ...(nonce ? { nonce } : {}),
-            unstable_extraScriptContent:
-              getRouterPrefetchCode(path2moduleIds) +
-              setupRouterSearchCodecs(getCachedConfigs()),
-          });
+          return renderHtml(
+            await renderRsc(entries.elements, { etags: entries.etags }),
+            html,
+            {
+              rscPath,
+              formState,
+              status,
+              ...(nonce ? { nonce } : {}),
+              unstable_extraScriptContent:
+                getRouterPrefetchCode(path2moduleIds) +
+                setupRouterSearchCodecs(getCachedConfigs()),
+            },
+          );
         };
         const url = new URL(input.req.url);
         const query = url.searchParams.toString();
@@ -1203,12 +1197,13 @@ export function unstable_defineRouter(fns: {
           if (!entries) {
             return;
           }
-          for (const id of Object.keys(entries)) {
+          for (const id of Object.keys(entries.elements)) {
             const cached = buildElementCache.get(id);
-            entries[id] = cached ? await cached : entries[id];
+            entries.elements[id] = cached ? await cached : entries.elements[id];
           }
           const moduleIds = new Set<string>();
-          const stream = await renderRsc(entries, {
+          const stream = await renderRsc(entries.elements, {
+            etags: entries.etags,
             unstable_clientModuleCallback: (ids) =>
               ids.forEach((id) => moduleIds.add(id)),
           });
@@ -1280,11 +1275,17 @@ export function unstable_defineRouter(fns: {
       const req = new Request(new URL('http://localhost:3000'));
       runTask(async () => {
         await runHandled(req, async () => {
-          const sliceElement = await getSliceElement(item, buildElementCache);
-          const body = await renderRsc({
-            [SLICE_SLOT_ID_PREFIX + item.id]: sliceElement,
-            [ETAG_ID_PREFIX + SLICE_SLOT_ID_PREFIX + item.id]: STATIC_ETAG,
-          });
+          const sliceSlotId = SLICE_SLOT_ID_PREFIX + item.id;
+          const { elements, etags } = await buildElements(
+            {},
+            {
+              [sliceSlotId]: {
+                immutable: true,
+                render: () => getSliceElement(item, buildElementCache),
+              },
+            },
+          );
+          const body = await renderRsc(elements, { etags });
           await generateFile(rscPath2pathname(rscPath), body);
         });
       });

--- a/packages/waku/src/router/isomorphic-utils/route-path.ts
+++ b/packages/waku/src/router/isomorphic-utils/route-path.ts
@@ -84,10 +84,3 @@ export function decodeSliceId(rscPath: string): string | null {
 export const ROUTE_ID = 'ROUTE';
 export const IS_STATIC_ID = 'IS_STATIC';
 export const HAS404_ID = 'HAS404';
-export const ETAG_ID_PREFIX = 'ETAG:';
-// Etag for any static slot, known without rendering. A number, never a string,
-// so it cannot equal a user `unstable_getEtag` value.
-export const STATIC_ETAG = 1;
-
-// For HTTP header
-export const SKIP_HEADER = 'X-Waku-Router-Skip';

--- a/packages/waku/tests/define-router-action.test.ts
+++ b/packages/waku/tests/define-router-action.test.ts
@@ -69,6 +69,7 @@ describe('define-router action requests', () => {
     expect(apiHandler).not.toHaveBeenCalled();
     expect(renderRsc).toHaveBeenCalledWith(
       expect.objectContaining({ [ROUTE_ID]: ['/about', ''] }),
+      { etags: {} },
     );
   });
 
@@ -111,7 +112,10 @@ describe('define-router action requests', () => {
 
     expect(apiHandler).not.toHaveBeenCalled();
     expect(actionFn).toHaveBeenCalledWith('arg');
-    expect(renderRsc).toHaveBeenCalledWith({}, { value: 'action-result' });
+    expect(renderRsc).toHaveBeenCalledWith(
+      {},
+      { value: 'action-result', etags: {} },
+    );
   });
 
   it('sets router initial route for 404 HTML', async () => {
@@ -147,6 +151,7 @@ describe('define-router action requests', () => {
 
     expect(renderRsc).toHaveBeenCalledWith(
       expect.objectContaining({ [ROUTE_ID]: ['/404', ''] }),
+      { etags: {} },
     );
     expect(renderHtml).toHaveBeenCalledWith(
       expect.any(ReadableStream),
@@ -201,6 +206,7 @@ describe('define-router action requests', () => {
       expect.objectContaining({
         'page:/': 'page:after',
       }),
+      { etags: {} },
     );
     expect(renderHtml).toHaveBeenCalledWith(
       expect.any(ReadableStream),
@@ -265,6 +271,7 @@ describe('define-router action requests', () => {
       expect.objectContaining({
         'page:/': 'page:after',
       }),
+      { etags: {} },
     );
     expect(renderHtml).toHaveBeenCalledWith(
       expect.any(ReadableStream),

--- a/packages/waku/tests/define-router-etag.test.ts
+++ b/packages/waku/tests/define-router-etag.test.ts
@@ -1,12 +1,15 @@
 import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { unstable_defineRouter } from '../src/router/define-router.js';
 import {
   ETAG_ID_PREFIX,
+  IMMUTABLE_ETAG,
+  parseClientEtags,
+} from '../src/lib/utils/etags.js';
+import type { Etags } from '../src/lib/utils/etags.js';
+import { unstable_defineRouter } from '../src/router/define-router.js';
+import {
   IS_STATIC_ID,
-  SKIP_HEADER,
-  STATIC_ETAG,
   encodeRoutePath,
   encodeSliceId,
 } from '../src/router/isomorphic-utils/route-path.js';
@@ -48,11 +51,12 @@ const buildRouter = (elements: Record<string, ElementSpec>) =>
     ],
   });
 
-// Drive a single RSC ("component") request and capture the entries record that
-// the router hands to renderRsc, so we can assert which slots were sent.
+// Drive a single RSC request and reconstruct the on-wire record: the `elements`
+// the router passes to renderRsc, merged with its `etags` re-encoded as
+// `_etag:<slot>` keys (what renderRsc attaches post-validation).
 const drive = async (
   router: ReturnType<typeof unstable_defineRouter>,
-  headers: Record<string, string>,
+  etags: Etags,
   rscPath = encodeRoutePath('/foo'),
 ): Promise<Record<string, unknown>> => {
   let captured: Record<string, unknown> = {};
@@ -62,13 +66,22 @@ const drive = async (
       pathname: '/foo',
       rscPath,
       rscParams: undefined,
-      req: new Request('http://localhost/foo', { headers }),
+      req: new Request('http://localhost/foo'),
+      etags,
     },
     {
-      renderRsc: vi.fn(async (entries: unknown) => {
-        captured = entries as Record<string, unknown>;
-        return makeStream();
-      }),
+      renderRsc: vi.fn(
+        async (
+          elements: Record<string, unknown>,
+          options?: { etags?: Record<string, unknown> },
+        ) => {
+          captured = { ...elements };
+          for (const [slotId, tag] of Object.entries(options?.etags ?? {})) {
+            captured[ETAG_ID_PREFIX + slotId] = tag;
+          }
+          return makeStream();
+        },
+      ),
       parseRsc: vi.fn(),
       renderHtml: vi.fn(),
       loadBuildMetadata: vi.fn(),
@@ -79,23 +92,20 @@ const drive = async (
 
 const getEntries = (
   router: ReturnType<typeof unstable_defineRouter>,
-  clientEtags?: Record<string, string | typeof STATIC_ETAG>,
-): Promise<Record<string, unknown>> =>
-  drive(
-    router,
-    clientEtags ? { [SKIP_HEADER]: JSON.stringify(clientEtags) } : {},
-  );
+  clientEtags?: Record<string, string | typeof IMMUTABLE_ETAG>,
+): Promise<Record<string, unknown>> => drive(router, clientEtags ?? {});
 
-// Drive with a raw, un-serialized skip header (for legacy/malformed inputs).
-const getEntriesWithSkipHeader = (
+// Drive with a raw, un-serialized etags header value parsed through the real
+// minimal parser (for legacy/malformed inputs), mirroring what getInput does.
+const getEntriesWithEtagsHeader = (
   router: ReturnType<typeof unstable_defineRouter>,
-  skipHeader: string,
+  etagsHeader: string,
 ): Promise<Record<string, unknown>> =>
-  drive(router, { [SKIP_HEADER]: skipHeader });
+  drive(router, parseClientEtags(etagsHeader));
 
 const etagKey = (slotId: string) => `${ETAG_ID_PREFIX}${slotId}`;
 
-describe('define-router etags (element tag skip)', () => {
+describe('define-router etags (per-slot omit)', () => {
   it('sends a dynamic slot with its etag when the client has none', async () => {
     const router = buildRouter({
       page: {
@@ -179,9 +189,9 @@ describe('define-router etags (element tag skip)', () => {
 
     const first = await getEntries(router);
     expect('page' in first).toBe(true);
-    expect(first[etagKey('page')]).toBe(STATIC_ETAG);
+    expect(first[etagKey('page')]).toBe(IMMUTABLE_ETAG);
 
-    const second = await getEntries(router, { page: STATIC_ETAG });
+    const second = await getEntries(router, { page: IMMUTABLE_ETAG });
     expect('page' in second).toBe(false);
     expect(etagKey('page') in second).toBe(false);
   });
@@ -196,7 +206,7 @@ describe('define-router etags (element tag skip)', () => {
     });
 
     const entries = await getEntries(router);
-    expect(entries[etagKey('page')]).toBe(STATIC_ETAG);
+    expect(entries[etagKey('page')]).toBe(IMMUTABLE_ETAG);
   });
 
   it('passes the element option to getEtag', async () => {
@@ -216,7 +226,7 @@ describe('define-router etags (element tag skip)', () => {
     expect(seen).toContainEqual(expect.objectContaining({ routePath: '/foo' }));
   });
 
-  it('applies the same etag skip to a dynamic slice', async () => {
+  it('applies the same etag omit to a dynamic slice', async () => {
     let sliceTag = 'sv1';
     const router = unstable_defineRouter({
       getConfigs: async () => [
@@ -278,7 +288,7 @@ describe('define-router etags (element tag skip)', () => {
     expect(calls).toEqual(['etag', 'render']);
   });
 
-  it('applies the etag skip to the root element', async () => {
+  it('applies the etag omit to the root element', async () => {
     let tag = 'r1';
     const router = unstable_defineRouter({
       getConfigs: async () => [
@@ -389,26 +399,34 @@ describe('define-router etags (element tag skip)', () => {
 
     const entries = await getEntries(router);
     expect(entries['slice:mySlice']).toBeDefined();
-    expect(entries[etagKey('slice:mySlice')]).toBe(STATIC_ETAG);
+    expect(entries[etagKey('slice:mySlice')]).toBe(IMMUTABLE_ETAG);
     // the etag is the only static signal; no IS_STATIC:<slot> marker
     expect(`${IS_STATIC_ID}:slice:mySlice` in entries).toBe(false);
   });
 
-  it('ignores a legacy, malformed, or non-string skip header', async () => {
+  it('ignores a legacy, malformed, or non-string etags header', async () => {
     const build = () =>
       buildRouter({
         page: { isStatic: true, renderer: () => createElement('div') },
       });
 
-    // A valid map would skip the static slot; these never do.
+    // A valid map would omit the static slot; these never do.
     for (const header of [
       JSON.stringify(['page']), // legacy array of ids
       'not json',
       JSON.stringify({ page: 123 }), // non-string value other than the sentinel
     ]) {
-      const entries = await getEntriesWithSkipHeader(build(), header);
+      const entries = await getEntriesWithEtagsHeader(build(), header);
       expect('page' in entries).toBe(true);
-      expect(entries[etagKey('page')]).toBe(STATIC_ETAG);
+      expect(entries[etagKey('page')]).toBe(IMMUTABLE_ETAG);
     }
+  });
+
+  it('parseClientEtags keeps only string and sentinel values', () => {
+    expect(
+      parseClientEtags(
+        JSON.stringify({ keep: 'v1', sentinel: IMMUTABLE_ETAG, drop: 123 }),
+      ),
+    ).toEqual({ keep: 'v1', sentinel: IMMUTABLE_ETAG });
   });
 });

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment happy-dom
+
+// Proves the per-slot cache-validator carry/replay lives in the minimal layer
+// (router-agnostic), driving the real minimal Root.
+import { act } from 'react';
+import type { ReactElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ETAGS_HEADER,
+  ETAG_ID_PREFIX,
+  IMMUTABLE_ETAG,
+  isValidEtag,
+} from '../src/lib/utils/etags.js';
+import {
+  CACHED_ETAGS,
+  ENTRY,
+  FETCH_ENHANCERS,
+  SET_ELEMENTS,
+  fetchRscStore,
+} from '../src/minimal/client-utils/fetch-store.js';
+import {
+  Root,
+  unstable_isImmutableElement as isImmutableElement,
+  unstable_prefetchRsc as prefetchRsc,
+  useRefetch,
+} from '../src/minimal/client.js';
+import { unstable_buildElements as buildElements } from '../src/minimal/server.js';
+
+const testHoisted = vi.hoisted(() => ({
+  elements: {} as Record<string, unknown>,
+}));
+
+vi.mock('react-server-dom-webpack/client', () => ({
+  default: {
+    createFromFetch: vi.fn(async (responsePromise: Promise<Response>) => {
+      await responsePromise;
+      return testHoisted.elements;
+    }),
+    encodeReply: vi.fn(async () => ''),
+    createTemporaryReferenceSet: vi.fn(() => new Map()),
+  },
+}));
+
+const flush = async () => {
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve));
+  });
+};
+
+const renderApp = async (element: ReactElement) => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  return {
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+};
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(null, { status: 200 }),
+  );
+  delete fetchRscStore[ENTRY];
+  delete fetchRscStore[SET_ELEMENTS];
+  delete fetchRscStore[FETCH_ENHANCERS];
+  delete fetchRscStore[CACHED_ETAGS];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('minimal per-slot cache-validator (carry + replay)', () => {
+  it('caches header-safe tags from a response and drops the clear/non-Latin1 ones', async () => {
+    testHoisted.elements = {
+      page: <div>page</div>,
+      [`${ETAG_ID_PREFIX}page`]: 'etag-foo',
+      [`${ETAG_ID_PREFIX}bar`]: 'etag-bar',
+      // numeric sentinel-style tag (opaque to minimal) is carried
+      [`${ETAG_ID_PREFIX}static`]: 1,
+      // empty string is the server's "clear" signal -> dropped
+      [`${ETAG_ID_PREFIX}cleared`]: '',
+      // non-Latin1 cannot ride in a header -> dropped
+      [`${ETAG_ID_PREFIX}nonLatin1`]: 'tag-☃',
+    };
+
+    const view = await renderApp(
+      <Root initialRscPath="R/foo">
+        <div>child</div>
+      </Root>,
+    );
+    await flush();
+
+    const cached = fetchRscStore[CACHED_ETAGS] ?? {};
+    expect(cached.page).toBe('etag-foo');
+    expect(cached.bar).toBe('etag-bar');
+    expect(cached.static).toBe(1);
+    expect('cleared' in cached).toBe(false);
+    expect('nonLatin1' in cached).toBe(false);
+
+    view.unmount();
+  });
+
+  it('sends the cached tags in the etags request header', () => {
+    fetchRscStore[CACHED_ETAGS] = { page: 'etag-foo' };
+
+    prefetchRsc('R/bar');
+
+    // requestRsc built the request init with the cached tags as a header.
+    const fetchSpy = globalThis.fetch as ReturnType<typeof vi.fn>;
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const header = (init.headers as Record<string, string>)[ETAGS_HEADER];
+    expect(JSON.parse(header as string)).toEqual({ page: 'etag-foo' });
+  });
+
+  it('isImmutableElement detects the immutable sentinel by tag', () => {
+    const elements = {
+      [`${ETAG_ID_PREFIX}static`]: IMMUTABLE_ETAG,
+      [`${ETAG_ID_PREFIX}dynamic`]: 'v1',
+    };
+    expect(isImmutableElement(elements, 'static')).toBe(true);
+    expect(isImmutableElement(elements, 'dynamic')).toBe(false);
+    expect(isImmutableElement(elements, 'missing')).toBe(false);
+  });
+
+  it('keeps a static slot etag eager through an instant-nav merge', async () => {
+    testHoisted.elements = {
+      page: <div>a</div>,
+      [`${ETAG_ID_PREFIX}page`]: IMMUTABLE_ETAG,
+    };
+    let refetch!: ReturnType<typeof useRefetch>;
+    const Capture = () => {
+      refetch = useRefetch();
+      return null;
+    };
+    const view = await renderApp(
+      <Root initialRscPath="R/foo">
+        <Capture />
+      </Root>,
+    );
+    await flush();
+
+    // an instant nav: a fresh fetch, with the static slot marked eager
+    testHoisted.elements = {
+      page: <div>b</div>,
+      [`${ETAG_ID_PREFIX}page`]: IMMUTABLE_ETAG,
+    };
+    await act(async () => {
+      await refetch('R/bar', undefined, {
+        unstable_isEager: (key) => key === 'page',
+      });
+    });
+    await flush();
+
+    // the etag survived the eager-merge Proxy as a value, not dropped as a
+    // pending promise (which collectCachedEtags would reject)
+    expect(fetchRscStore[CACHED_ETAGS]?.page).toBe(IMMUTABLE_ETAG);
+
+    view.unmount();
+  });
+});
+
+describe('unstable_buildElements', () => {
+  it('omits matched slots, attaches/clears tags, and maps immutable to the sentinel', async () => {
+    const render = () => Promise.resolve('el');
+    const { elements, etags } = await buildElements(
+      { match: 'v1', stale: 'old' },
+      {
+        match: { getEtag: () => Promise.resolve('v1'), render },
+        changed: { getEtag: () => Promise.resolve('v2'), render },
+        immut: { immutable: true, render },
+        stale: { getEtag: () => Promise.resolve(undefined), render },
+      },
+    );
+
+    expect(Object.keys(elements).sort()).toEqual(['changed', 'immut', 'stale']);
+    expect(etags).toEqual({ changed: 'v2', immut: IMMUTABLE_ETAG, stale: '' });
+  });
+});
+
+describe('isValidEtag', () => {
+  it('accepts the sentinel and header-safe strings, rejects empty and non-Latin1', () => {
+    expect(isValidEtag(IMMUTABLE_ETAG)).toBe(true);
+    expect(isValidEtag('v1')).toBe(true);
+    expect(isValidEtag('')).toBe(false);
+    expect(isValidEtag('tag-☃')).toBe(false);
+    expect(isValidEtag(123)).toBe(false);
+  });
+});

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -184,14 +184,17 @@ describe('unstable_buildElements', () => {
     expect(etags).toEqual({ changed: 'v2', immut: IMMUTABLE_ETAG, stale: '' });
   });
 
-  it('treats an empty-string getEtag as no etag, not the clear sentinel', async () => {
+  it('drops empty or invalid getEtag results server-side (no etag, not the clear sentinel)', async () => {
     const render = () => Promise.resolve('el');
     const { elements, etags } = await buildElements(
       {},
-      { empty: { getEtag: () => Promise.resolve(''), render } },
+      {
+        empty: { getEtag: () => Promise.resolve(''), render },
+        control: { getEtag: () => Promise.resolve('tag\x7f'), render },
+      },
     );
 
-    expect(elements).toEqual({ empty: 'el' });
+    expect(elements).toEqual({ empty: 'el', control: 'el' });
     expect(etags).toEqual({});
   });
 });

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -183,13 +183,27 @@ describe('unstable_buildElements', () => {
     expect(Object.keys(elements).sort()).toEqual(['changed', 'immut', 'stale']);
     expect(etags).toEqual({ changed: 'v2', immut: IMMUTABLE_ETAG, stale: '' });
   });
+
+  it('treats an empty-string getEtag as no etag, not the clear sentinel', async () => {
+    const render = () => Promise.resolve('el');
+    const { elements, etags } = await buildElements(
+      {},
+      { empty: { getEtag: () => Promise.resolve(''), render } },
+    );
+
+    expect(elements).toEqual({ empty: 'el' });
+    expect(etags).toEqual({});
+  });
 });
 
 describe('isValidEtag', () => {
-  it('accepts the sentinel and header-safe strings, rejects empty and non-Latin1', () => {
+  it('accepts the sentinel and printable Latin-1, rejects empty, control, and non-Latin1', () => {
     expect(isValidEtag(IMMUTABLE_ETAG)).toBe(true);
     expect(isValidEtag('v1')).toBe(true);
+    expect(isValidEtag('café')).toBe(true);
     expect(isValidEtag('')).toBe(false);
+    expect(isValidEtag('tag\x7f')).toBe(false);
+    expect(isValidEtag('tag\x80')).toBe(false);
     expect(isValidEtag('tag-☃')).toBe(false);
     expect(isValidEtag(123)).toBe(false);
   });

--- a/packages/waku/tests/render-utils.test.ts
+++ b/packages/waku/tests/render-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
+import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import { createRenderUtils } from '../src/lib/utils/render.js';
 
 const makeRenderUtils = () => {
@@ -25,6 +26,25 @@ describe('createRenderUtils', () => {
 
     expect(renderToReadableStream).toHaveBeenCalledWith(
       { App: 'app', _value: undefined },
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test('attaches _etag:<slot> keys from the etags option, past id validation', async () => {
+    const { renderToReadableStream, renderUtils } = makeRenderUtils();
+
+    await renderUtils.renderRsc(
+      { App: 'app' },
+      { etags: { page: 'v1', slice: IMMUTABLE_ETAG } },
+    );
+
+    expect(renderToReadableStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        App: 'app',
+        [`${ETAG_ID_PREFIX}page`]: 'v1',
+        [`${ETAG_ID_PREFIX}slice`]: IMMUTABLE_ETAG,
+      }),
       expect.anything(),
       expect.anything(),
     );

--- a/packages/waku/tests/request.test.ts
+++ b/packages/waku/tests/request.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { resolveConfig } from '../src/lib/utils/config.js';
 import { getErrorInfo } from '../src/lib/utils/custom-errors.js';
+import { ETAGS_HEADER } from '../src/lib/utils/etags.js';
 import { getInput } from '../src/lib/utils/request.js';
 
 const makeConfig = () => {
@@ -125,5 +126,28 @@ describe('getInput server action request validation', () => {
         ),
       ),
     ).resolves.toBe(403);
+  });
+});
+
+describe('getInput etags', () => {
+  it('parses the etags header into input.etags', async () => {
+    const input = await makeInput(
+      makeRequest({
+        origin: 'https://app.test',
+        [ETAGS_HEADER]: JSON.stringify({ page: 'v1' }),
+      }),
+    );
+
+    expect(input.etags).toEqual({ page: 'v1' });
+  });
+
+  it('defaults input.etags to {} for an absent or malformed header', async () => {
+    const absent = await makeInput(makeRequest({ origin: 'https://app.test' }));
+    expect(absent.etags).toEqual({});
+
+    const malformed = await makeInput(
+      makeRequest({ origin: 'https://app.test', [ETAGS_HEADER]: 'nope' }),
+    );
+    expect(malformed.etags).toEqual({});
   });
 });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -17,6 +17,7 @@ import {
   vi,
 } from 'vitest';
 import { createCustomError } from '../src/lib/utils/custom-errors.js';
+import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import { fetchRscStore } from '../src/minimal/client-utils/fetch-store.js';
 import {
   Children,
@@ -43,12 +44,9 @@ import {
   useRouter,
 } from '../src/router/client.js';
 import {
-  ETAG_ID_PREFIX,
   HAS404_ID,
   IS_STATIC_ID,
   ROUTE_ID,
-  SKIP_HEADER,
-  STATIC_ETAG,
 } from '../src/router/isomorphic-utils/route-path.js';
 
 const postsSearchCodec = {
@@ -1247,7 +1245,7 @@ describe('Slice', () => {
     const slotId = unstable_getSliceSlotId('slice-1');
     const elements = {
       [slotId]: <div>loaded</div>,
-      [`${ETAG_ID_PREFIX}${slotId}`]: STATIC_ETAG,
+      [`${ETAG_ID_PREFIX}${slotId}`]: IMMUTABLE_ETAG,
     };
 
     const view = await renderWithMinimalRoot(
@@ -1397,11 +1395,12 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('registers its fetch enhancer and callServer listener once, and removes them on unmount (StrictMode)', async () => {
-    // The store is a module-level singleton; 'f' is FETCH_ENHANCERS, 'l' is
-    // CALL_SERVER_ELEMENTS_LISTENERS.
+  test('registers its callServer listener once, and removes it on unmount (StrictMode)', async () => {
+    // The store is a module-level singleton; 'l' is CALL_SERVER_ELEMENTS_LISTENERS.
+    // NOTE: the etags-header *fetch enhancer* ('f') is no longer owned by the
+    // router; it moved into the minimal layer (covered by the minimal
+    // carry/replay test). The router keeps only the callServer listener.
     const store = fetchRscStore as unknown as Record<string, unknown>;
-    delete store.f;
     delete store.l;
     const size = (key: string) =>
       (store[key] as Set<unknown> | undefined)?.size ?? 0;
@@ -1417,13 +1416,11 @@ describe('Router integration', () => {
     );
 
     // Registered exactly once despite StrictMode's mount/unmount/mount cycle.
-    expect(size('f')).toBe(1);
     expect(size('l')).toBe(1);
 
     view.unmount();
 
     // Fully unregistered on unmount, so nothing leaks into later RSC requests.
-    expect(size('f')).toBe(0);
     expect(size('l')).toBe(0);
   });
 
@@ -2462,31 +2459,13 @@ describe('Router integration', () => {
     }
   });
 
-  test('changeRoute refetch injects skip header', async () => {
+  // NOTE: etags carry/replay moved into the minimal layer; it is now
+  // covered by tests/minimal-etags.test.tsx. The router only triggers the
+  // refetch on navigation, which this test pins.
+  test('changeRoute refetches on navigation to a dynamic route', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
-    const fetchSpy = vi.fn<typeof fetch>(
-      async () => new Response(null, { status: 200 }),
-    );
-    const fetchMock = vi
-      .spyOn(globalThis, 'fetch')
-      .mockImplementation(fetchSpy as typeof fetch);
-    // Apply the router's registered fetch enhancers (the skip-header enhancer)
-    // the way the real refetch would, so the header is asserted on the request.
-    // ('f' is the internal FETCH_ENHANCERS key.)
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => {
-      const enhancers = (
-        fetchRscStore as {
-          f?: Set<(fn: typeof fetch) => typeof fetch>;
-        }
-      ).f;
-      let fetchFn: typeof fetch = fetch;
-      for (const enhance of enhancers ?? []) {
-        fetchFn = enhance(fetchFn);
-      }
-      await fetchFn('http://localhost/rsc', {});
-      return {};
-    });
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
     vi.mocked(useRefetch).mockReturnValue(refetch);
 
     const elements = {
@@ -2494,12 +2473,6 @@ describe('Router integration', () => {
       [unstable_getRouteSlotId('/next')]: <Probe />,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
-      [`${ETAG_ID_PREFIX}foo`]: 'etag-foo',
-      [`${ETAG_ID_PREFIX}bar`]: 'etag-bar',
-      // An empty tag is the server's clear signal; it must not be sent back.
-      [`${ETAG_ID_PREFIX}cleared`]: '',
-      // A non-Latin1 tag would make fetch reject the header; it must be dropped.
-      [`${ETAG_ID_PREFIX}nonLatin1`]: 'tag-☃',
     };
 
     const view = await renderRouter(
@@ -2515,33 +2488,11 @@ describe('Router integration', () => {
       await act(async () => {
         await capture.router!.push('/next');
       });
-      const readHeader = (init: RequestInit | undefined, name: string) => {
-        const h = init?.headers;
-        if (!h) {
-          return undefined;
-        }
-        if (h instanceof Headers) {
-          return h.get(name) ?? undefined;
-        }
-        if (Array.isArray(h)) {
-          return (h as [string, string][]).find(([k]) => k === name)?.[1];
-        }
-        return (h as Record<string, string>)[name];
-      };
-      const skipStr = fetchSpy.mock.calls
-        .map((call) => readHeader(call[1], SKIP_HEADER))
-        .find((value) => value !== null && value !== undefined);
-      expect(skipStr).toBeTypeOf('string');
-      const skipped = JSON.parse(skipStr!) as Record<string, string>;
-      expect(skipped.foo).toBe('etag-foo');
-      expect(skipped.bar).toBe('etag-bar');
-      expect('cleared' in skipped).toBe(false);
-      expect('nonLatin1' in skipped).toBe(false);
+      expect(refetch).toHaveBeenCalled();
       expect(capture.router.path).toBe('/next');
       expect(capture.router.query).toBe('');
     } finally {
       view.unmount();
-      fetchMock.mockRestore();
     }
   });
 


### PR DESCRIPTION
Internal refactor, no behavior change.

Waku uses a small per-slot "etag" so the server can skip re-rendering parts of a page the client already has. Until now waku/router had to know how that etag was carried (an HTTP header) and encoded. This PR moves all of that into the internal minimal/lib layer.

Now the router only:
- says whether a slot is static or dynamic, and
- reads the already-parsed etags it's handed.

It no longer references the header, the encoding, or the "immutable" sentinel at all, so we can later change how etags travel (header, cookie, query) without touching the router.

Existing behavior is unchanged and covered by the unit suite plus the cache-tag and instant-nav e2e tests.
  
