### PR TITLE
fix: return 400 for form action requests without an action reference

### DIFF
--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -79,8 +79,7 @@ export async function getInput(
           const formData = (await getActionBody(req)) as FormData;
           const decodedAction = await decodeAction(formData);
           if (typeof decodedAction !== 'function') {
-            // multipart/form-data POST without an action reference
-            // (e.g. crawlers or vulnerability scanners probing arbitrary paths)
+            // multipart/form-data POST without an action reference (e.g. crawlers)
             throw createCustomError('Bad Request', { status: 400 });
           }
           const result = await decodedAction();

--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -16,7 +16,7 @@ export async function getInput(
     body: string | FormData,
     options?: object,
   ) => Promise<unknown[]>,
-  decodeAction: (body: FormData) => Promise<() => Promise<void>>,
+  decodeAction: (body: FormData) => Promise<() => Promise<void>> | null,
   decodeFormState: (
     actionResult: unknown,
     body: FormData,
@@ -78,6 +78,11 @@ export async function getInput(
         fn: async () => {
           const formData = (await getActionBody(req)) as FormData;
           const decodedAction = await decodeAction(formData);
+          if (typeof decodedAction !== 'function') {
+            // multipart/form-data POST without an action reference
+            // (e.g. crawlers or vulnerability scanners probing arbitrary paths)
+            throw createCustomError('Bad Request', { status: 400 });
+          }
           const result = await decodedAction();
           return await decodeFormState(result, formData);
         },

--- a/packages/waku/tests/request.test.ts
+++ b/packages/waku/tests/request.test.ts
@@ -141,7 +141,7 @@ describe('getInput server action request validation', () => {
       makeConfig(),
       undefined,
       vi.fn(),
-      vi.fn().mockResolvedValue(null),
+      vi.fn().mockReturnValue(null),
       vi.fn(),
       vi.fn(),
     );

--- a/packages/waku/tests/request.test.ts
+++ b/packages/waku/tests/request.test.ts
@@ -127,6 +127,31 @@ describe('getInput server action request validation', () => {
       ),
     ).resolves.toBe(403);
   });
+
+  it('rejects form action requests without an action reference', async () => {
+    const formData = new FormData();
+    formData.set('key', 'value');
+
+    const input = await getInput(
+      new Request('https://app.test/', {
+        method: 'POST',
+        body: formData,
+        headers: { origin: 'https://app.test' },
+      }),
+      makeConfig(),
+      undefined,
+      vi.fn(),
+      vi.fn().mockResolvedValue(null),
+      vi.fn(),
+      vi.fn(),
+    );
+
+    expect(input.type).toBe('action');
+    if (input.type !== 'action') {
+      throw new Error('unreachable');
+    }
+    await expect(getStatus(input.fn())).resolves.toBe(400);
+  });
 });
 
 describe('getInput etags', () => {


### PR DESCRIPTION
A multipart/form-data POST to any non-RSC path is treated as a progressive-enhancement server action, but decodeAction returns null when the form data contains no $ACTION_ reference. The result was invoked unconditionally, so such requests (typically crawlers or vulnerability scanners probing arbitrary paths) crashed the render with "TypeError: (intermediate value) is not a function" and produced a 500 with a stack trace in server logs.

Guard the decoded action and throw a custom error instead, which the handler already maps to a clean 400 response. Also widen the decodeAction parameter type to include null, matching React's actual signature.