### PR TITLE
test(vite): cover user base override

### DIFF
--- a/packages/waku/tests/vite-plugin-environments.test.ts
+++ b/packages/waku/tests/vite-plugin-environments.test.ts
@@ -1,0 +1,40 @@
+import type { UserConfig } from 'vite';
+import { expect, test } from 'vitest';
+import type { Config } from '../src/config.js';
+import { resolveConfig } from '../src/lib/utils/config.js';
+import { environmentsPlugin } from '../src/lib/vite-plugins/environments.js';
+
+const runConfigHook = async (config: Config): Promise<UserConfig> => {
+  const plugin = environmentsPlugin(resolveConfig(config));
+  const hook = plugin.config;
+  if (!(typeof hook === 'function')) {
+    throw new Error('Plugin config is not defined');
+  }
+  return (await hook.call(
+    undefined,
+    {},
+    {
+      command: 'build',
+      mode: 'production',
+    },
+  )) as UserConfig;
+};
+
+test('uses basePath as the default Vite base', async () => {
+  const config = await runConfigHook({
+    basePath: '/custom/base/',
+  });
+
+  expect(config.base).toBe('/custom/base/');
+});
+
+test('lets user-provided Vite base override basePath', async () => {
+  const config = await runConfigHook({
+    basePath: '/custom/base/',
+    vite: {
+      base: 'https://cdn.example.com/assets/',
+    },
+  });
+
+  expect(config.base).toBe('https://cdn.example.com/assets/');
+});

--- a/packages/waku/tests/vite-plugin-environments.test.ts
+++ b/packages/waku/tests/vite-plugin-environments.test.ts
@@ -11,7 +11,7 @@ const runConfigHook = async (config: Config): Promise<UserConfig> => {
     throw new Error('Plugin config is not defined');
   }
   return (await hook.call(
-    undefined,
+    {} as never,
     {},
     {
       command: 'build',


### PR DESCRIPTION
## Summary

Adds coverage for the Vite config path that sets `basePath` as Waku's default Vite `base`, while still allowing a user-provided `vite.base` to override it.

## Why

#2000 asks whether client chunks can be served from a different domain. The current `mergeConfig` path already preserves `vite.base`; this test locks that behavior so it does not regress while the Vite environment plugin keeps changing.

## Validation

- `../../node_modules/.pnpm/node_modules/.bin/vitest run tests/vite-plugin-environments.test.ts`
- `./node_modules/.bin/prettier -c packages/waku/tests/vite-plugin-environments.test.ts`
- `git diff --check`
