### PR TITLE
feat(router): prefetch mode

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -89,7 +89,7 @@ export const Nav = () => (
 Both props take an options object. Passing an empty object enables prefetching with the defaults; omitting the prop disables it.
 
 - `mode: 'always'` (the default) fetches on the first trigger and dedupes repeat triggers for the same path and query within the `ttl`. Within the `ttl`, navigation reuses the prefetched response without another request.
-- `mode: 'once'` fetches a route only once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit.
+- `mode: 'once'` fetches a route at most once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit.
 - `ttl` sets how long a prefetched response stays reusable, in milliseconds (default: 60000).
 
 The same options work with `router.prefetch(to, options)`.

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -73,10 +73,10 @@ import { Link } from 'waku';
 
 export const Nav = () => (
   <nav>
-    <Link to="/docs" unstable_prefetchOnEnter>
+    <Link to="/docs" unstable_prefetchOnEnter={{}}>
       Docs
     </Link>
-    <Link to="/blog" unstable_prefetchOnView>
+    <Link to="/blog" unstable_prefetchOnView={{ mode: 'once' }}>
       Blog
     </Link>
   </nav>
@@ -86,6 +86,14 @@ export const Nav = () => (
 - `unstable_prefetchOnEnter` starts prefetching when the pointer enters the link.
 - `unstable_prefetchOnView` starts prefetching when the link enters the viewport.
 
+Both props take an options object:
+
+- `mode: 'always'` (the default) fetches on the first trigger and dedupes repeat triggers for the same path and query within the `ttl`. Within the `ttl`, navigation reuses the prefetched response without another request.
+- `mode: 'once'` fetches a route only once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit.
+- `ttl` sets how long a prefetched response stays reusable, in milliseconds (default: 60000).
+
+The same options work with `router.prefetch(to, options)`.
+
 Prefer intent-based prefetching for expensive dynamic routes. View-based prefetching can be useful for short pages with a small number of important links, but it can waste server work if applied to every link in a large list.
 
 ## Instant Navigation
@@ -94,7 +102,7 @@ By default, navigating to a dynamic route waits for the server response before t
 
 It relies on two things:
 
-- The route's **static shell is already cached**, for example from an earlier visit. A route's first visit is never instant.
+- The route's **static shell is already cached**, from an earlier visit or from a prefetch (any prefetch caches the static parts it learns, so a prefetched route's first visit can be instant).
 - The dynamic part of the page sits inside a `<Suspense>` boundary, so there is a fallback to show while it streams.
 
 Opt in per navigation with the `unstable_instant` prop on `<Link>`. Here a static layout wraps the dynamic page in `<Suspense>`:

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -89,7 +89,7 @@ export const Nav = () => (
 Both props take an options object. Passing an empty object enables prefetching with the defaults; omitting the prop disables it.
 
 - `mode: 'always'` (the default) fetches on the first trigger and dedupes repeat triggers for the same path and query within the `ttl`. Within the `ttl`, navigation reuses the prefetched response without another request.
-- `mode: 'once'` fetches a route at most once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit.
+- `mode: 'once'` fetches a route at most once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit. Warmed routes are kept in a bounded store, so a long session may eventually fetch a route again.
 - `ttl` sets how long a prefetched response stays reusable, in milliseconds (default: 60000).
 
 The same options work with `router.prefetch(to, options)`.

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -86,7 +86,7 @@ export const Nav = () => (
 - `unstable_prefetchOnEnter` starts prefetching when the pointer enters the link.
 - `unstable_prefetchOnView` starts prefetching when the link enters the viewport.
 
-Both props take an options object:
+Both props take an options object. Passing an empty object enables prefetching with the defaults; omitting the prop disables it.
 
 - `mode: 'always'` (the default) fetches on the first trigger and dedupes repeat triggers for the same path and query within the `ttl`. Within the `ttl`, navigation reuses the prefetched response without another request.
 - `mode: 'once'` fetches a route only once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit.

--- a/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
+++ b/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
@@ -27,7 +27,7 @@ const HomeLayout = ({ children }: { children: ReactNode }) => {
             </Link>
           </li>
           <li>
-            <Link to="/bar" unstable_prefetchOnEnter>
+            <Link to="/bar" unstable_prefetchOnEnter={{}}>
               Bar
             </Link>
           </li>

--- a/e2e/fixtures/fs-router/src/pages/_layout.tsx
+++ b/e2e/fixtures/fs-router/src/pages/_layout.tsx
@@ -21,7 +21,7 @@ const HomeLayout = ({ children }: { children: ReactNode }) => (
           </Link>
         </li>
         <li>
-          <Link to="/bar" unstable_prefetchOnEnter>
+          <Link to="/bar" unstable_prefetchOnEnter={{}}>
             Bar
             <Pending />
           </Link>

--- a/e2e/fixtures/instant-nav/src/pages/_layout.tsx
+++ b/e2e/fixtures/instant-nav/src/pages/_layout.tsx
@@ -27,6 +27,23 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Link to="/gate" unstable_instant data-testid="link-gate">
           gate
         </Link>
+        {' | '}
+        <Link
+          to="/slow"
+          unstable_instant
+          unstable_prefetchOnView={{ mode: 'once', ttl: 300 }}
+          data-testid="link-slow"
+        >
+          slow
+        </Link>
+        {' | '}
+        <Link
+          to="/hover"
+          unstable_prefetchOnEnter={{ ttl: 600 }}
+          data-testid="link-hover"
+        >
+          hover
+        </Link>
       </nav>
       <main>
         <Suspense fallback={<div data-testid="page-skeleton">loading...</div>}>

--- a/e2e/fixtures/instant-nav/src/pages/hover.tsx
+++ b/e2e/fixtures/instant-nav/src/pages/hover.tsx
@@ -1,0 +1,12 @@
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default async function Hover() {
+  await sleep(300);
+  return <div data-testid="hover-body">Hover page</div>;
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'dynamic',
+  } as const;
+};

--- a/e2e/fixtures/instant-nav/src/pages/slow.tsx
+++ b/e2e/fixtures/instant-nav/src/pages/slow.tsx
@@ -1,0 +1,12 @@
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default async function Slow() {
+  await sleep(500);
+  return <div data-testid="slow-body">Slow page</div>;
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'dynamic',
+  } as const;
+};

--- a/e2e/fixtures/router-client-no-404/src/pages/start.tsx
+++ b/e2e/fixtures/router-client-no-404/src/pages/start.tsx
@@ -28,7 +28,7 @@ export default function StartPage() {
       <p>
         <Link
           to="/view-target?from=view"
-          unstable_prefetchOnView
+          unstable_prefetchOnView={{}}
           data-testid="prefetch-on-view-link"
         >
           Prefetch on view target

--- a/e2e/fixtures/router-client/src/pages/start.tsx
+++ b/e2e/fixtures/router-client/src/pages/start.tsx
@@ -37,7 +37,7 @@ export default function StartPage() {
       <p>
         <Link
           to="/next?from=enter"
-          unstable_prefetchOnEnter
+          unstable_prefetchOnEnter={{}}
           data-testid="prefetch-on-enter-link"
         >
           Prefetch on enter
@@ -85,7 +85,7 @@ export default function StartPage() {
       <p>
         <Link
           to="/view-target?from=view"
-          unstable_prefetchOnView
+          unstable_prefetchOnView={{}}
           data-testid="prefetch-on-view-link"
         >
           Prefetch on view target

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -99,6 +99,98 @@ test.describe('instant-nav', () => {
     await expect(page).toHaveURL(/\/post\/1$/);
   });
 
+  // A view prefetch with mode 'once' warms the route's static parts, so even
+  // the route's first visit paints the shell instantly.
+  test('a prefetched route is instant on its first visit', async ({ page }) => {
+    const slowRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('R/slow')) {
+        slowRequests.push(request.url());
+      }
+    });
+    await page.goto(`http://localhost:${port}/post/1`);
+    await waitForHydration(page);
+    // link-slow is in view, so its 'once' prefetch fires on load
+    await expect.poll(() => slowRequests.length).toBe(1);
+    // let the prefetched response expire (ttl: 300); the statics stay
+    await page.waitForTimeout(500);
+
+    await page.getByTestId('link-slow').click();
+    // the shell paints before the slow response arrives
+    await expect(page).toHaveURL(/\/slow$/);
+    await expect(page.getByTestId('page-skeleton')).toBeVisible();
+    await expect(page.getByTestId('slow-body')).toHaveText('Slow page');
+  });
+
+  test('mode once warms a route only once per session', async ({ page }) => {
+    const slowRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('R/slow')) {
+        slowRequests.push(request.url());
+      }
+    });
+    await page.goto(`http://localhost:${port}/post/1`);
+    await waitForHydration(page);
+    await expect.poll(() => slowRequests.length).toBe(1);
+    await page.waitForTimeout(500);
+
+    // the navigation fetches fresh (the prefetched response expired)
+    await page.getByTestId('link-slow').click();
+    await expect(page.getByTestId('slow-body')).toHaveText('Slow page');
+    expect(slowRequests.length).toBe(2);
+
+    // back on a page with the link in view: 'once' does not warm again
+    await page.getByTestId('link-post-1').click();
+    await expect(page.getByTestId('post-body')).toHaveText('Post 1');
+    await page.waitForTimeout(500);
+    expect(slowRequests.length).toBe(2);
+  });
+
+  // Within the ttl, a navigation reuses the prefetched response and makes no
+  // request of its own.
+  test('a navigation within the ttl reuses the prefetch', async ({ page }) => {
+    const hoverRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('R/hover')) {
+        hoverRequests.push(request.url());
+      }
+    });
+    await page.goto(`http://localhost:${port}/post/1`);
+    await waitForHydration(page);
+
+    await page.getByTestId('link-hover').hover();
+    await expect.poll(() => hoverRequests.length).toBe(1);
+    await page.getByTestId('link-hover').click();
+    await expect(page.getByTestId('hover-body')).toHaveText('Hover page');
+    expect(hoverRequests.length).toBe(1);
+  });
+
+  test('a prefetch after the ttl fetches again', async ({ page }) => {
+    const hoverRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('R/hover')) {
+        hoverRequests.push(request.url());
+      }
+    });
+    await page.goto(`http://localhost:${port}/post/1`);
+    await waitForHydration(page);
+
+    await page.getByTestId('link-hover').hover();
+    await expect.poll(() => hoverRequests.length).toBe(1);
+
+    // hovering again within the ttl is deduped
+    await page.getByTestId('link-post-1').hover();
+    await page.getByTestId('link-hover').hover();
+    await page.waitForTimeout(100);
+    expect(hoverRequests.length).toBe(1);
+
+    // after the ttl (600), the same trigger fetches again
+    await page.waitForTimeout(700);
+    await page.getByTestId('link-post-1').hover();
+    await page.getByTestId('link-hover').hover();
+    await expect.poll(() => hoverRequests.length).toBe(2);
+  });
+
   // The optimistic commit happens before the response, so it reconciles a
   // server redirect once the response lands.
   test('a redirected instant navigation reconciles to the target', async ({

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -135,7 +135,13 @@ const swrElementsPromise = (
           : pin(key);
         nextElements[key] = pinned
           ? aRes[key]
-          : b.then((bRes) => (key in bRes ? bRes[key] : aRes[key]));
+          : b.then((bRes) =>
+              key in bRes
+                ? bRes[key]
+                : base && key in base
+                  ? base[key]
+                  : aRes[key],
+            );
       }
       if (base) {
         for (const key of Object.keys(base)) {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -115,6 +115,9 @@ const mergeElementsPromise = (
   return getCached(getResult, cache2, b);
 };
 
+const slotIdOf = (key: string) =>
+  key.startsWith(ETAG_ID_PREFIX) ? key.slice(ETAG_ID_PREFIX.length) : key;
+
 const swrCache = new WeakMap();
 const swrElementsPromise = (
   a: Promise<Elements>,
@@ -124,42 +127,29 @@ const swrElementsPromise = (
 ): Promise<Elements> => {
   const getResult = () => {
     const result: Promise<Elements> = Promise.resolve(a).then((aRes) => {
+      const holeFor = (key: string) =>
+        b.then((bRes) =>
+          key in bRes ? bRes[key] : base && key in base ? base[key] : aRes[key],
+        );
       const nextElements: Elements = {};
       for (const key of Object.keys(aRes)) {
         if (key === '_value') {
           continue;
         }
         // an _etag:<slot> key follows its slot's swr-ness, not its own
-        const pinned = key.startsWith(ETAG_ID_PREFIX)
-          ? pin(key.slice(ETAG_ID_PREFIX.length))
-          : pin(key);
-        nextElements[key] = pinned
-          ? aRes[key]
-          : b.then((bRes) =>
-              key in bRes
-                ? bRes[key]
-                : base && key in base
-                  ? base[key]
-                  : aRes[key],
-            );
+        nextElements[key] = pin(slotIdOf(key)) ? aRes[key] : holeFor(key);
       }
       if (base) {
         for (const key of Object.keys(base)) {
           if (key === '_value' || key in nextElements) {
             continue;
           }
-          let slotId = key;
-          if (slotId.startsWith(ETAG_ID_PREFIX)) {
-            slotId = slotId.slice(ETAG_ID_PREFIX.length);
-          }
           // pin only what the base proves immutable; pinning a mutable
           // base key would eagerly serve possibly-stale content
-          if (unstable_isImmutableElement(base, slotId)) {
+          if (unstable_isImmutableElement(base, slotIdOf(key))) {
             nextElements[key] = base[key];
           } else {
-            nextElements[key] = b.then((bRes) =>
-              key in bRes ? bRes[key] : base[key],
-            );
+            nextElements[key] = holeFor(key);
           }
         }
       }

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -119,7 +119,8 @@ const swrCache = new WeakMap();
 const swrElementsPromise = (
   a: Promise<Elements>,
   b: Promise<Elements>,
-  isSwr: (key: string) => boolean,
+  pin: (key: string) => boolean,
+  base?: Elements,
 ): Promise<Elements> => {
   const getResult = () => {
     const result: Promise<Elements> = Promise.resolve(a).then((aRes) => {
@@ -129,12 +130,32 @@ const swrElementsPromise = (
           continue;
         }
         // an _etag:<slot> key follows its slot's swr-ness, not its own
-        const swr = key.startsWith(ETAG_ID_PREFIX)
-          ? isSwr(key.slice(ETAG_ID_PREFIX.length))
-          : isSwr(key);
-        nextElements[key] = swr
+        const pinned = key.startsWith(ETAG_ID_PREFIX)
+          ? pin(key.slice(ETAG_ID_PREFIX.length))
+          : pin(key);
+        nextElements[key] = pinned
           ? aRes[key]
           : b.then((bRes) => (key in bRes ? bRes[key] : aRes[key]));
+      }
+      if (base) {
+        for (const key of Object.keys(base)) {
+          if (key === '_value' || key in nextElements) {
+            continue;
+          }
+          let slotId = key;
+          if (slotId.startsWith(ETAG_ID_PREFIX)) {
+            slotId = slotId.slice(ETAG_ID_PREFIX.length);
+          }
+          // pin only what the base proves immutable; pinning a mutable
+          // base key would eagerly serve possibly-stale content
+          if (unstable_isImmutableElement(base, slotId)) {
+            nextElements[key] = base[key];
+          } else {
+            nextElements[key] = b.then((bRes) =>
+              key in bRes ? bRes[key] : base[key],
+            );
+          }
+        }
       }
       resolvedMergeResults.set(result, nextElements);
       return nextElements;
@@ -190,10 +211,10 @@ type Refetch = (
   rscPath: string,
   rscParams?: unknown,
   options?: FetchRscOptions & {
-    unstable_isSwr?: (key: string) => boolean;
-    unstable_prefetched?: {
-      elements: Elements | Promise<Elements>;
-      complete?: boolean;
+    unstable_prefetched?: Elements | Promise<Elements>;
+    unstable_swr?: {
+      pin: (key: string) => boolean;
+      base?: Elements;
     };
   },
 ) => Promise<Elements>;
@@ -493,19 +514,27 @@ export const Root = ({
     elements.then(updateCachedEtags, () => {});
   }, [elements]);
   const refetch = useCallback<Refetch>(async (rscPath, rscParams, options) => {
-    const { unstable_isSwr: isSwr, unstable_prefetched: prefetched } =
+    const { unstable_prefetched: prefetched, unstable_swr: swr } =
       options ?? {};
     delete fetchRscStore[ENTRY];
     let data: Promise<Elements>;
-    if (prefetched?.complete) {
-      data = Promise.resolve(prefetched.elements);
+    if (prefetched) {
+      data = Promise.resolve(prefetched);
       reloadOnBuildIdMismatch(data, options?.onBuildIdMismatch);
     } else {
+      if (swr?.base) {
+        fetchRscStore[CACHED_ETAGS] = {
+          ...fetchRscStore[CACHED_ETAGS],
+          ...collectCachedEtags(swr.base),
+        };
+      }
       data = unstable_fetchRsc(rscPath, rscParams, options);
     }
     const dataWithoutErrors = Promise.resolve(data).catch(() => ({}));
-    if (isSwr) {
-      setElements((prev) => swrElementsPromise(prev, dataWithoutErrors, isSwr));
+    if (swr) {
+      setElements((prev) =>
+        swrElementsPromise(prev, dataWithoutErrors, swr.pin, swr.base),
+      );
       return Promise.resolve(data).then((resolved) => {
         setElements((prev) =>
           swrNewKeysElementsPromise(prev, dataWithoutErrors, resolved),

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -580,8 +580,11 @@ export function Link<Path extends RoutePath>({
   const startTransitionFn = unstable_startTransition || startTransition;
   const [ref, setRef] = useSharedRef<HTMLAnchorElement>(refProp);
 
+  const prefetchOnView = !!unstable_prefetchOnView;
+  const prefetchOnViewMode = unstable_prefetchOnView?.mode;
+  const prefetchOnViewTtl = unstable_prefetchOnView?.ttl;
   useEffect(() => {
-    if (!unstable_prefetchOnView || !ref.current) {
+    if (!prefetchOnView || !ref.current) {
       return;
     }
     const observer = new IntersectionObserver(
@@ -590,7 +593,12 @@ export function Link<Path extends RoutePath>({
           if (entry.isIntersecting) {
             const url = new URL(resolvedTo, window.location.href);
             if (router && url.href !== window.location.href) {
-              router.prefetchRoute(parseRoute(url), unstable_prefetchOnView);
+              router.prefetchRoute(parseRoute(url), {
+                ...(prefetchOnViewMode ? { mode: prefetchOnViewMode } : {}),
+                ...(prefetchOnViewTtl !== undefined
+                  ? { ttl: prefetchOnViewTtl }
+                  : {}),
+              });
             }
           }
         });
@@ -603,7 +611,14 @@ export function Link<Path extends RoutePath>({
     return () => {
       observer.disconnect();
     };
-  }, [unstable_prefetchOnView, router, resolvedTo, ref]);
+  }, [
+    prefetchOnView,
+    prefetchOnViewMode,
+    prefetchOnViewTtl,
+    router,
+    resolvedTo,
+    ref,
+  ]);
   const internalOnClick = () => {
     const url = new URL(resolvedTo, window.location.href);
     if (url.href !== window.location.href) {
@@ -1193,10 +1208,10 @@ const InnerRouter = ({
             signal: abortController.signal,
             unstable_swr: {
               pin,
-              ...(prefetchedElements ? { base: prefetchedElements } : null),
+              ...(prefetchedElements ? { base: prefetchedElements } : {}),
             },
             onBuildIdMismatch,
-            ...(cached ? { unstable_prefetched: cached.promise } : null),
+            ...(cached ? { unstable_prefetched: cached.promise } : {}),
           });
           commitRoute(nextRoute);
           return dataPromise.then(
@@ -1242,7 +1257,7 @@ const InnerRouter = ({
         const elements = await refetch(rscPath, rscParams, {
           signal: abortController.signal,
           onBuildIdMismatch,
-          ...(cached ? { unstable_prefetched: cached.promise } : null),
+          ...(cached ? { unstable_prefetched: cached.promise } : {}),
         });
         const redirect = getRedirect(elements);
         if (redirect) {
@@ -1336,6 +1351,9 @@ const InnerRouter = ({
           expireAt: Date.now() + (options?.ttl ?? PREFETCH_TTL),
         };
         setPrefetch(cache, key, entry);
+        if (!store.has(rscPath)) {
+          store.set(rscPath, null);
+        }
         promise.then(
           (resolved) => {
             mergePrefetchedElements(store, rscPath, resolved);
@@ -1343,6 +1361,9 @@ const InnerRouter = ({
           () => {
             if (cache.get(key) === entry) {
               cache.delete(key);
+            }
+            if (store.get(rscPath) === null) {
+              store.delete(rscPath);
             }
           },
         );

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -69,6 +69,8 @@ import {
   getPrefetch,
   mergePrefetchedElements,
   prefetchCacheKey,
+  releasePrefetchedElements,
+  reservePrefetchedElements,
   setPrefetch,
 } from './prefetch-cache.js';
 
@@ -1351,9 +1353,7 @@ const InnerRouter = ({
           expireAt: Date.now() + (options?.ttl ?? PREFETCH_TTL),
         };
         setPrefetch(cache, key, entry);
-        if (!store.has(rscPath)) {
-          store.set(rscPath, null);
-        }
+        reservePrefetchedElements(store, rscPath);
         promise.then(
           (resolved) => {
             mergePrefetchedElements(store, rscPath, resolved);
@@ -1362,9 +1362,7 @@ const InnerRouter = ({
             if (cache.get(key) === entry) {
               cache.delete(key);
             }
-            if (store.get(rscPath) === null) {
-              store.delete(rscPath);
-            }
+            releasePrefetchedElements(store, rscPath);
           },
         );
       }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -60,10 +60,14 @@ import {
   getRouteSearchCodecId,
   isCodec,
 } from './isomorphic-utils/search-codec-registry.js';
-import type { PrefetchCache, PrefetchEntry } from './prefetch-cache.js';
 import {
   PREFETCH_TTL,
+  type PrefetchCache,
+  type PrefetchEntry,
+  type PrefetchOptions,
+  type PrefetchedElementsStore,
   getPrefetch,
+  mergePrefetchedElements,
   prefetchCacheKey,
   setPrefetch,
 } from './prefetch-cache.js';
@@ -92,8 +96,11 @@ type Navigate = {
 };
 
 type Prefetch = {
-  (to: RouteHref): void;
-  <Path extends RoutePath>(target: BuildRouteHrefTarget<Path>): void;
+  (to: RouteHref, options?: PrefetchOptions): void;
+  <Path extends RoutePath>(
+    target: BuildRouteHrefTarget<Path>,
+    options?: PrefetchOptions,
+  ): void;
 };
 
 const pathnameToCurrentRoutePath = (pathname: string) =>
@@ -188,7 +195,7 @@ type ChangeRouteEvent = 'start' | 'complete';
 
 type ChangeRouteCallback = (route: RouteProps) => void;
 
-type PrefetchRoute = (route: RouteProps) => void;
+type PrefetchRoute = (route: RouteProps, options?: PrefetchOptions) => void;
 
 type SliceId = string;
 
@@ -313,14 +320,17 @@ export function useRouter() {
     window.history.forward();
   }, []);
   const prefetch = useCallback(
-    (to: RouteHref | BuildRouteHrefTarget<RoutePath>) => {
+    (
+      to: RouteHref | BuildRouteHrefTarget<RoutePath>,
+      options?: PrefetchOptions,
+    ) => {
       const href =
         typeof to === 'string' ? to : buildRouteHref(to, resolveCodec);
       const url = new URL(
         addBase(href, import.meta.env.WAKU_CONFIG_BASE_PATH),
         window.location.href,
       );
-      prefetchRoute(parseRoute(url));
+      prefetchRoute(parseRoute(url), options);
     },
     [prefetchRoute, resolveCodec],
   ) as Prefetch;
@@ -529,8 +539,8 @@ export type LinkProps<Path extends RoutePath> = {
    * away and stream the dynamic parts in.
    */
   unstable_instant?: boolean;
-  unstable_prefetchOnEnter?: boolean;
-  unstable_prefetchOnView?: boolean;
+  unstable_prefetchOnEnter?: PrefetchOptions;
+  unstable_prefetchOnView?: PrefetchOptions;
   /**
    * Overrides how the navigation transition is started, e.g. to integrate the
    * browser View Transitions API. When provided, React's `useTransition` is
@@ -580,7 +590,7 @@ export function Link<Path extends RoutePath>({
           if (entry.isIntersecting) {
             const url = new URL(resolvedTo, window.location.href);
             if (router && url.href !== window.location.href) {
-              router.prefetchRoute(parseRoute(url));
+              router.prefetchRoute(parseRoute(url), unstable_prefetchOnView);
             }
           }
         });
@@ -598,7 +608,7 @@ export function Link<Path extends RoutePath>({
     const url = new URL(resolvedTo, window.location.href);
     if (url.href !== window.location.href) {
       const route = parseRoute(url);
-      prefetchRoute(route);
+      preloadRouteModules(route.path);
       if (unstable_instant) {
         changeRoute(route, {
           shouldScroll: scroll ?? shouldScrollByDefault(url),
@@ -644,7 +654,7 @@ export function Link<Path extends RoutePath>({
     ? (event: MouseEvent<HTMLAnchorElement>) => {
         const url = new URL(resolvedTo, window.location.href);
         if (url.href !== window.location.href) {
-          prefetchRoute(parseRoute(url));
+          prefetchRoute(parseRoute(url), unstable_prefetchOnEnter);
         }
         props.onMouseEnter?.(event);
       }
@@ -858,6 +868,12 @@ const ThrowError = ({ error }: { error: unknown }) => {
 const getRouteSlotId = (path: string) => 'route:' + path;
 const getSliceSlotId = (id: SliceId) => 'slice:' + id;
 
+const preloadRouteModules = (path: string) => {
+  globalThis.__WAKU_ROUTER_PREFETCH__?.(path, (id) => {
+    preloadModule(id, { as: 'script' });
+  });
+};
+
 export function Slice({
   id,
   children,
@@ -1038,6 +1054,7 @@ const InnerRouter = ({
     useElementsMetadata(elementsPromise);
   // FIXME this "fetchingSlices" hack feels suboptimal.
   const fetchingSlicesRef = useRef(new Set<SliceId>());
+  const prefetchedElementsStoreRef = useRef<PrefetchedElementsStore>(new Map());
   // A ref (not a module-level map) so it is scoped to the router instance and
   // reset on remount.
   const prefetchCacheRef = useRef<PrefetchCache>(new Map());
@@ -1156,87 +1173,76 @@ const InnerRouter = ({
         window.history.pushState(window.history.state, '', targetUrl);
         window.location.reload();
       };
-      if (options.instant && isStaticSlot(getRouteSlotId(nextRoute.path))) {
-        const isSwr = (key: string) => isMetaKey(key) || isStaticSlot(key);
-        // An in-flight or absent prefetch fetches fresh instead — an instant
-        // nav must not wait.
-        const cacheKey = prefetchCacheKey(rscPath, nextRoute.query);
-        const cached = getPrefetch(
-          prefetchCacheRef.current,
-          cacheKey,
-          Date.now(),
-        );
-        // TODO(daishi) keep the resolved shell for repeat instant navs.
-        if (cached) {
-          prefetchCacheRef.current.delete(cacheKey);
+      if (options.instant) {
+        const prefetchedElements =
+          prefetchedElementsStoreRef.current.get(rscPath);
+        const routeSlotId = getRouteSlotId(nextRoute.path);
+        if (
+          isStaticSlot(routeSlotId) ||
+          (prefetchedElements &&
+            isImmutableElement(prefetchedElements, routeSlotId))
+        ) {
+          const pin = (key: string) => isMetaKey(key) || isStaticSlot(key);
+          const cacheKey = prefetchCacheKey(rscPath, nextRoute.query);
+          const cached = getPrefetch(
+            prefetchCacheRef.current,
+            cacheKey,
+            Date.now(),
+          );
+          const dataPromise = refetch(rscPath, rscParams, {
+            signal: abortController.signal,
+            unstable_swr: {
+              pin,
+              ...(prefetchedElements ? { base: prefetchedElements } : null),
+            },
+            onBuildIdMismatch,
+            ...(cached ? { unstable_prefetched: cached.promise } : null),
+          });
+          commitRoute(nextRoute);
+          return dataPromise.then(
+            (elements) => {
+              if (isAborted()) {
+                return;
+              }
+              routeChangeAbortRef.current = null;
+              const redirect = getRedirect(elements);
+              if (redirect) {
+                routeRef.current = redirect;
+                setRoute(redirect);
+                if (redirect.path !== '/404') {
+                  setPendingHistory({
+                    mode: 'replace',
+                    url: getRouteUrl(redirect),
+                  });
+                }
+              }
+              emitRouteChangeEvent('complete', redirect ?? nextRoute);
+            },
+            (e) => {
+              if (isAborted()) {
+                return;
+              }
+              routeChangeAbortRef.current = null;
+              setErr(e);
+              throw e;
+            },
+          );
         }
-        const dataPromise = refetch(rscPath, rscParams, {
-          signal: abortController.signal,
-          unstable_isSwr: isSwr,
-          onBuildIdMismatch,
-          ...(cached?.resolved
-            ? {
-                unstable_prefetched: {
-                  elements: cached.resolved,
-                  complete: true,
-                },
-              }
-            : null),
-        });
-        commitRoute(nextRoute);
-        return dataPromise.then(
-          (elements) => {
-            if (isAborted()) {
-              return;
-            }
-            routeChangeAbortRef.current = null;
-            const redirect = getRedirect(elements);
-            if (redirect) {
-              routeRef.current = redirect;
-              setRoute(redirect);
-              if (redirect.path !== '/404') {
-                setPendingHistory({
-                  mode: 'replace',
-                  url: getRouteUrl(redirect),
-                });
-              }
-            }
-            emitRouteChangeEvent('complete', redirect ?? nextRoute);
-          },
-          (e) => {
-            if (isAborted()) {
-              return;
-            }
-            routeChangeAbortRef.current = null;
-            setErr(e);
-            throw e;
-          },
-        );
       }
-      // Consume the prefetch (matched by path and query) so it is not reused by
-      // a later navigation.
+      // Reuse a prefetch (matched by path and query) within its ttl; an
+      // in-flight one is adopted as the data source (it resolves no later
+      // than a fresh request, and prefetches are not abortable anyway).
       const cacheKey = prefetchCacheKey(rscPath, nextRoute.query);
       const cached = getPrefetch(
         prefetchCacheRef.current,
         cacheKey,
         Date.now(),
       );
-      if (cached) {
-        prefetchCacheRef.current.delete(cacheKey);
-      }
       try {
         const elements = await refetch(rscPath, rscParams, {
           signal: abortController.signal,
           onBuildIdMismatch,
-          // Reuse only resolved prefetches; an in-flight one isn't abortable.
-          ...(cached?.resolved
-            ? {
-                unstable_prefetched: {
-                  elements: cached.resolved,
-                  complete: true,
-                },
-              }
-            : null),
+          ...(cached ? { unstable_prefetched: cached.promise } : null),
         });
         const redirect = getRedirect(elements);
         if (redirect) {
@@ -1267,6 +1273,7 @@ const InnerRouter = ({
       staticPathSetRef,
       resolvedElementsRef,
       prefetchCacheRef,
+      prefetchedElementsStoreRef,
     ],
   );
   const applyChangeRouteData = useCallback(
@@ -1306,29 +1313,32 @@ const InnerRouter = ({
   }, [applyChangeRouteData]);
 
   const prefetchRoute: PrefetchRoute = useCallback(
-    (route) => {
+    (route, options) => {
+      preloadRouteModules(route.path);
       if (staticPathSetRef.current.has(route.path)) {
         return;
       }
       const rscPath = encodeRoutePath(route.path);
       const rscParams = createRscParams(route.query);
-      // Dedupe per (path, query) so a click that re-prefetches before an instant
-      // nav keeps an already-resolved shell instead of replacing it with an
-      // in-flight one (which would lose the instant shell).
+      const store = prefetchedElementsStoreRef.current;
+      if (options?.mode === 'once' && store.has(rscPath)) {
+        return;
+      }
+      // Dedupe per (path, query) so a repeat trigger within the ttl keeps an
+      // already-resolved response instead of replacing it with an in-flight
+      // one (which would lose the instant shell).
       const cache = prefetchCacheRef.current;
       const key = prefetchCacheKey(rscPath, route.query);
       if (!getPrefetch(cache, key, Date.now())) {
         const promise = prefetchRsc(rscPath, rscParams);
         const entry: PrefetchEntry = {
           promise,
-          expireAt: Date.now() + PREFETCH_TTL,
+          expireAt: Date.now() + (options?.ttl ?? PREFETCH_TTL),
         };
         setPrefetch(cache, key, entry);
         promise.then(
           (resolved) => {
-            if (cache.get(key) === entry) {
-              entry.resolved = resolved;
-            }
+            mergePrefetchedElements(store, rscPath, resolved);
           },
           () => {
             if (cache.get(key) === entry) {
@@ -1337,11 +1347,8 @@ const InnerRouter = ({
           },
         );
       }
-      globalThis.__WAKU_ROUTER_PREFETCH__?.(route.path, (id) => {
-        preloadModule(id, { as: 'script' });
-      });
     },
-    [staticPathSetRef, prefetchCacheRef],
+    [staticPathSetRef, prefetchCacheRef, prefetchedElementsStoreRef],
   );
 
   useEffect(() => {
@@ -1459,6 +1466,7 @@ export type Unstable_ChangeRoute = ChangeRoute;
 export type Unstable_ChangeRouteEvent = ChangeRouteEvent;
 export type Unstable_ChangeRouteCallback = ChangeRouteCallback;
 export type Unstable_PrefetchRoute = PrefetchRoute;
+export type Unstable_PrefetchOptions = PrefetchOptions;
 export type Unstable_SliceId = SliceId;
 export type Unstable_RouteHref = RouteHref;
 export type Unstable_RoutePath = RoutePath;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -61,17 +61,12 @@ import {
   isCodec,
 } from './isomorphic-utils/search-codec-registry.js';
 import {
-  PREFETCH_TTL,
   type PrefetchCache,
-  type PrefetchEntry,
   type PrefetchOptions,
   type PrefetchedElementsStore,
   getPrefetch,
-  mergePrefetchedElements,
   prefetchCacheKey,
-  releasePrefetchedElements,
-  reservePrefetchedElements,
-  setPrefetch,
+  startPrefetch,
 } from './prefetch-cache.js';
 
 type NavigateOptions = {
@@ -1190,6 +1185,14 @@ const InnerRouter = ({
         window.history.pushState(window.history.state, '', targetUrl);
         window.location.reload();
       };
+      // Reuse a prefetch (matched by path and query) within its ttl; an
+      // in-flight one is adopted as the data source (it resolves no later
+      // than a fresh request, and prefetches are not abortable anyway).
+      const cached = getPrefetch(
+        prefetchCacheRef.current,
+        prefetchCacheKey(rscPath, nextRoute.query),
+        Date.now(),
+      );
       if (options.instant) {
         const prefetchedElements =
           prefetchedElementsStoreRef.current.get(rscPath);
@@ -1200,12 +1203,6 @@ const InnerRouter = ({
             isImmutableElement(prefetchedElements, routeSlotId))
         ) {
           const pin = (key: string) => isMetaKey(key) || isStaticSlot(key);
-          const cacheKey = prefetchCacheKey(rscPath, nextRoute.query);
-          const cached = getPrefetch(
-            prefetchCacheRef.current,
-            cacheKey,
-            Date.now(),
-          );
           const dataPromise = refetch(rscPath, rscParams, {
             signal: abortController.signal,
             unstable_swr: {
@@ -1246,15 +1243,6 @@ const InnerRouter = ({
           );
         }
       }
-      // Reuse a prefetch (matched by path and query) within its ttl; an
-      // in-flight one is adopted as the data source (it resolves no later
-      // than a fresh request, and prefetches are not abortable anyway).
-      const cacheKey = prefetchCacheKey(rscPath, nextRoute.query);
-      const cached = getPrefetch(
-        prefetchCacheRef.current,
-        cacheKey,
-        Date.now(),
-      );
       try {
         const elements = await refetch(rscPath, rscParams, {
           signal: abortController.signal,
@@ -1337,35 +1325,14 @@ const InnerRouter = ({
       }
       const rscPath = encodeRoutePath(route.path);
       const rscParams = createRscParams(route.query);
-      const store = prefetchedElementsStoreRef.current;
-      if (options?.mode === 'once' && store.has(rscPath)) {
-        return;
-      }
-      // Dedupe per (path, query) so a repeat trigger within the ttl keeps an
-      // already-resolved response instead of replacing it with an in-flight
-      // one (which would lose the instant shell).
-      const cache = prefetchCacheRef.current;
-      const key = prefetchCacheKey(rscPath, route.query);
-      if (!getPrefetch(cache, key, Date.now())) {
-        const promise = prefetchRsc(rscPath, rscParams);
-        const entry: PrefetchEntry = {
-          promise,
-          expireAt: Date.now() + (options?.ttl ?? PREFETCH_TTL),
-        };
-        setPrefetch(cache, key, entry);
-        reservePrefetchedElements(store, rscPath);
-        promise.then(
-          (resolved) => {
-            mergePrefetchedElements(store, rscPath, resolved);
-          },
-          () => {
-            if (cache.get(key) === entry) {
-              cache.delete(key);
-            }
-            releasePrefetchedElements(store, rscPath);
-          },
-        );
-      }
+      startPrefetch(
+        prefetchCacheRef.current,
+        prefetchedElementsStoreRef.current,
+        rscPath,
+        route.query,
+        () => prefetchRsc(rscPath, rscParams),
+        options,
+      );
     },
     [staticPathSetRef, prefetchCacheRef, prefetchedElementsStoreRef],
   );

--- a/packages/waku/src/router/prefetch-cache.ts
+++ b/packages/waku/src/router/prefetch-cache.ts
@@ -4,13 +4,25 @@
 
 type Elements = Record<string, unknown>;
 
+export type PrefetchMode = 'always' | 'once';
+
+export type PrefetchOptions = {
+  mode?: PrefetchMode;
+  ttl?: number;
+};
+
 export type PrefetchEntry = {
   promise: Promise<Elements>;
-  resolved?: Elements;
   expireAt: number;
 };
 
 export type PrefetchCache = Map<string, PrefetchEntry>;
+
+// Session store of prefetched responses, keyed by rscPath alone. Entries are
+// only served under the etag protocol: they paint immutable slots (which
+// cannot vary by query) and fall back for a dynamic slot only when the
+// server omits it, which proves the stored copy current.
+export type PrefetchedElementsStore = Map<string, Elements>;
 
 export const PREFETCH_TTL = 1000 * 60;
 export const PREFETCH_LIMIT = 100;
@@ -46,4 +58,14 @@ export const setPrefetch = (
     cache.delete(oldest);
   }
   cache.set(key, entry);
+};
+
+/** Merge a prefetched response into the session store. */
+export const mergePrefetchedElements = (
+  store: PrefetchedElementsStore,
+  rscPath: string,
+  elements: Elements,
+): void => {
+  const existing = store.get(rscPath);
+  store.set(rscPath, existing ? { ...existing, ...elements } : elements);
 };

--- a/packages/waku/src/router/prefetch-cache.ts
+++ b/packages/waku/src/router/prefetch-cache.ts
@@ -62,7 +62,7 @@ export const setPrefetch = (
 };
 
 /** Reserve a route in the store while its first prefetch is in flight. */
-export const reservePrefetchedElements = (
+const reservePrefetchedElements = (
   store: PrefetchedElementsStore,
   rscPath: string,
 ): void => {
@@ -79,7 +79,7 @@ export const reservePrefetchedElements = (
 };
 
 /** Release a reservation that was never fulfilled. */
-export const releasePrefetchedElements = (
+const releasePrefetchedElements = (
   store: PrefetchedElementsStore,
   rscPath: string,
 ): void => {
@@ -89,7 +89,7 @@ export const releasePrefetchedElements = (
 };
 
 /** Merge a prefetched response into the session store. */
-export const mergePrefetchedElements = (
+const mergePrefetchedElements = (
   store: PrefetchedElementsStore,
   rscPath: string,
   elements: Elements,
@@ -97,4 +97,43 @@ export const mergePrefetchedElements = (
   reservePrefetchedElements(store, rscPath);
   const existing = store.get(rscPath);
   store.set(rscPath, existing ? { ...existing, ...elements } : elements);
+};
+
+/** Start a prefetch unless the mode or an entry within its ttl dedupes it. */
+export const startPrefetch = (
+  cache: PrefetchCache,
+  store: PrefetchedElementsStore,
+  rscPath: string,
+  query: string,
+  fetchElements: () => Promise<Elements>,
+  options: PrefetchOptions | undefined,
+): void => {
+  if (options?.mode === 'once' && store.has(rscPath)) {
+    return;
+  }
+  // Dedupe per (path, query), so a repeat trigger within the ttl keeps an
+  // already-resolved response instead of replacing it with an in-flight one.
+  const key = prefetchCacheKey(rscPath, query);
+  const now = Date.now();
+  if (getPrefetch(cache, key, now)) {
+    return;
+  }
+  const promise = fetchElements();
+  const entry: PrefetchEntry = {
+    promise,
+    expireAt: now + (options?.ttl ?? PREFETCH_TTL),
+  };
+  setPrefetch(cache, key, entry);
+  reservePrefetchedElements(store, rscPath);
+  promise.then(
+    (resolved) => {
+      mergePrefetchedElements(store, rscPath, resolved);
+    },
+    () => {
+      if (cache.get(key) === entry) {
+        cache.delete(key);
+      }
+      releasePrefetchedElements(store, rscPath);
+    },
+  );
 };

--- a/packages/waku/src/router/prefetch-cache.ts
+++ b/packages/waku/src/router/prefetch-cache.ts
@@ -61,18 +61,40 @@ export const setPrefetch = (
   cache.set(key, entry);
 };
 
+/** Reserve a route in the store while its first prefetch is in flight. */
+export const reservePrefetchedElements = (
+  store: PrefetchedElementsStore,
+  rscPath: string,
+): void => {
+  if (store.has(rscPath)) {
+    return;
+  }
+  if (store.size >= PREFETCH_LIMIT) {
+    const oldestKey = store.keys().next().value;
+    if (oldestKey !== undefined) {
+      store.delete(oldestKey);
+    }
+  }
+  store.set(rscPath, null);
+};
+
+/** Release a reservation that was never fulfilled. */
+export const releasePrefetchedElements = (
+  store: PrefetchedElementsStore,
+  rscPath: string,
+): void => {
+  if (store.get(rscPath) === null) {
+    store.delete(rscPath);
+  }
+};
+
 /** Merge a prefetched response into the session store. */
 export const mergePrefetchedElements = (
   store: PrefetchedElementsStore,
   rscPath: string,
   elements: Elements,
 ): void => {
-  if (!store.has(rscPath) && store.size >= PREFETCH_LIMIT) {
-    const oldestKey = store.keys().next().value;
-    if (oldestKey !== undefined) {
-      store.delete(oldestKey);
-    }
-  }
+  reservePrefetchedElements(store, rscPath);
   const existing = store.get(rscPath);
   store.set(rscPath, existing ? { ...existing, ...elements } : elements);
 };

--- a/packages/waku/src/router/prefetch-cache.ts
+++ b/packages/waku/src/router/prefetch-cache.ts
@@ -21,8 +21,9 @@ export type PrefetchCache = Map<string, PrefetchEntry>;
 // Session store of prefetched responses, keyed by rscPath alone. Entries are
 // only served under the etag protocol: they paint immutable slots (which
 // cannot vary by query) and fall back for a dynamic slot only when the
-// server omits it, which proves the stored copy current.
-export type PrefetchedElementsStore = Map<string, Elements>;
+// server omits it, which proves the stored copy current. A null entry marks
+// a route whose first prefetch is still in flight.
+export type PrefetchedElementsStore = Map<string, Elements | null>;
 
 export const PREFETCH_TTL = 1000 * 60;
 export const PREFETCH_LIMIT = 100;
@@ -66,6 +67,12 @@ export const mergePrefetchedElements = (
   rscPath: string,
   elements: Elements,
 ): void => {
+  if (!store.has(rscPath) && store.size >= PREFETCH_LIMIT) {
+    const oldestKey = store.keys().next().value;
+    if (oldestKey !== undefined) {
+      store.delete(oldestKey);
+    }
+  }
   const existing = store.get(rscPath);
   store.set(rscPath, existing ? { ...existing, ...elements } : elements);
 };

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -13,6 +13,7 @@ import {
   test,
   vi,
 } from 'vitest';
+import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import { fetchRscStore } from '../src/minimal/client-utils/fetch-store.js';
 import {
   Root,
@@ -332,7 +333,7 @@ describe('minimal/client eager merge', () => {
     const unstable_isEager = (key: string) => key === 'cached';
     await act(async () => {
       await refetch!('R/next.txt', undefined, {
-        unstable_isSwr: unstable_isEager,
+        unstable_swr: { pin: unstable_isEager },
       });
     });
     await act(async () => {
@@ -380,7 +381,7 @@ describe('minimal/client eager merge', () => {
     mocks.createFromFetch.mockReturnValueOnce(resolvedThenable({ extra: 'X' }));
     await act(async () => {
       await refetch!('R/next.txt', undefined, {
-        unstable_isSwr: (key) => key === 'cached',
+        unstable_swr: { pin: (key) => key === 'cached' },
       }).then(() => {
         // synchronously in the continuation, like the redirect handler
         mountExtra();
@@ -433,7 +434,7 @@ describe('minimal/client eager merge', () => {
     );
     const isSwr = (key: string) => key === 'eager';
     await act(async () => {
-      void refetch!('R/next.txt', undefined, { unstable_isSwr: isSwr });
+      void refetch!('R/next.txt', undefined, { unstable_swr: { pin: isSwr } });
     });
 
     // eager shows its cached A1 instantly; the hole suspends.
@@ -486,7 +487,7 @@ describe('minimal/client eager merge', () => {
     let refetched: Promise<unknown> | undefined;
     await act(async () => {
       refetched = refetch!('R/next.txt', undefined, {
-        unstable_isSwr: (key) => key === 'eager',
+        unstable_swr: { pin: (key) => key === 'eager' },
       });
     });
     const midPromise = elementsPromise!;
@@ -548,7 +549,7 @@ describe('minimal/client eager merge', () => {
     let refetched: unknown;
     await act(async () => {
       refetched = await refetch!('R/next.txt', undefined, {
-        unstable_isSwr: (key) => key === 'eager',
+        unstable_swr: { pin: (key) => key === 'eager' },
       });
     });
     expect(refetched).toEqual({ eager: 'A2', hole: 'H2', extra: 'X' });
@@ -602,7 +603,7 @@ describe('minimal/client eager merge', () => {
     let refetched1: Promise<unknown> | undefined;
     await act(async () => {
       refetched1 = refetch!('R/first.txt', undefined, {
-        unstable_isSwr: (key) => key === 'eager',
+        unstable_swr: { pin: (key) => key === 'eager' },
       });
     });
 
@@ -615,7 +616,7 @@ describe('minimal/client eager merge', () => {
     let refetched2: Promise<unknown> | undefined;
     await act(async () => {
       refetched2 = refetch!('R/second.txt', undefined, {
-        unstable_isSwr: (key) => key === 'eager',
+        unstable_swr: { pin: (key) => key === 'eager' },
       });
     });
     const midPromise = elementsPromise!;
@@ -676,7 +677,7 @@ describe('minimal/client eager merge', () => {
     let refetched: Promise<unknown> | undefined;
     await act(async () => {
       refetched = refetch!('R/next.txt', undefined, {
-        unstable_isSwr: (key) => key === 'eager',
+        unstable_swr: { pin: (key) => key === 'eager' },
       });
     });
     const midElements = await elementsPromise!;
@@ -698,21 +699,36 @@ describe('minimal/client eager merge', () => {
     act(() => root.unmount());
   });
 
-  test('an incomplete prefetch is ignored: refetch fetches fresh', async () => {
-    // complete: false is reserved: the elements must not serve as the data
-    // source nor be grafted (a stale graft would shadow the response's
-    // values); a fresh request serves the navigation.
+  test('a base serves pinned keys and falls back for keys the response omits', async () => {
+    // A base (e.g. a stored prefetched response) joins the merge like extra
+    // previous elements: immutable keys pin immediately, the rest become
+    // holes on the response and fall back to the base value only when the
+    // server omits the key, which the etag protocol guarantees means
+    // unchanged.
     mocks.createFromFetch.mockReturnValueOnce(
       resolvedThenable({ _value: null, cached: 'C', dynamic: 'D1' }),
     );
     stubFetch();
 
     let refetch: ReturnType<typeof useRefetch> | undefined;
-    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    let mountExtra: () => void = () => {};
     const Probe = () => {
       refetch = useRefetch();
-      elementsPromise = useElementsPromise_UNSTABLE();
-      return null;
+      const [extra, setExtra] = useState(false);
+      mountExtra = () => setExtra(true);
+      return extra ? (
+        <>
+          <Suspense fallback={<span>[S]</span>}>
+            <Slot id="shell" />
+          </Suspense>
+          <Suspense fallback={<span>[K]</span>}>
+            <Slot id="kept" />
+          </Suspense>
+          <Suspense fallback={<span>[L]</span>}>
+            <Slot id="lazy" />
+          </Suspense>
+        </>
+      ) : null;
     };
 
     const container = document.createElement('div');
@@ -722,34 +738,51 @@ describe('minimal/client eager merge', () => {
         <Root initialRscPath="R/app.txt">
           <Suspense fallback={null}>
             <Slot id="cached" />
-            <Slot id="dynamic" />
-            <Probe />
           </Suspense>
+          <Suspense fallback={<span>[D]</span>}>
+            <Slot id="dynamic" />
+          </Suspense>
+          <Probe />
         </Root>,
       );
     });
     expect(container.textContent).toBe('CD1');
 
+    let resolveB: (value: Record<string, unknown>) => void = () => {};
     mocks.createFromFetch.mockReturnValueOnce(
-      resolvedThenable({ dynamic: 'D2' }),
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveB = resolve;
+      }),
     );
-    let refetched: unknown;
+    let refetched: Promise<unknown> | undefined;
     await act(async () => {
-      refetched = await refetch!('R/next.txt', undefined, {
-        unstable_isSwr: (key) => key === 'cached',
-        unstable_prefetched: {
-          elements: { cached: 'STALE', dynamic: 'STALE', planted: 'STALE' },
-          complete: false,
+      refetched = refetch!('R/next.txt', undefined, {
+        unstable_swr: {
+          // the pin predicate governs previous elements only: shell pins
+          // because the base proves it immutable, not because of this
+          pin: (key) => key === 'cached',
+          base: {
+            cached: 'STALE',
+            shell: 'S',
+            [`${ETAG_ID_PREFIX}shell`]: IMMUTABLE_ETAG,
+            kept: 'K',
+            lazy: 'STALE',
+          },
         },
       });
+      mountExtra();
     });
+    // pinned: cached from prev (not the base), shell from the base;
+    // holes: dynamic, kept and lazy suspend on the response
+    expect(container.textContent).toBe('C[D]S[K][L]');
 
-    // a fresh request was made and its response won
+    await act(async () => {
+      resolveB({ dynamic: 'D2', lazy: 'L' });
+      await refetched;
+    });
+    // the response wins where it has the key; the base fills the omission
+    expect(container.textContent).toBe('CD2SKL');
     expect(mocks.createFromFetch).toHaveBeenCalledTimes(2);
-    expect(container.textContent).toBe('CD2');
-    expect(refetched).toEqual({ dynamic: 'D2' });
-    const finalElements = await elementsPromise!;
-    expect('planted' in finalElements).toBe(false);
 
     act(() => root.unmount());
   });
@@ -796,7 +829,7 @@ describe('minimal/client eager merge', () => {
     mocks.createFromFetch.mockReturnValueOnce(chunkLike({ extra: 'X' }));
     await act(async () => {
       await refetch!('R/next.txt', undefined, {
-        unstable_isSwr: (key) => key === 'cached',
+        unstable_swr: { pin: (key) => key === 'cached' },
       }).then(() => {
         mountExtra();
       });
@@ -866,7 +899,7 @@ describe('minimal/client refetch scenarios', () => {
     view.unmount();
   });
 
-  test('a complete prefetch paints elements immediately without fetching', async () => {
+  test('prefetched elements are adopted as the data source without fetching', async () => {
     const view = await mount({ _value: null, page: 'P1' }, () => (
       <Suspense fallback={null}>
         <Slot id="page" />
@@ -877,10 +910,7 @@ describe('minimal/client refetch scenarios', () => {
     mocks.createFromFetch.mockClear();
     await act(async () => {
       await view.refetch()('R/done.txt', undefined, {
-        unstable_prefetched: {
-          elements: { _value: null, page: 'P2' },
-          complete: true,
-        },
+        unstable_prefetched: { _value: null, page: 'P2' },
       });
     });
     expect(view.container.textContent).toBe('P2');
@@ -889,7 +919,7 @@ describe('minimal/client refetch scenarios', () => {
     view.unmount();
   });
 
-  test('reusing a complete prefetch re-checks the build id', async () => {
+  test('adopting prefetched elements re-checks the build id', async () => {
     vi.stubEnv('WAKU_BUILD_ID', 'build-1');
     const view = await mount(
       { _value: null, page: 'P1', _buildId: 'build-1' },
@@ -902,10 +932,7 @@ describe('minimal/client refetch scenarios', () => {
     const onBuildIdMismatch = vi.fn();
     await act(async () => {
       await view.refetch()('R/done.txt', undefined, {
-        unstable_prefetched: {
-          elements: { _value: null, page: 'P2', _buildId: 'build-2' },
-          complete: true,
-        },
+        unstable_prefetched: { _value: null, page: 'P2', _buildId: 'build-2' },
         onBuildIdMismatch,
       });
       await wait();

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -567,6 +567,55 @@ describe('minimal/client eager merge', () => {
     act(() => root.unmount());
   });
 
+  test('an overlapping key falls back to the base when the response omits it', async () => {
+    // The base's etag is what rides the request for keys the base holds, so
+    // an omission proves the base copy current: the fallback must serve the
+    // base copy, not a possibly older live one.
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ _value: null, eager: 'A1', shared: 'LIVE' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Suspense fallback={null}>
+            <Slot id="eager" />
+            <Slot id="shared" />
+          </Suspense>
+          <Probe />
+        </Root>,
+      );
+    });
+    expect(container.textContent).toBe('A1LIVE');
+
+    mocks.createFromFetch.mockReturnValueOnce(resolvedThenable({}));
+    await act(async () => {
+      await refetch!('R/next.txt', undefined, {
+        unstable_swr: {
+          pin: (key) => key === 'eager',
+          base: { shared: 'BASE' },
+        },
+      });
+    });
+
+    expect(container.textContent).toBe('A1BASE');
+    const finalElements = await elementsPromise!;
+    await expect(finalElements.shared).resolves.toBe('BASE');
+
+    act(() => root.unmount());
+  });
+
   test('a superseded refetch does not commit onto the newer state', async () => {
     // If another refetch commits between the eager merge and the response,
     // the stale response's second commit must leave the newer state as is:

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -154,7 +154,7 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     };
     await act(async () => {
       await refetch('R/bar', undefined, {
-        unstable_isSwr: (key) => key === 'page',
+        unstable_swr: { pin: (key) => key === 'page' },
       });
     });
     await flush();
@@ -166,10 +166,51 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     view.unmount();
   });
 
+  it("sends a base's etags with the request it accompanies", async () => {
+    // Statics served from an incomplete prefetch must ride the request as
+    // etags, so the server skips re-rendering and re-sending them.
+    testHoisted.elements = {
+      page: <div>a</div>,
+      [`${ETAG_ID_PREFIX}page`]: 'etag-page',
+    };
+    let refetch!: ReturnType<typeof useRefetch>;
+    const Capture = () => {
+      refetch = useRefetch();
+      return null;
+    };
+    const view = await renderApp(
+      <Root initialRscPath="R/foo">
+        <Capture />
+      </Root>,
+    );
+    await flush();
+
+    testHoisted.elements = { page: <div>b</div> };
+    await act(async () => {
+      await refetch('R/bar', undefined, {
+        unstable_swr: {
+          pin: () => false,
+          base: {
+            widget: <div>w</div>,
+            [`${ETAG_ID_PREFIX}widget`]: 'etag-widget',
+          },
+        },
+      });
+    });
+
+    const lastCall = vi.mocked(globalThis.fetch).mock.calls.at(-1);
+    const headers = new Headers(
+      (lastCall?.[1] as RequestInit | undefined)?.headers,
+    );
+    const sent = JSON.parse(headers.get(ETAGS_HEADER) ?? '{}');
+    expect(sent.widget).toBe('etag-widget');
+
+    view.unmount();
+  });
+
   it('caches the etag of a slot a response newly introduces in an instant-nav merge', async () => {
-    // A response-only slot lands via the second swr commit, and its etag must
-    // enter the cache like any other (the old merge Proxy never enumerated
-    // response-only keys, so these etags were silently dropped).
+    // A slot only the response introduces lands via the second swr commit,
+    // and its etag must enter the cache like any other.
     testHoisted.elements = {
       page: <div>a</div>,
       [`${ETAG_ID_PREFIX}page`]: IMMUTABLE_ETAG,
@@ -194,7 +235,7 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     };
     await act(async () => {
       await refetch('R/bar', undefined, {
-        unstable_isSwr: (key) => key === 'page',
+        unstable_swr: { pin: (key) => key === 'page' },
       });
     });
     await flush();

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -193,6 +193,8 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
           base: {
             widget: <div>w</div>,
             [`${ETAG_ID_PREFIX}widget`]: 'etag-widget',
+            page: <div>p</div>,
+            [`${ETAG_ID_PREFIX}page`]: 'etag-page-2',
           },
         },
       });
@@ -204,6 +206,9 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     );
     const sent = JSON.parse(headers.get(ETAGS_HEADER) ?? '{}');
     expect(sent.widget).toBe('etag-widget');
+    // for a key the base holds, the base's etag is claimed: an omission then
+    // proves the base copy current, and the merge falls back to it
+    expect(sent.page).toBe('etag-page-2');
 
     view.unmount();
   });

--- a/packages/waku/tests/prefetch-cache.test.ts
+++ b/packages/waku/tests/prefetch-cache.test.ts
@@ -3,12 +3,14 @@ import {
   PREFETCH_LIMIT,
   PREFETCH_TTL,
   getPrefetch,
+  mergePrefetchedElements,
   prefetchCacheKey,
   setPrefetch,
 } from '../src/router/prefetch-cache.js';
 import type {
   PrefetchCache,
   PrefetchEntry,
+  PrefetchedElementsStore,
 } from '../src/router/prefetch-cache.js';
 
 const entry = (expireAt: number): PrefetchEntry => ({
@@ -50,5 +52,28 @@ describe('router prefetch cache', () => {
 
   it('has a positive ttl', () => {
     expect(PREFETCH_TTL).toBeGreaterThan(0);
+  });
+
+  it('merges responses for the same rscPath in the store', () => {
+    const store: PrefetchedElementsStore = new Map();
+    mergePrefetchedElements(store, '/p', { a: 1 });
+    mergePrefetchedElements(store, '/p', { b: 2 });
+    expect(store.get('/p')).toEqual({ a: 1, b: 2 });
+  });
+
+  it('bounds the store at PREFETCH_LIMIT, evicting the oldest first', () => {
+    const store: PrefetchedElementsStore = new Map();
+    for (let i = 0; i < PREFETCH_LIMIT + 5; i += 1) {
+      mergePrefetchedElements(store, `/p${i}`, { i });
+    }
+    expect(store.size).toBe(PREFETCH_LIMIT);
+    expect(store.has('/p0')).toBe(false);
+    expect(store.has('/p4')).toBe(false);
+    expect(store.has('/p5')).toBe(true);
+    expect(store.has(`/p${PREFETCH_LIMIT + 4}`)).toBe(true);
+    // merging into an existing entry does not evict
+    mergePrefetchedElements(store, '/p5', { j: 1 });
+    expect(store.size).toBe(PREFETCH_LIMIT);
+    expect(store.has('/p5')).toBe(true);
   });
 });

--- a/packages/waku/tests/prefetch-cache.test.ts
+++ b/packages/waku/tests/prefetch-cache.test.ts
@@ -3,11 +3,9 @@ import {
   PREFETCH_LIMIT,
   PREFETCH_TTL,
   getPrefetch,
-  mergePrefetchedElements,
   prefetchCacheKey,
-  releasePrefetchedElements,
-  reservePrefetchedElements,
   setPrefetch,
+  startPrefetch,
 } from '../src/router/prefetch-cache.js';
 import type {
   PrefetchCache,
@@ -56,20 +54,19 @@ describe('router prefetch cache', () => {
     expect(PREFETCH_TTL).toBeGreaterThan(0);
   });
 
-  it('merges responses for the same rscPath in the store', () => {
+  it('merges responses for the same rscPath in the store', async () => {
+    const cache: PrefetchCache = new Map();
     const store: PrefetchedElementsStore = new Map();
-    mergePrefetchedElements(store, '/p', { a: 1 });
-    mergePrefetchedElements(store, '/p', { b: 2 });
+    await startAndSettle(cache, store, '/p', 'q=a', { a: 1 });
+    await startAndSettle(cache, store, '/p', 'q=b', { b: 2 });
     expect(store.get('/p')).toEqual({ a: 1, b: 2 });
   });
 
-  it('bounds the store at PREFETCH_LIMIT, evicting the oldest first', () => {
+  it('bounds the store at PREFETCH_LIMIT, evicting the oldest first', async () => {
+    const cache: PrefetchCache = new Map();
     const store: PrefetchedElementsStore = new Map();
     for (let i = 0; i < PREFETCH_LIMIT + 5; i += 1) {
-      // the flow the router follows: reserve at fetch start, merge on
-      // resolution
-      reservePrefetchedElements(store, `/p${i}`);
-      mergePrefetchedElements(store, `/p${i}`, { i });
+      await startAndSettle(cache, store, `/p${i}`, '', { i });
     }
     expect(store.size).toBe(PREFETCH_LIMIT);
     expect(store.has('/p0')).toBe(false);
@@ -77,29 +74,92 @@ describe('router prefetch cache', () => {
     expect(store.has('/p5')).toBe(true);
     expect(store.has(`/p${PREFETCH_LIMIT + 4}`)).toBe(true);
     // merging into an existing entry does not evict
-    mergePrefetchedElements(store, '/p5', { j: 1 });
+    await startAndSettle(cache, store, '/p5', 'q=b', { j: 1 });
     expect(store.size).toBe(PREFETCH_LIMIT);
     expect(store.has('/p5')).toBe(true);
   });
 
-  it('replaces a reservation with the resolved response', () => {
+  it('reserves the route while the first prefetch is in flight', async () => {
+    const cache: PrefetchCache = new Map();
     const store: PrefetchedElementsStore = new Map();
-    reservePrefetchedElements(store, '/p');
-    expect(store.get('/p')).toBe(null);
-    reservePrefetchedElements(store, '/p');
-    expect(store.size).toBe(1);
-    mergePrefetchedElements(store, '/p', { a: 1 });
+    let fetched = 0;
+    let resolveFetch: (value: Record<string, unknown>) => void = () => {};
+    const fetchElements = () => {
+      fetched += 1;
+      return new Promise<Record<string, unknown>>((resolve) => {
+        resolveFetch = resolve;
+      });
+    };
+    startPrefetch(cache, store, '/p', 'q=a', fetchElements, {
+      mode: 'once',
+    });
+    startPrefetch(cache, store, '/p', 'q=b', fetchElements, {
+      mode: 'once',
+    });
+    expect(fetched).toBe(1);
+    resolveFetch({ a: 1 });
+    await Promise.resolve();
     expect(store.get('/p')).toEqual({ a: 1 });
   });
 
-  it('releases only an unfulfilled reservation', () => {
+  it('releases only an unfulfilled reservation', async () => {
+    const cache: PrefetchCache = new Map();
     const store: PrefetchedElementsStore = new Map();
-    reservePrefetchedElements(store, '/p');
-    releasePrefetchedElements(store, '/p');
+    await expect(
+      startAndReject(cache, store, '/p', 'q=a'),
+    ).resolves.toBeUndefined();
     expect(store.has('/p')).toBe(false);
-    reservePrefetchedElements(store, '/p');
-    mergePrefetchedElements(store, '/p', { a: 1 });
-    releasePrefetchedElements(store, '/p');
+    await startAndSettle(cache, store, '/p', 'q=b', { a: 1 });
+    await expect(
+      startAndReject(cache, store, '/p', 'q=c'),
+    ).resolves.toBeUndefined();
     expect(store.get('/p')).toEqual({ a: 1 });
   });
 });
+
+const startAndSettle = async (
+  cache: PrefetchCache,
+  store: PrefetchedElementsStore,
+  rscPath: string,
+  query: string,
+  elements: Record<string, unknown>,
+) => {
+  let resolveFetch: (value: Record<string, unknown>) => void = () => {};
+  startPrefetch(
+    cache,
+    store,
+    rscPath,
+    query,
+    () =>
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    undefined,
+  );
+  resolveFetch(elements);
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const startAndReject = async (
+  cache: PrefetchCache,
+  store: PrefetchedElementsStore,
+  rscPath: string,
+  query: string,
+) => {
+  let rejectFetch: (reason: unknown) => void = () => {};
+  startPrefetch(
+    cache,
+    store,
+    rscPath,
+    query,
+    () =>
+      new Promise<Record<string, unknown>>((_resolve, reject) => {
+        rejectFetch = reject;
+      }),
+    undefined,
+  );
+  rejectFetch(new Error('network'));
+  await Promise.resolve();
+  await Promise.resolve();
+};

--- a/packages/waku/tests/prefetch-cache.test.ts
+++ b/packages/waku/tests/prefetch-cache.test.ts
@@ -5,6 +5,8 @@ import {
   getPrefetch,
   mergePrefetchedElements,
   prefetchCacheKey,
+  releasePrefetchedElements,
+  reservePrefetchedElements,
   setPrefetch,
 } from '../src/router/prefetch-cache.js';
 import type {
@@ -64,6 +66,9 @@ describe('router prefetch cache', () => {
   it('bounds the store at PREFETCH_LIMIT, evicting the oldest first', () => {
     const store: PrefetchedElementsStore = new Map();
     for (let i = 0; i < PREFETCH_LIMIT + 5; i += 1) {
+      // the flow the router follows: reserve at fetch start, merge on
+      // resolution
+      reservePrefetchedElements(store, `/p${i}`);
       mergePrefetchedElements(store, `/p${i}`, { i });
     }
     expect(store.size).toBe(PREFETCH_LIMIT);
@@ -75,5 +80,26 @@ describe('router prefetch cache', () => {
     mergePrefetchedElements(store, '/p5', { j: 1 });
     expect(store.size).toBe(PREFETCH_LIMIT);
     expect(store.has('/p5')).toBe(true);
+  });
+
+  it('replaces a reservation with the resolved response', () => {
+    const store: PrefetchedElementsStore = new Map();
+    reservePrefetchedElements(store, '/p');
+    expect(store.get('/p')).toBe(null);
+    reservePrefetchedElements(store, '/p');
+    expect(store.size).toBe(1);
+    mergePrefetchedElements(store, '/p', { a: 1 });
+    expect(store.get('/p')).toEqual({ a: 1 });
+  });
+
+  it('releases only an unfulfilled reservation', () => {
+    const store: PrefetchedElementsStore = new Map();
+    reservePrefetchedElements(store, '/p');
+    releasePrefetchedElements(store, '/p');
+    expect(store.has('/p')).toBe(false);
+    reservePrefetchedElements(store, '/p');
+    mergePrefetchedElements(store, '/p', { a: 1 });
+    releasePrefetchedElements(store, '/p');
+    expect(store.get('/p')).toEqual({ a: 1 });
   });
 });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -512,11 +512,14 @@ describe('useRouter + Link with context', () => {
     expect(replaceStateSpy).not.toHaveBeenCalled();
     expect(backSpy).toHaveBeenCalledTimes(1);
     expect(forwardSpy).toHaveBeenCalledTimes(1);
-    expect(prefetchRoute).toHaveBeenCalledWith({
-      path: '/prefetch',
-      query: 'x=1',
-      hash: '#h',
-    });
+    expect(prefetchRoute).toHaveBeenCalledWith(
+      {
+        path: '/prefetch',
+        query: 'x=1',
+        hash: '#h',
+      },
+      undefined,
+    );
     expect(capture.router.unstable_events).toBe(routeChangeEvents);
 
     view.unmount();
@@ -632,16 +635,24 @@ describe('useRouter + Link with context', () => {
         });
       });
 
-      expect(prefetchRoute).toHaveBeenNthCalledWith(1, {
-        path: '/static',
-        query: '',
-        hash: '',
-      });
-      expect(prefetchRoute).toHaveBeenNthCalledWith(2, {
-        path: '/posts/a',
-        query: '',
-        hash: '',
-      });
+      expect(prefetchRoute).toHaveBeenNthCalledWith(
+        1,
+        {
+          path: '/static',
+          query: '',
+          hash: '',
+        },
+        undefined,
+      );
+      expect(prefetchRoute).toHaveBeenNthCalledWith(
+        2,
+        {
+          path: '/posts/a',
+          query: '',
+          hash: '',
+        },
+        undefined,
+      );
 
       view.unmount();
     } finally {
@@ -796,11 +807,9 @@ describe('useRouter + Link with context', () => {
     await flush();
 
     expect(normalClick.defaultPrevented).toBe(true);
-    expect(prefetchRoute).toHaveBeenCalledWith({
-      path: '/next',
-      query: '',
-      hash: '',
-    });
+    // a click only preloads modules; a fetch started here could never be
+    // reused, since changeRoute looks the cache up in the same task
+    expect(prefetchRoute).not.toHaveBeenCalled();
     expect(changeRoute).toHaveBeenCalledTimes(1);
     expect(changeRoute).toHaveBeenCalledWith(
       { path: '/next', query: '', hash: '' },
@@ -1021,7 +1030,7 @@ describe('useRouter + Link with context', () => {
     expect(secondTargetClick.defaultPrevented).toBe(true);
     expect(downloadClick.defaultPrevented).toBe(true);
     expect(secondDownloadClick.defaultPrevented).toBe(true);
-    expect(prefetchRoute).toHaveBeenCalledTimes(5);
+    expect(prefetchRoute).not.toHaveBeenCalled();
     expect(changeRoute).toHaveBeenCalledTimes(5);
     expect(warnSpy).toHaveBeenCalledTimes(4);
     expect(warnSpy).toHaveBeenCalledWith(
@@ -1051,8 +1060,8 @@ describe('useRouter + Link with context', () => {
       >
         <Link
           to="/next"
-          unstable_prefetchOnEnter
-          unstable_prefetchOnView
+          unstable_prefetchOnEnter={{}}
+          unstable_prefetchOnView={{}}
           onMouseEnter={onMouseEnter}
         >
           next
@@ -1066,11 +1075,14 @@ describe('useRouter + Link with context', () => {
     }
 
     link.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-    expect(prefetchRoute).toHaveBeenCalledWith({
-      path: '/next',
-      query: '',
-      hash: '',
-    });
+    expect(prefetchRoute).toHaveBeenCalledWith(
+      {
+        path: '/next',
+        query: '',
+        hash: '',
+      },
+      {},
+    );
     expect(onMouseEnter).toHaveBeenCalledTimes(1);
 
     const observer = getIntersectionObserverMockInstance();
@@ -2242,9 +2254,9 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  // The instant shell: a RESOLVED prefetch for the target is passed to refetch
-  // as `unstable_prefetched`, so the merge Proxy paints the static shell from
-  // it while dynamic holes stream from the fresh fetch.
+  // The instant shell: a prefetch for the target is adopted via
+  // `unstable_prefetched` as the navigation's data source, while the eager
+  // merge paints the static shell and the base.
   const instantNavElements = () => ({
     [unstable_getRouteSlotId('/start')]: <div>start</div>,
     [unstable_getRouteSlotId('/next')]: <div>next</div>,
@@ -2254,7 +2266,7 @@ describe('Router integration', () => {
     [`${ETAG_ID_PREFIX}${unstable_getRouteSlotId('/next')}`]: IMMUTABLE_ETAG,
   });
 
-  test('instant nav reuses a resolved prefetch as the shell base', async () => {
+  test('instant nav reuses a prefetched response as data source and base', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
@@ -2266,7 +2278,8 @@ describe('Router integration', () => {
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
     };
-    vi.mocked(prefetchRsc).mockReturnValue(resolvedThenable(shell));
+    const shellPromise = resolvedThenable(shell);
+    vi.mocked(prefetchRsc).mockReturnValue(shellPromise);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -2297,22 +2310,23 @@ describe('Router integration', () => {
       unstable_encodeRoutePath('/next'),
       expect.any(URLSearchParams),
       expect.objectContaining({
-        unstable_prefetched: { elements: shell, complete: true },
+        unstable_prefetched: shellPromise,
+        unstable_swr: { pin: expect.any(Function), base: shell },
       }),
     );
 
     view.unmount();
   });
 
-  test('instant nav does not reuse an in-flight prefetch', async () => {
+  test('instant nav adopts an in-flight prefetch as its data source', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
     }));
     vi.mocked(useRefetch).mockReturnValue(refetch);
 
-    // Never resolves: the prefetch stays in-flight, so it is not reused (an
-    // instant nav must not wait) and refetch fetches fresh instead.
+    // Still in flight at navigation time: it started earlier than a fresh
+    // request could, so the navigation adopts it instead of duplicating it.
     const pending = createDeferred<Record<string, unknown>>();
     vi.mocked(prefetchRsc).mockReturnValue(pending.promise);
 
@@ -2335,13 +2349,17 @@ describe('Router integration', () => {
       capture.router!.prefetch('/next');
     });
     await act(async () => {
-      await capture.router!.push('/next', { unstable_instant: true });
+      const pushed = capture.router!.push('/next', { unstable_instant: true });
+      pending.resolve({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: true });
+      await pushed;
     });
 
     expect(refetch).toHaveBeenCalledWith(
       unstable_encodeRoutePath('/next'),
       expect.any(URLSearchParams),
-      expect.not.objectContaining({ unstable_prefetched: expect.anything() }),
+      expect.objectContaining({
+        unstable_prefetched: pending.promise,
+      }),
     );
 
     view.unmount();
@@ -2385,7 +2403,9 @@ describe('Router integration', () => {
       await capture.router!.push('/next?q=b', { unstable_instant: true });
     });
 
-    // The q=a shell must not be served for the q=b navigation.
+    // The q=a response must not become the q=b navigation's data source.
+    // It may still ride along as the base: its statics cannot vary by query
+    // and its dynamic slots are only served under a matching etag.
     expect(refetch).toHaveBeenCalledWith(
       unstable_encodeRoutePath('/next'),
       expect.any(URLSearchParams),
@@ -2395,15 +2415,13 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('non-instant nav does not reuse an in-flight prefetch', async () => {
+  test('non-instant nav adopts an in-flight prefetch as its data source', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
     }));
     vi.mocked(useRefetch).mockReturnValue(refetch);
 
-    // Never resolves: the prefetch stays in-flight (no abort signal), so it
-    // must not become the navigation's data source.
     const pending = createDeferred<Record<string, unknown>>();
     vi.mocked(prefetchRsc).mockReturnValue(pending.promise);
 
@@ -2426,15 +2444,167 @@ describe('Router integration', () => {
       capture.router!.prefetch('/next');
     });
     await act(async () => {
-      await capture.router!.push('/next');
+      const pushed = capture.router!.push('/next');
+      pending.resolve({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: true });
+      await pushed;
     });
 
     expect(refetch).toHaveBeenCalledWith(
       unstable_encodeRoutePath('/next'),
       expect.any(URLSearchParams),
-      expect.not.objectContaining({ unstable_prefetched: expect.anything() }),
+      expect.objectContaining({
+        unstable_prefetched: pending.promise,
+      }),
     );
 
+    view.unmount();
+  });
+
+  test('mode once fetches a route only once per session', async () => {
+    const shell = {
+      [unstable_getRouteSlotId('/next')]: <div>next-shell</div>,
+      [`${ETAG_ID_PREFIX}${unstable_getRouteSlotId('/next')}`]: IMMUTABLE_ETAG,
+      [ROUTE_ID]: ['/next', ''],
+      [IS_STATIC_ID]: false,
+    };
+    vi.mocked(prefetchRsc).mockReturnValue(resolvedThenable(shell));
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      capture.router!.prefetch('/next', { mode: 'once' });
+      await flush();
+    });
+    await act(async () => {
+      // a repeat trigger, even for a different query, is deduped by rscPath
+      capture.router!.prefetch('/next?q=a', { mode: 'once' });
+      await flush();
+    });
+
+    expect(prefetchRsc).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+  });
+
+  test('prefetch honors a per-call ttl', async () => {
+    vi.mocked(prefetchRsc).mockReturnValue(
+      resolvedThenable({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false }),
+    );
+    const now = Date.now();
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      capture.router!.prefetch('/next', { ttl: 100 });
+      await flush();
+    });
+    await act(async () => {
+      // within the ttl: deduped
+      capture.router!.prefetch('/next', { ttl: 100 });
+      await flush();
+    });
+    expect(prefetchRsc).toHaveBeenCalledTimes(1);
+
+    dateNow.mockReturnValue(now + 200);
+    await act(async () => {
+      // after the ttl: fetched again
+      capture.router!.prefetch('/next', { ttl: 100 });
+      await flush();
+    });
+    expect(prefetchRsc).toHaveBeenCalledTimes(2);
+
+    dateNow.mockRestore();
+    view.unmount();
+  });
+
+  test('instant nav serves stored statics on a first visit', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
+      [ROUTE_ID]: ['/fresh', ''],
+      [IS_STATIC_ID]: false,
+    }));
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const freshSlotId = unstable_getRouteSlotId('/fresh');
+    const shell = {
+      [freshSlotId]: <div>fresh-shell</div>,
+      [`${ETAG_ID_PREFIX}${freshSlotId}`]: IMMUTABLE_ETAG,
+      [ROUTE_ID]: ['/fresh', ''],
+      [IS_STATIC_ID]: false,
+    };
+    vi.mocked(prefetchRsc).mockReturnValue(resolvedThenable(shell));
+    const now = Date.now();
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    // /fresh has no static etag in the live elements, so the instant gate
+    // can only pass through the store
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [freshSlotId]: <div>fresh-live</div>,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      capture.router!.prefetch('/fresh', { ttl: 100 });
+      await flush();
+    });
+    // the prefetched response expires; the learned statics do not
+    dateNow.mockReturnValue(now + 200);
+    await act(async () => {
+      await capture.router!.push('/fresh', { unstable_instant: true });
+    });
+
+    expect(refetch).toHaveBeenCalledWith(
+      unstable_encodeRoutePath('/fresh'),
+      expect.any(URLSearchParams),
+      expect.objectContaining({
+        unstable_swr: expect.objectContaining({
+          base: expect.objectContaining({
+            [freshSlotId]: expect.anything(),
+            [`${ETAG_ID_PREFIX}${freshSlotId}`]: IMMUTABLE_ETAG,
+          }),
+        }),
+      }),
+    );
+
+    dateNow.mockRestore();
     view.unmount();
   });
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2499,6 +2499,72 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('mode once dedupes concurrent prefetches by rscPath', async () => {
+    const pending = createDeferred<Record<string, unknown>>();
+    vi.mocked(prefetchRsc).mockReturnValue(pending.promise);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      // the first request is still in flight when the second trigger fires
+      capture.router!.prefetch('/next?q=a', { mode: 'once' });
+      capture.router!.prefetch('/next?q=b', { mode: 'once' });
+    });
+
+    expect(prefetchRsc).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+  });
+
+  test('mode once retries after a failed prefetch', async () => {
+    vi.mocked(prefetchRsc)
+      .mockReturnValueOnce(Promise.reject(new Error('network')))
+      .mockReturnValueOnce(
+        resolvedThenable({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false }),
+      );
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      capture.router!.prefetch('/next', { mode: 'once' });
+      await flush();
+    });
+    await act(async () => {
+      capture.router!.prefetch('/next?q=b', { mode: 'once' });
+      await flush();
+    });
+
+    expect(prefetchRsc).toHaveBeenCalledTimes(2);
+
+    view.unmount();
+  });
+
   test('prefetch honors a per-call ttl', async () => {
     vi.mocked(prefetchRsc).mockReturnValue(
       resolvedThenable({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false }),

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2574,7 +2574,7 @@ describe('Router integration', () => {
 
   test('mode once retries after a failed prefetch', async () => {
     vi.mocked(prefetchRsc)
-      .mockReturnValueOnce(Promise.reject(new Error('network')))
+      .mockImplementationOnce(() => Promise.reject(new Error('network')))
       .mockReturnValueOnce(
         resolvedThenable({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false }),
       );

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -48,6 +48,7 @@ import {
   IS_STATIC_ID,
   ROUTE_ID,
 } from '../src/router/isomorphic-utils/route-path.js';
+import { PREFETCH_LIMIT } from '../src/router/prefetch-cache.js';
 
 const postsSearchCodec = {
   id: 'posts-test',
@@ -2525,6 +2526,48 @@ describe('Router integration', () => {
     });
 
     expect(prefetchRsc).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+  });
+
+  test('an evicted route can be warmed once again', async () => {
+    // The store is bounded, so "once" holds while the route stays in it: a
+    // route evicted by newer prefetches is fetched again on a later trigger.
+    vi.mocked(prefetchRsc).mockImplementation(((rscPath: string) =>
+      resolvedThenable({
+        [ROUTE_ID]: [rscPath, ''],
+        [IS_STATIC_ID]: false,
+      })) as never);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      for (let i = 0; i < PREFETCH_LIMIT + 1; i += 1) {
+        capture.router!.prefetch(`/p${i}`, { mode: 'once' });
+      }
+      await flush();
+    });
+    expect(prefetchRsc).toHaveBeenCalledTimes(PREFETCH_LIMIT + 1);
+
+    await act(async () => {
+      // /p0 was evicted by the overflowing prefetches above
+      capture.router!.prefetch('/p0', { mode: 'once' });
+      await flush();
+    });
+    expect(prefetchRsc).toHaveBeenCalledTimes(PREFETCH_LIMIT + 2);
 
     view.unmount();
   });


### PR DESCRIPTION
Adds prefetch modes and ttl to the router.

`unstable_prefetchOnEnter`, `unstable_prefetchOnView` and `router.prefetch` now take an options object with `mode` and `ttl` instead of a boolean. Mode `always` (the default) fetches on the first trigger and dedupes repeat triggers for the same path and query within the ttl (default 60s). Mode `once` fetches a route only once per session, ignoring the query. Within the ttl, a navigation reuses the prefetched response without another request, and an in-flight prefetch is adopted as the navigation's data source.

Every prefetched response is also kept in a session store keyed by rscPath. On an instant navigation, the stored response joins the eager merge as a base: its immutable slots paint immediately, so a prefetched route can be instant even on its first visit. Its other slots are only served when the server omits them, which the etags sent with the request prove means unchanged, so stale content is never shown.

The minimal refetch options are restructured for this: `unstable_prefetched` is a response to adopt as the data source, and `unstable_swr` groups the pin predicate with the optional base. A link click no longer starts an RSC fetch of its own, which could never be reused; it only preloads modules.

Related to #2167 #1212.