### PR TITLE
fix(minimal): two commits for swr (avoids proxy)

### DIFF
--- a/e2e/fixtures/instant-nav/src/components/route-events.tsx
+++ b/e2e/fixtures/instant-nav/src/components/route-events.tsx
@@ -3,15 +3,25 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'waku/router/client';
 
-// Records the path of the last completed navigation so tests can assert that
-// route-change events fire for the final (reconciled) route.
+// Records the path of the last completed navigation and how many completions
+// fired, so tests can assert that route-change events fire for the final
+// (reconciled) route and that reconciliation does not navigate twice.
 export function RouteEvents() {
   const { unstable_events } = useRouter();
   const [lastComplete, setLastComplete] = useState('');
+  const [completeCount, setCompleteCount] = useState(0);
   useEffect(() => {
-    const handler = (route: { path: string }) => setLastComplete(route.path);
+    const handler = (route: { path: string }) => {
+      setLastComplete(route.path);
+      setCompleteCount((c) => c + 1);
+    };
     unstable_events.on('complete', handler);
     return () => unstable_events.off('complete', handler);
   }, [unstable_events]);
-  return <div data-testid="last-complete">{lastComplete}</div>;
+  return (
+    <div>
+      <div data-testid="last-complete">{lastComplete}</div>
+      <div data-testid="complete-count">{completeCount}</div>
+    </div>
+  );
 }

--- a/e2e/fixtures/instant-nav/src/pages/_layout.tsx
+++ b/e2e/fixtures/instant-nav/src/pages/_layout.tsx
@@ -1,12 +1,10 @@
 import { Suspense } from 'react';
 import type { ReactNode } from 'react';
 import { Link } from 'waku/router/client';
-import { RouteEvents } from '../components/route-events.js';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <div>
-      <RouteEvents />
       <nav data-testid="nav">
         <Link to="/">home</Link>
         {' | '}

--- a/e2e/fixtures/instant-nav/src/pages/_root.tsx
+++ b/e2e/fixtures/instant-nav/src/pages/_root.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import { ErrorBoundary } from 'waku/router/client';
+import { RouteEvents } from '../components/route-events.js';
+
+// RouteEvents lives in the root element, outside the router's redirect
+// error boundary, so it keeps counting completions while a redirect error
+// unmounts the route slot.
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary>
+      <html>
+        <head />
+        <body>
+          <RouteEvents />
+          {children}
+        </body>
+      </html>
+    </ErrorBoundary>
+  );
+}

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -110,11 +110,16 @@ test.describe('instant-nav', () => {
 
     await page.getByTestId('link-post-1').click();
     await expect(page.getByTestId('post-body')).toHaveText('Post 1');
+    await expect(page.getByTestId('complete-count')).toHaveText('1');
 
     // /gate is cached now; revisiting it makes the server redirect to /post/2.
     await page.getByTestId('link-gate').click();
     await expect(page).toHaveURL(/\/post\/2$/);
     await expect(page.getByTestId('post-body')).toHaveText('Post 2');
+    // the optimistic /gate commit and the redirect each complete exactly once
+    await expect(page.getByTestId('complete-count')).toHaveText('3');
+    await page.waitForTimeout(500);
+    await expect(page.getByTestId('complete-count')).toHaveText('3');
   });
 
   // ...and surfaces a fetch error instead of getting stuck on the skeleton.

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -98,27 +98,22 @@ const getCached = <T,>(c: () => T, m: WeakMap<WeakKey, T>, k: object): T =>
   (m.has(k) ? m : m.set(k, c())).get(k) as T;
 
 const resolvedMergeResults = new WeakMap<Promise<Elements>, Elements>();
-const trackResolved = (p: Promise<Elements>): Promise<Elements> => {
-  p.then(
-    (m) => resolvedMergeResults.set(p, m),
-    () => {},
-  );
-  return p;
-};
+const swrMergeSources = new WeakMap<Promise<Elements>, Promise<Elements>>();
 
 const mergeCache = new WeakMap();
 const mergeElementsPromise = (
   a: Promise<Elements>,
   b: Promise<Elements> | Elements,
 ): Promise<Elements> => {
-  const getResult = () =>
-    trackResolved(
-      Promise.all([a, b]).then(([a, b]) => {
-        const nextElements = { ...a, ...b };
-        delete nextElements._value;
-        return nextElements;
-      }),
-    );
+  const getResult = () => {
+    const result: Promise<Elements> = Promise.all([a, b]).then(([a, b]) => {
+      const nextElements = { ...a, ...b };
+      delete nextElements._value;
+      resolvedMergeResults.set(result, nextElements);
+      return nextElements;
+    });
+    return result;
+  };
   const cache2 = getCached(() => new WeakMap(), mergeCache, a);
   return getCached(getResult, cache2, b);
 };
@@ -129,34 +124,41 @@ const swrElementsPromise = (
   b: Promise<Elements>,
   isSwr: (key: string) => boolean,
 ): Promise<Elements> => {
-  const getResult = () =>
-    trackResolved(
-      Promise.resolve(a).then((aRes) => {
-        const nextElements: Elements = {};
-        for (const key of Object.keys(aRes)) {
-          if (key === '_value') {
-            continue;
-          }
-          // an _etag:<slot> key follows its slot's swr-ness, not its own
-          const swr = key.startsWith(ETAG_ID_PREFIX)
-            ? isSwr(key.slice(ETAG_ID_PREFIX.length))
-            : isSwr(key);
-          nextElements[key] = swr
-            ? aRes[key]
-            : b.then((bRes) => (key in bRes ? bRes[key] : aRes[key]));
+  const getResult = () => {
+    const result: Promise<Elements> = Promise.resolve(a).then((aRes) => {
+      const nextElements: Elements = {};
+      for (const key of Object.keys(aRes)) {
+        if (key === '_value') {
+          continue;
         }
-        return nextElements;
-      }),
-    );
+        // an _etag:<slot> key follows its slot's swr-ness, not its own
+        const swr = key.startsWith(ETAG_ID_PREFIX)
+          ? isSwr(key.slice(ETAG_ID_PREFIX.length))
+          : isSwr(key);
+        nextElements[key] = swr
+          ? aRes[key]
+          : b.then((bRes) => (key in bRes ? bRes[key] : aRes[key]));
+      }
+      resolvedMergeResults.set(result, nextElements);
+      return nextElements;
+    });
+    return result;
+  };
   const cache2 = getCached(() => new WeakMap(), swrCache, a);
-  return getCached(getResult, cache2, b);
+  const result = getCached(getResult, cache2, b);
+  swrMergeSources.set(result, b);
+  return result;
 };
 
 const swrNewKeysCache = new WeakMap();
 const swrNewKeysElementsPromise = (
   prev: Promise<Elements>,
+  b: Promise<Elements>,
   bRes: Elements,
 ): Promise<Elements> => {
+  if (swrMergeSources.get(prev) !== b) {
+    return prev;
+  }
   const prevRes = resolvedMergeResults.get(prev);
   if (
     prevRes &&
@@ -165,21 +167,19 @@ const swrNewKeysElementsPromise = (
     return prev;
   }
   const getResult = () =>
-    trackResolved(
-      Promise.resolve(prev).then((prevRes) => {
-        const newKeys = Object.keys(bRes).filter(
-          (key) => key !== '_value' && !(key in prevRes),
-        );
-        if (!newKeys.length) {
-          return prevRes;
-        }
-        const nextElements = { ...prevRes };
-        for (const key of newKeys) {
-          nextElements[key] = bRes[key];
-        }
-        return nextElements;
-      }),
-    );
+    Promise.resolve(prev).then((prevRes) => {
+      const newKeys = Object.keys(bRes).filter(
+        (key) => key !== '_value' && !(key in prevRes),
+      );
+      if (!newKeys.length) {
+        return prevRes;
+      }
+      const nextElements = { ...prevRes };
+      for (const key of newKeys) {
+        nextElements[key] = bRes[key];
+      }
+      return nextElements;
+    });
   const cache2 = getCached(() => new WeakMap(), swrNewKeysCache, prev);
   return getCached(getResult, cache2, bRes);
 };
@@ -510,7 +510,9 @@ export const Root = ({
     if (isSwr) {
       setElements((prev) => swrElementsPromise(prev, dataWithoutErrors, isSwr));
       return Promise.resolve(data).then((resolved) => {
-        setElements((prev) => swrNewKeysElementsPromise(prev, resolved));
+        setElements((prev) =>
+          swrNewKeysElementsPromise(prev, dataWithoutErrors, resolved),
+        );
         return resolved;
       });
     }

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -94,51 +94,94 @@ export const unstable_isImmutableElement = (
   slotId: string,
 ): boolean => elements[ETAG_ID_PREFIX + slotId] === IMMUTABLE_ETAG;
 
-// TODO(daishi) do we still need this?
 const getCached = <T,>(c: () => T, m: WeakMap<WeakKey, T>, k: object): T =>
   (m.has(k) ? m : m.set(k, c())).get(k) as T;
 
-const cache1 = new WeakMap();
+const resolvedMergeResults = new WeakMap<Promise<Elements>, Elements>();
+const trackResolved = (p: Promise<Elements>): Promise<Elements> => {
+  p.then(
+    (m) => resolvedMergeResults.set(p, m),
+    () => {},
+  );
+  return p;
+};
+
+const mergeCache = new WeakMap();
 const mergeElementsPromise = (
   a: Promise<Elements>,
   b: Promise<Elements> | Elements,
-  isSwr?: (key: string) => boolean,
 ): Promise<Elements> => {
-  const getResult = () => {
-    if (!isSwr) {
-      return Promise.all([a, b]).then(([a, b]) => {
+  const getResult = () =>
+    trackResolved(
+      Promise.all([a, b]).then(([a, b]) => {
         const nextElements = { ...a, ...b };
         delete nextElements._value;
         return nextElements;
-      });
-    }
-    return Promise.resolve(a).then((aRes) => {
-      const bPromise: Promise<Elements> = Promise.resolve(b);
-      const base: Elements = { ...aRes };
-      delete base._value;
-      return new Proxy(base, {
-        get(target, key: string) {
+      }),
+    );
+  const cache2 = getCached(() => new WeakMap(), mergeCache, a);
+  return getCached(getResult, cache2, b);
+};
+
+const swrCache = new WeakMap();
+const swrElementsPromise = (
+  a: Promise<Elements>,
+  b: Promise<Elements>,
+  isSwr: (key: string) => boolean,
+): Promise<Elements> => {
+  const getResult = () =>
+    trackResolved(
+      Promise.resolve(a).then((aRes) => {
+        const nextElements: Elements = {};
+        for (const key of Object.keys(aRes)) {
+          if (key === '_value') {
+            continue;
+          }
           // an _etag:<slot> key follows its slot's swr-ness, not its own
           const swr = key.startsWith(ETAG_ID_PREFIX)
             ? isSwr(key.slice(ETAG_ID_PREFIX.length))
             : isSwr(key);
-          if (
-            key !== '_value' &&
-            !swr &&
-            // a lazy key still equal to aRes's value hasn't been streamed yet
-            target[key] === aRes[key]
-          ) {
-            target[key] = bPromise.then((bRes) =>
-              key in bRes ? bRes[key] : aRes[key],
-            );
-          }
-          return target[key];
-        },
-      });
-    });
-  };
-  const cache2 = getCached(() => new WeakMap(), cache1, a);
+          nextElements[key] = swr
+            ? aRes[key]
+            : b.then((bRes) => (key in bRes ? bRes[key] : aRes[key]));
+        }
+        return nextElements;
+      }),
+    );
+  const cache2 = getCached(() => new WeakMap(), swrCache, a);
   return getCached(getResult, cache2, b);
+};
+
+const swrNewKeysCache = new WeakMap();
+const swrNewKeysElementsPromise = (
+  prev: Promise<Elements>,
+  bRes: Elements,
+): Promise<Elements> => {
+  const prevRes = resolvedMergeResults.get(prev);
+  if (
+    prevRes &&
+    !Object.keys(bRes).some((key) => key !== '_value' && !(key in prevRes))
+  ) {
+    return prev;
+  }
+  const getResult = () =>
+    trackResolved(
+      Promise.resolve(prev).then((prevRes) => {
+        const newKeys = Object.keys(bRes).filter(
+          (key) => key !== '_value' && !(key in prevRes),
+        );
+        if (!newKeys.length) {
+          return prevRes;
+        }
+        const nextElements = { ...prevRes };
+        for (const key of newKeys) {
+          nextElements[key] = bRes[key];
+        }
+        return nextElements;
+      }),
+    );
+  const cache2 = getCached(() => new WeakMap(), swrNewKeysCache, prev);
+  return getCached(getResult, cache2, bRes);
 };
 
 type FetchRscOptions = {
@@ -402,7 +445,9 @@ export const unstable_fetchRsc = (
   return data;
 };
 
-/** Fetch + decode a route's elements; the caller (the router) holds the result. */
+/**
+ * Fetch + decode a route's elements; the caller (the router) holds the result.
+ */
 export const unstable_prefetchRsc = (
   rscPath: string,
   rscParams?: unknown,
@@ -462,7 +507,14 @@ export const Root = ({
       data = unstable_fetchRsc(rscPath, rscParams, options);
     }
     const dataWithoutErrors = Promise.resolve(data).catch(() => ({}));
-    setElements((prev) => mergeElementsPromise(prev, dataWithoutErrors, isSwr));
+    if (isSwr) {
+      setElements((prev) => swrElementsPromise(prev, dataWithoutErrors, isSwr));
+      return Promise.resolve(data).then((resolved) => {
+        setElements((prev) => swrNewKeysElementsPromise(prev, resolved));
+        return resolved;
+      });
+    }
+    setElements((prev) => mergeElementsPromise(prev, dataWithoutErrors));
     return data;
   }, []);
   return (

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -105,15 +105,12 @@ const mergeElementsPromise = (
   a: Promise<Elements>,
   b: Promise<Elements> | Elements,
 ): Promise<Elements> => {
-  const getResult = () => {
-    const result: Promise<Elements> = Promise.all([a, b]).then(([a, b]) => {
+  const getResult = () =>
+    Promise.all([a, b]).then(([a, b]) => {
       const nextElements = { ...a, ...b };
       delete nextElements._value;
-      resolvedMergeResults.set(result, nextElements);
       return nextElements;
     });
-    return result;
-  };
   const cache2 = getCached(() => new WeakMap(), mergeCache, a);
   return getCached(getResult, cache2, b);
 };

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -972,8 +972,7 @@ const useElementsMetadata = (
   useEffect(() => {
     elementsPromise.then(
       (elements) => {
-        // plain copy: the live elements may be an eager-merge Proxy, and isStaticSlot reads this ref
-        resolvedElementsRef.current = { ...elements };
+        resolvedElementsRef.current = elements;
         const {
           [ROUTE_ID]: routeData,
           [IS_STATIC_ID]: isStatic,

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -508,6 +508,81 @@ describe('minimal/client eager merge', () => {
     act(() => root.unmount());
   });
 
+  test('a superseded refetch does not commit onto the newer state', async () => {
+    // If another refetch commits between the eager merge and the response,
+    // the stale response's second commit must leave the newer state as is:
+    // grafting onto it would re-render it and plant stale keys.
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ _value: null, eager: 'A1', hole: 'H1' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Probe />
+        </Root>,
+      );
+    });
+
+    let resolveB1: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveB1 = resolve;
+      }),
+    );
+    let refetched1: Promise<unknown> | undefined;
+    await act(async () => {
+      refetched1 = refetch!('R/first.txt', undefined, {
+        unstable_isSwr: (key) => key === 'eager',
+      });
+    });
+
+    let resolveB2: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveB2 = resolve;
+      }),
+    );
+    let refetched2: Promise<unknown> | undefined;
+    await act(async () => {
+      refetched2 = refetch!('R/second.txt', undefined, {
+        unstable_isSwr: (key) => key === 'eager',
+      });
+    });
+    const midPromise = elementsPromise!;
+
+    // the superseded response resolves with a key the state has never seen
+    await act(async () => {
+      resolveB1({ hole: 'H1x', stale: 'S' });
+      await refetched1;
+    });
+    expect(elementsPromise).toBe(midPromise);
+    const midElements = await elementsPromise!;
+    expect('stale' in midElements).toBe(false);
+
+    await act(async () => {
+      resolveB2({ hole: 'H2', fresh: 'F' });
+      await refetched2;
+    });
+    const finalElements = await elementsPromise!;
+    expect('stale' in finalElements).toBe(false);
+    expect(finalElements.fresh).toBe('F');
+    await expect(finalElements.hole).resolves.toBe('H2');
+
+    act(() => root.unmount());
+  });
+
   test('merges keys only b introduces in a second commit', async () => {
     // The rare case (e.g. a rerendered route's elements): commit-2 adds the
     // new keys while every already-delivered key keeps its exact value.

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -23,6 +23,7 @@ import {
   unstable_registerCallServerElementsListener,
   unstable_registerFetchEnhancer,
   unstable_registerFetchRscInputTransformer,
+  useElementsPromise_UNSTABLE,
   useRefetch,
 } from '../src/minimal/client.js';
 
@@ -344,10 +345,57 @@ describe('minimal/client eager merge', () => {
     act(() => root.unmount());
   });
 
+  test('a slot only b introduces is mountable as soon as refetch resolves', async () => {
+    // The router's redirect reconcile switches the route in the refetch
+    // continuation, rendering a slot only the response carries. The elements
+    // state must already contain it by then (commit-2 before resolution).
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ _value: null, cached: 'C' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let mountExtra: () => void = () => {};
+    const Probe = () => {
+      refetch = useRefetch();
+      const [extra, setExtra] = useState(false);
+      mountExtra = () => setExtra(true);
+      return extra ? <Slot id="extra" /> : null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Suspense fallback={null}>
+            <Slot id="cached" />
+            <Probe />
+          </Suspense>
+        </Root>,
+      );
+    });
+    expect(container.textContent).toBe('C');
+
+    mocks.createFromFetch.mockReturnValueOnce(resolvedThenable({ extra: 'X' }));
+    await act(async () => {
+      await refetch!('R/next.txt', undefined, {
+        unstable_isSwr: (key) => key === 'cached',
+      }).then(() => {
+        // synchronously in the continuation, like the redirect handler
+        mountExtra();
+      });
+    });
+
+    expect(container.textContent).toBe('CX');
+
+    act(() => root.unmount());
+  });
+
   test('serves an isSwr key from a even when b has a fresh value', async () => {
-    // isSwr pins the slot to its cached value from `a` (the eager-merge
-    // Proxy); only non-isSwr holes stream from `b`. Separate Suspense
-    // boundaries let us observe the pinned eager value while the hole streams.
+    // isSwr pins the slot to its cached value from `a` (the eager merge);
+    // only non-isSwr holes stream from `b`. Separate Suspense boundaries let
+    // us observe the pinned eager value while the hole streams.
     mocks.createFromFetch.mockReturnValueOnce(
       resolvedThenable({ _value: null, eager: 'A1', hole: 'H1' }),
     );
@@ -398,6 +446,230 @@ describe('minimal/client eager merge', () => {
 
     // the eager key stays A1 (pinned to a); the hole streams b's H2.
     expect(container.textContent).toBe('A1H2');
+
+    act(() => root.unmount());
+  });
+
+  test('skips the second commit when b introduces no new keys', async () => {
+    // The common case: every response key was already delivered by the eager
+    // merge, so commit-2 bails out (same promise, same map) and nothing is
+    // re-rendered through a second commit.
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ _value: null, eager: 'A1', hole: 'H1' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Probe />
+        </Root>,
+      );
+    });
+
+    let resolveB: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveB = resolve;
+      }),
+    );
+    let refetched: Promise<unknown> | undefined;
+    await act(async () => {
+      refetched = refetch!('R/next.txt', undefined, {
+        unstable_isSwr: (key) => key === 'eager',
+      });
+    });
+    const midPromise = elementsPromise!;
+    const midElements = await midPromise;
+    const holeThenable = midElements.hole;
+
+    await act(async () => {
+      resolveB({ eager: 'A2', hole: 'H2' });
+      await refetched;
+    });
+
+    expect(elementsPromise).toBe(midPromise);
+    const finalElements = await elementsPromise!;
+    expect(finalElements).toBe(midElements);
+    expect(finalElements.hole).toBe(holeThenable);
+    expect(finalElements.eager).toBe('A1');
+    await expect(finalElements.hole).resolves.toBe('H2');
+
+    act(() => root.unmount());
+  });
+
+  test('merges keys only b introduces in a second commit', async () => {
+    // The rare case (e.g. a rerendered route's elements): commit-2 adds the
+    // new keys while every already-delivered key keeps its exact value.
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ _value: null, eager: 'A1', hole: 'H1' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Probe />
+        </Root>,
+      );
+    });
+
+    let resolveB: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveB = resolve;
+      }),
+    );
+    let refetched: Promise<unknown> | undefined;
+    await act(async () => {
+      refetched = refetch!('R/next.txt', undefined, {
+        unstable_isSwr: (key) => key === 'eager',
+      });
+    });
+    const midElements = await elementsPromise!;
+    const holeThenable = midElements.hole;
+
+    await act(async () => {
+      resolveB({ eager: 'A2', hole: 'H2', extra: 'X' });
+      await refetched;
+    });
+    const finalElements = await elementsPromise!;
+
+    expect(finalElements).not.toBe(midElements);
+    expect(finalElements.hole).toBe(holeThenable);
+    expect(finalElements.eager).toBe('A1');
+    expect(finalElements.extra).toBe('X');
+    expect('extra' in midElements).toBe(false);
+    await expect(finalElements.hole).resolves.toBe('H2');
+
+    act(() => root.unmount());
+  });
+
+  test('an incomplete prefetch is ignored: refetch fetches fresh', async () => {
+    // complete: false is reserved: the elements must not serve as the data
+    // source nor be grafted (a stale graft would shadow the response's
+    // values); a fresh request serves the navigation.
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ _value: null, cached: 'C', dynamic: 'D1' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Suspense fallback={null}>
+            <Slot id="cached" />
+            <Slot id="dynamic" />
+            <Probe />
+          </Suspense>
+        </Root>,
+      );
+    });
+    expect(container.textContent).toBe('CD1');
+
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ dynamic: 'D2' }),
+    );
+    let refetched: unknown;
+    await act(async () => {
+      refetched = await refetch!('R/next.txt', undefined, {
+        unstable_isSwr: (key) => key === 'cached',
+        unstable_prefetched: {
+          elements: { cached: 'STALE', dynamic: 'STALE', planted: 'STALE' },
+          complete: false,
+        },
+      });
+    });
+
+    // a fresh request was made and its response won
+    expect(mocks.createFromFetch).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toBe('CD2');
+    expect(refetched).toEqual({ dynamic: 'D2' });
+    const finalElements = await elementsPromise!;
+    expect('planted' in finalElements).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  test('an isSwr refetch works with decode promises whose then() returns undefined', async () => {
+    // react-server-dom decode promises are flight Chunks: then() registers
+    // callbacks but returns undefined, so they must never be chained directly.
+    const chunkLike = <T,>(value: T): Promise<T> => {
+      const p = Promise.resolve(value);
+      return {
+        then: (f: (v: T) => unknown, r?: (e: unknown) => unknown) => {
+          void p.then(f, r);
+        },
+      } as unknown as Promise<T>;
+    };
+    mocks.createFromFetch.mockReturnValueOnce(
+      chunkLike({ _value: null, cached: 'C' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let mountExtra: () => void = () => {};
+    const Probe = () => {
+      refetch = useRefetch();
+      const [extra, setExtra] = useState(false);
+      mountExtra = () => setExtra(true);
+      return extra ? <Slot id="extra" /> : null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Suspense fallback={null}>
+            <Slot id="cached" />
+            <Probe />
+          </Suspense>
+        </Root>,
+      );
+    });
+    expect(container.textContent).toBe('C');
+
+    mocks.createFromFetch.mockReturnValueOnce(chunkLike({ extra: 'X' }));
+    await act(async () => {
+      await refetch!('R/next.txt', undefined, {
+        unstable_isSwr: (key) => key === 'cached',
+      }).then(() => {
+        mountExtra();
+      });
+    });
+
+    expect(container.textContent).toBe('CX');
 
     act(() => root.unmount());
   });

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -508,6 +508,64 @@ describe('minimal/client eager merge', () => {
     act(() => root.unmount());
   });
 
+  test('merges new keys even while the previous elements are still streaming', async () => {
+    // The response can resolve before the previous elements do. The second
+    // commit cannot inspect a pending state synchronously, so it chains on
+    // it instead; this is safe because a pending state has never rendered.
+    let resolveInitial: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveInitial = resolve;
+      }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Suspense fallback={null}>
+            <Slot id="eager" />
+            <Slot id="hole" />
+          </Suspense>
+          <Probe />
+        </Root>,
+      );
+    });
+
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ eager: 'A2', hole: 'H2', extra: 'X' }),
+    );
+    let refetched: unknown;
+    await act(async () => {
+      refetched = await refetch!('R/next.txt', undefined, {
+        unstable_isSwr: (key) => key === 'eager',
+      });
+    });
+    expect(refetched).toEqual({ eager: 'A2', hole: 'H2', extra: 'X' });
+
+    await act(async () => {
+      resolveInitial({ _value: null, eager: 'A1', hole: 'H1' });
+    });
+
+    expect(container.textContent).toBe('A1H2');
+    const finalElements = await elementsPromise!;
+    expect(finalElements.eager).toBe('A1');
+    expect(finalElements.extra).toBe('X');
+    await expect(finalElements.hole).resolves.toBe('H2');
+
+    act(() => root.unmount());
+  });
+
   test('a superseded refetch does not commit onto the newer state', async () => {
     // If another refetch commits between the eager merge and the response,
     // the stale response's second commit must leave the newer state as is:

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -159,7 +159,7 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     });
     await flush();
 
-    // the _etag: key follows its slot's swr-ness through the merge Proxy, so a
+    // the _etag: key follows its slot's swr-ness through the eager merge, so a
     // pinned static slot's etag stays a concrete value and survives in the cache
     expect(fetchRscStore[CACHED_ETAGS]?.page).toBe(IMMUTABLE_ETAG);
 

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -165,6 +165,45 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
 
     view.unmount();
   });
+
+  it('caches the etag of a slot a response newly introduces in an instant-nav merge', async () => {
+    // A response-only slot lands via the second swr commit, and its etag must
+    // enter the cache like any other (the old merge Proxy never enumerated
+    // response-only keys, so these etags were silently dropped).
+    testHoisted.elements = {
+      page: <div>a</div>,
+      [`${ETAG_ID_PREFIX}page`]: IMMUTABLE_ETAG,
+    };
+    let refetch!: ReturnType<typeof useRefetch>;
+    const Capture = () => {
+      refetch = useRefetch();
+      return null;
+    };
+    const view = await renderApp(
+      <Root initialRscPath="R/foo">
+        <Capture />
+      </Root>,
+    );
+    await flush();
+
+    testHoisted.elements = {
+      page: <div>b</div>,
+      [`${ETAG_ID_PREFIX}page`]: IMMUTABLE_ETAG,
+      widget: <div>w</div>,
+      [`${ETAG_ID_PREFIX}widget`]: 'etag-widget',
+    };
+    await act(async () => {
+      await refetch('R/bar', undefined, {
+        unstable_isSwr: (key) => key === 'page',
+      });
+    });
+    await flush();
+
+    expect(fetchRscStore[CACHED_ETAGS]?.widget).toBe('etag-widget');
+    expect(fetchRscStore[CACHED_ETAGS]?.page).toBe(IMMUTABLE_ETAG);
+
+    view.unmount();
+  });
 });
 
 describe('unstable_buildElements', () => {


### PR DESCRIPTION
Removes the eager-merge `Proxy` from `minimal/client.tsx` and uses plain maps instead.

The Proxy created thenables lazily in a get trap and mutated its target during render. This PR replaces it with two plain commits. The first commit builds the map eagerly: isSwr keys are copied from the previous elements, and the other keys are thenables on the response. The second commit only adds keys that the response newly introduces. If there are no new keys, it returns the previous state as is, because committing the same elements again re-renders them, and re-rendering a redirect error element causes duplicate redirect navigations.

No API changes and no state mutation. The behavior is the same as the Proxy.

Fixes the deferred item from #2182.