### PR TITLE
fix(minimal): etags with prefetch

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -89,8 +89,10 @@ export const Nav = () => (
 Both props take an options object. Passing an empty object enables prefetching with the defaults; omitting the prop disables it.
 
 - `mode: 'always'` (the default) fetches on the first trigger and dedupes repeat triggers for the same path and query within the `ttl`. Within the `ttl`, navigation reuses the prefetched response without another request.
-- `mode: 'once'` fetches a route at most once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit. Warmed routes are kept in a bounded store, so a long session may eventually fetch a route again. A repeat prefetch sends the etags of the stored response, so the server only renders and sends what changed.
+- `mode: 'once'` fetches a route at most once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit. Warmed routes are kept in a bounded store, so a long session may eventually fetch a route again.
 - `ttl` sets how long a prefetched response stays reusable, in milliseconds (default: 60000).
+
+A repeat prefetch sends the etags of the stored response, so the server only renders and sends what changed.
 
 The same options work with `router.prefetch(to, options)`.
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -89,7 +89,7 @@ export const Nav = () => (
 Both props take an options object. Passing an empty object enables prefetching with the defaults; omitting the prop disables it.
 
 - `mode: 'always'` (the default) fetches on the first trigger and dedupes repeat triggers for the same path and query within the `ttl`. Within the `ttl`, navigation reuses the prefetched response without another request.
-- `mode: 'once'` fetches a route at most once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit. Warmed routes are kept in a bounded store, so a long session may eventually fetch a route again.
+- `mode: 'once'` fetches a route at most once per session, ignoring the query. Its main purpose is to warm the route's static parts, which cannot change within a build, so instant navigation can paint them even on the route's first visit. Warmed routes are kept in a bounded store, so a long session may eventually fetch a route again. A repeat prefetch sends the etags of the stored response, so the server only renders and sends what changed.
 - `ttl` sets how long a prefetched response stays reusable, in milliseconds (default: 60000).
 
 The same options work with `router.prefetch(to, options)`.

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { expect } from '@playwright/test';
 import { prepareNormalSetup, test, waitForHydration } from './utils.js';
 
@@ -287,5 +289,57 @@ test.describe('instant-nav', () => {
 
     await page.getByTestId('link-post-2').click();
     await expect(page.getByTestId('post-body')).toHaveText('Post 2');
+  });
+
+  test('an HMR update invalidates stored prefetches', async ({
+    page,
+    mode,
+  }) => {
+    test.skip(mode !== 'DEV', 'HMR is only available in development mode');
+    const layoutFile = fileURLToPath(
+      new URL('./fixtures/instant-nav/src/pages/_layout.tsx', import.meta.url),
+    );
+    const original = readFileSync(layoutFile, 'utf-8');
+    try {
+      const bodies: string[] = [];
+      page.on('response', (response) => {
+        if (response.url().includes('R/slow')) {
+          const index = bodies.length;
+          bodies.push('pending');
+          response.text().then(
+            (text) => {
+              bodies[index] = text;
+            },
+            () => {},
+          );
+        }
+      });
+      await page.goto(`http://localhost:${port}/post/1`);
+      await waitForHydration(page);
+      // the view prefetch stores /slow's pre-edit template
+      await expect.poll(() => bodies.length).toBe(1);
+
+      writeFileSync(
+        layoutFile,
+        original.replace(
+          '<nav data-testid="nav">',
+          '<nav data-testid="nav"><span data-testid="hmr-marker">v2</span>',
+        ),
+      );
+      await expect(page.getByTestId('hmr-marker')).toBeVisible();
+
+      // the stored template predates the edit, so its etags must not ride
+      // the navigation: the response has to carry the fresh route template
+      await page.getByTestId('link-slow').click();
+      await expect(page.getByTestId('slow-body')).toHaveText('Slow page');
+      await expect.poll(() => bodies.length).toBeGreaterThanOrEqual(2);
+      await expect.poll(() => bodies[1]).not.toBe('pending');
+      expect(bodies[1]).toContain('route:/slow');
+      expect(bodies[1]).toContain('hmr-marker');
+      await expect(page.getByTestId('hmr-marker')).toBeVisible();
+    } finally {
+      writeFileSync(layoutFile, original);
+      await page.waitForTimeout(300);
+    }
   });
 });

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -1,5 +1,5 @@
 import { cpSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { expect } from '@playwright/test';
 import { prepareNormalSetup, test, waitForHydration } from './utils.js';
@@ -302,6 +302,7 @@ const hmrFixtureDir = join(
   dirname(fixtureSrc),
   `instant-nav-hmr-tmp-${process.pid}`,
 );
+const distDir = join(fixtureSrc, 'dist');
 const startHmrApp = prepareNormalSetup('instant-nav', {
   fixtureDir: hmrFixtureDir,
 });
@@ -318,7 +319,7 @@ test.describe('instant-nav hmr', () => {
   test.beforeAll(async ({ mode }) => {
     cpSync(fixtureSrc, hmrFixtureDir, {
       recursive: true,
-      filter: (src) => !src.includes('dist'),
+      filter: (src) => src !== distDir && !src.startsWith(distDir + sep),
     });
     ({ port, stopApp } = await startHmrApp(mode));
   });

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -1,4 +1,5 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { cpSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { expect } from '@playwright/test';
 import { prepareNormalSetup, test, waitForHydration } from './utils.js';
@@ -290,56 +291,81 @@ test.describe('instant-nav', () => {
     await page.getByTestId('link-post-2').click();
     await expect(page.getByTestId('post-body')).toHaveText('Post 2');
   });
+});
 
-  test('an HMR update invalidates stored prefetches', async ({
-    page,
-    mode,
-  }) => {
-    test.skip(mode !== 'DEV', 'HMR is only available in development mode');
-    const layoutFile = fileURLToPath(
-      new URL('./fixtures/instant-nav/src/pages/_layout.tsx', import.meta.url),
-    );
+// The hmr test edits its fixture, so it runs against a worker-local copy. A
+// sibling directory keeps the fixture's relative node_modules links valid.
+const fixtureSrc = fileURLToPath(
+  new URL('./fixtures/instant-nav', import.meta.url),
+);
+const hmrFixtureDir = join(
+  dirname(fixtureSrc),
+  `instant-nav-hmr-tmp-${process.pid}`,
+);
+const startHmrApp = prepareNormalSetup('instant-nav', {
+  fixtureDir: hmrFixtureDir,
+});
+
+test.describe('instant-nav hmr', () => {
+  test.skip(
+    ({ mode }) => mode !== 'DEV',
+    'HMR is only available in development mode',
+  );
+
+  let port: number;
+  let stopApp: (() => Promise<void>) | undefined;
+
+  test.beforeAll(async ({ mode }) => {
+    cpSync(fixtureSrc, hmrFixtureDir, {
+      recursive: true,
+      filter: (src) => !src.includes('dist'),
+    });
+    ({ port, stopApp } = await startHmrApp(mode));
+  });
+
+  test.afterAll(async () => {
+    await stopApp?.();
+    rmSync(hmrFixtureDir, { recursive: true, force: true });
+  });
+
+  test('an HMR update invalidates stored prefetches', async ({ page }) => {
+    const layoutFile = join(hmrFixtureDir, 'src/pages/_layout.tsx');
     const original = readFileSync(layoutFile, 'utf-8');
-    try {
-      const bodies: string[] = [];
-      page.on('response', (response) => {
-        if (response.url().includes('R/slow')) {
-          const index = bodies.length;
-          bodies.push('pending');
-          response.text().then(
-            (text) => {
-              bodies[index] = text;
-            },
-            () => {},
-          );
-        }
-      });
-      await page.goto(`http://localhost:${port}/post/1`);
-      await waitForHydration(page);
-      // the view prefetch stores /slow's pre-edit template
-      await expect.poll(() => bodies.length).toBe(1);
+    const bodies: string[] = [];
+    page.on('response', (response) => {
+      if (response.url().includes('R/slow')) {
+        const index = bodies.length;
+        bodies.push('pending');
+        response.text().then(
+          (text) => {
+            bodies[index] = text;
+          },
+          () => {},
+        );
+      }
+    });
+    await page.goto(`http://localhost:${port}/post/1`);
+    await waitForHydration(page);
+    // the view prefetch stores /slow's pre-edit template
+    await expect.poll(() => bodies.length).toBe(1);
 
-      writeFileSync(
-        layoutFile,
-        original.replace(
-          '<nav data-testid="nav">',
-          '<nav data-testid="nav"><span data-testid="hmr-marker">v2</span>',
-        ),
-      );
-      await expect(page.getByTestId('hmr-marker')).toBeVisible();
+    writeFileSync(
+      layoutFile,
+      original.replace(
+        '<nav data-testid="nav">',
+        '<nav data-testid="nav"><span data-testid="hmr-marker">v2</span>',
+      ),
+    );
+    await expect(page.getByTestId('hmr-marker')).toBeVisible();
 
-      // the stored template predates the edit, so its etags must not ride
-      // the navigation: the response has to carry the fresh route template
-      await page.getByTestId('link-slow').click();
-      await expect(page.getByTestId('slow-body')).toHaveText('Slow page');
-      await expect.poll(() => bodies.length).toBeGreaterThanOrEqual(2);
-      await expect.poll(() => bodies[1]).not.toBe('pending');
-      expect(bodies[1]).toContain('route:/slow');
-      expect(bodies[1]).toContain('hmr-marker');
-      await expect(page.getByTestId('hmr-marker')).toBeVisible();
-    } finally {
-      writeFileSync(layoutFile, original);
-      await page.waitForTimeout(300);
-    }
+    // the stored template predates the edit, so its etags must not ride
+    // the navigation: the response has to carry the fresh route template
+    await page.getByTestId('link-slow').click();
+    await expect(page.getByTestId('slow-body')).toHaveText('Slow page');
+    await expect.poll(() => bodies.length).toBeGreaterThanOrEqual(2);
+    await expect.poll(() => bodies[1]).not.toBe('pending');
+    expect(bodies[1]).toContain('route:/slow');
+    expect(bodies[1]).toContain('hmr-marker');
+    await expect(page.getByTestId('hmr-marker')).toBeVisible();
   });
 });

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -191,6 +191,41 @@ test.describe('instant-nav', () => {
     await expect.poll(() => hoverRequests.length).toBe(2);
   });
 
+  test('a repeat prefetch omits what the store holds current', async ({
+    page,
+  }) => {
+    const bodies: string[] = [];
+    page.on('response', (response) => {
+      if (response.url().includes('R/hover')) {
+        const index = bodies.length;
+        bodies.push('pending');
+        response.text().then(
+          (text) => {
+            bodies[index] = text;
+          },
+          () => {},
+        );
+      }
+    });
+    await page.goto(`http://localhost:${port}/post/1`);
+    await waitForHydration(page);
+
+    await page.getByTestId('link-hover').hover();
+    await expect.poll(() => bodies.length).toBe(1);
+    await expect.poll(() => bodies[0]).toContain('route:/hover');
+
+    // after the ttl (600), the repeat prefetch sends the stored etags, so
+    // the server omits the route template it already proved current
+    await page.waitForTimeout(700);
+    await page.getByTestId('link-post-1').hover();
+    await page.getByTestId('link-hover').hover();
+    await expect.poll(() => bodies.length).toBe(2);
+    await expect.poll(() => bodies[1]).not.toBe('pending');
+    expect(bodies[1]).not.toContain('route:/hover');
+    expect(bodies[1]).toContain('hover-body');
+    expect(bodies[0]).toContain('hover-body');
+  });
+
   // The optimistic commit happens before the response, so it reconciles a
   // server redirect once the response lands.
   test('a redirected instant navigation reconciles to the target', async ({

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -479,8 +479,9 @@ export const unstable_prefetchRsc = (
   options?: {
     /**
      * Elements the client already holds for this path. Their etags are sent
-     * with the request, so the server can omit any the client holds current.
-     * The caller is responsible for keeping every copy it claims.
+     * with the request, so the server can omit any the client holds current,
+     * and the returned elements are the response merged over the base, so a
+     * caller cannot claim copies it does not keep.
      */
     unstable_base?: Elements;
   },
@@ -497,7 +498,11 @@ export const unstable_prefetchRsc = (
     undefined,
     base ? collectCachedEtags(base) : undefined,
   );
-  return decodeRsc(responsePromise, temporaryReferences, undefined);
+  const data = decodeRsc(responsePromise, temporaryReferences, undefined);
+  if (!base) {
+    return data;
+  }
+  return Promise.resolve(data).then((response) => ({ ...base, ...response }));
 };
 
 const RefetchContext = createContext<Refetch>(() => {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -240,15 +240,14 @@ const requestRsc = (
   rscParams: unknown,
   temporaryReferences: ReturnType<typeof createTemporaryReferenceSet>,
   signal: AbortSignal | undefined,
-  extraEtags?: Etags,
+  etagsOverride?: Etags,
 ): Promise<Response> => {
   const url = BASE_RSC_PATH + encodeRscPath(rscPath);
   const init: RequestInit = {
     headers: {
-      [ETAGS_HEADER]: serializeClientEtags({
-        ...fetchRscStore[CACHED_ETAGS],
-        ...extraEtags,
-      }),
+      [ETAGS_HEADER]: serializeClientEtags(
+        etagsOverride ?? fetchRscStore[CACHED_ETAGS] ?? {},
+      ),
     },
   };
   if (signal) {
@@ -478,10 +477,10 @@ export const unstable_prefetchRsc = (
   rscParams?: unknown,
   options?: {
     /**
-     * Elements the client already holds for this path. Their etags are sent
-     * with the request, so the server can omit any the client holds current,
-     * and the returned elements are the response merged over the base, so a
-     * caller cannot claim copies it does not keep.
+     * Elements the client already holds for this path. Their etags are the
+     * only ones sent with the request, so the server can omit any the client
+     * holds current, and the returned elements are the response merged over
+     * the base, so a caller cannot claim copies it does not keep.
      */
     unstable_base?: Elements;
   },
@@ -496,7 +495,7 @@ export const unstable_prefetchRsc = (
     rscParams,
     temporaryReferences,
     undefined,
-    base ? collectCachedEtags(base) : undefined,
+    base ? collectCachedEtags(base) : {},
   );
   const data = decodeRsc(responsePromise, temporaryReferences, undefined);
   if (!base) {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -240,11 +240,15 @@ const requestRsc = (
   rscParams: unknown,
   temporaryReferences: ReturnType<typeof createTemporaryReferenceSet>,
   signal: AbortSignal | undefined,
+  extraEtags?: Etags,
 ): Promise<Response> => {
   const url = BASE_RSC_PATH + encodeRscPath(rscPath);
   const init: RequestInit = {
     headers: {
-      [ETAGS_HEADER]: serializeClientEtags(fetchRscStore[CACHED_ETAGS] ?? {}),
+      [ETAGS_HEADER]: serializeClientEtags({
+        ...fetchRscStore[CACHED_ETAGS],
+        ...extraEtags,
+      }),
     },
   };
   if (signal) {
@@ -472,9 +476,18 @@ export const unstable_fetchRsc = (
 export const unstable_prefetchRsc = (
   rscPath: string,
   rscParams?: unknown,
+  options?: {
+    /**
+     * Elements the client already holds for this path. Their etags are sent
+     * with the request, so the server can omit any the client holds current.
+     * The caller is responsible for keeping every copy it claims.
+     */
+    unstable_base?: Elements;
+  },
 ): Promise<Elements> => {
   // Transformers must be prefetchOnly-agnostic (prefetches reused as navs).
   [rscPath, rscParams] = applyInputTransformers(rscPath, rscParams, true);
+  const base = options?.unstable_base;
   const temporaryReferences = createTemporaryReferenceSet();
   const responsePromise = requestRsc(
     getFetchFn(),
@@ -482,6 +495,7 @@ export const unstable_prefetchRsc = (
     rscParams,
     temporaryReferences,
     undefined,
+    base ? collectCachedEtags(base) : undefined,
   );
   return decodeRsc(responsePromise, temporaryReferences, undefined);
 };

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1308,7 +1308,12 @@ const InnerRouter = ({
         prefetchedElementsStoreRef.current,
         rscPath,
         route.query,
-        () => prefetchRsc(rscPath, rscParams),
+        () => {
+          const base = prefetchedElementsStoreRef.current.get(rscPath);
+          return prefetchRsc(rscPath, rscParams, {
+            ...(base ? { unstable_base: base } : {}),
+          });
+        },
         options,
       );
     },

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1308,12 +1308,10 @@ const InnerRouter = ({
         prefetchedElementsStoreRef.current,
         rscPath,
         route.query,
-        () => {
-          const base = prefetchedElementsStoreRef.current.get(rscPath);
-          return prefetchRsc(rscPath, rscParams, {
+        (base) =>
+          prefetchRsc(rscPath, rscParams, {
             ...(base ? { unstable_base: base } : {}),
-          });
-        },
+          }),
         options,
       );
     },

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1030,6 +1030,8 @@ const InnerRouter = ({
     // The etag cache is cleared by minimal's own reload listener, which Root
     // registers (via unstable_fetchRsc) ahead of this one, so it runs first.
     const refetchRoute = () => {
+      prefetchCacheRef.current = new Map();
+      prefetchedElementsStoreRef.current = new Map();
       staticPathSetRef.current.clear();
       const rscPath = encodeRoutePath(route.path);
       const rscParams = createRscParams(route.query);

--- a/packages/waku/src/router/prefetch-cache.ts
+++ b/packages/waku/src/router/prefetch-cache.ts
@@ -105,7 +105,7 @@ export const startPrefetch = (
   store: PrefetchedElementsStore,
   rscPath: string,
   query: string,
-  fetchElements: () => Promise<Elements>,
+  fetchElements: (base: Elements | undefined) => Promise<Elements>,
   options: PrefetchOptions | undefined,
 ): void => {
   if (options?.mode === 'once' && store.has(rscPath)) {
@@ -118,7 +118,8 @@ export const startPrefetch = (
   if (getPrefetch(cache, key, now)) {
     return;
   }
-  const promise = fetchElements();
+  const base = store.get(rscPath) ?? undefined;
+  const promise = fetchElements(base);
   const entry: PrefetchEntry = {
     promise,
     expireAt: now + (options?.ttl ?? PREFETCH_TTL),

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -213,6 +213,35 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     view.unmount();
   });
 
+  it('a prefetch claims the etags of its base and returns the merge', async () => {
+    fetchRscStore[CACHED_ETAGS] = { widget: 'etag-live', page: 'etag-page' };
+    testHoisted.elements = {
+      page: <div>b</div>,
+      [`${ETAG_ID_PREFIX}page`]: 'etag-page-2',
+    };
+    const result = await prefetchRsc('R/bar', undefined, {
+      unstable_base: {
+        widget: <div>w</div>,
+        [`${ETAG_ID_PREFIX}widget`]: 'etag-widget',
+      },
+    });
+
+    const lastCall = vi.mocked(globalThis.fetch).mock.calls.at(-1);
+    const headers = new Headers(
+      (lastCall?.[1] as RequestInit | undefined)?.headers,
+    );
+    const sent = JSON.parse(headers.get(ETAGS_HEADER) ?? '{}');
+    // the base's etag wins over the live copy's for a key the base holds
+    expect(sent.widget).toBe('etag-widget');
+    expect(sent.page).toBe('etag-page');
+
+    // a key the response omits is kept from the base, with its etag: a
+    // caller cannot claim copies it does not keep
+    expect(result.widget).toBeDefined();
+    expect(result[`${ETAG_ID_PREFIX}widget`]).toBe('etag-widget');
+    expect(result[`${ETAG_ID_PREFIX}page`]).toBe('etag-page-2');
+  });
+
   it('caches the etag of a slot a response newly introduces in an instant-nav merge', async () => {
     // A slot only the response introduces lands via the second swr commit,
     // and its etag must enter the cache like any other.
@@ -294,33 +323,5 @@ describe('isValidEtag', () => {
     expect(isValidEtag('tag\x80')).toBe(false);
     expect(isValidEtag('tag-☃')).toBe(false);
     expect(isValidEtag(123)).toBe(false);
-  });
-
-  it('a prefetch claims the etags of its base', async () => {
-    fetchRscStore[CACHED_ETAGS] = { widget: 'etag-live', page: 'etag-page' };
-    testHoisted.elements = {
-      page: <div>b</div>,
-      [`${ETAG_ID_PREFIX}page`]: 'etag-page-2',
-    };
-    const result = await prefetchRsc('R/bar', undefined, {
-      unstable_base: {
-        widget: <div>w</div>,
-        [`${ETAG_ID_PREFIX}widget`]: 'etag-widget',
-      },
-    });
-
-    const lastCall = vi.mocked(globalThis.fetch).mock.calls.at(-1);
-    const headers = new Headers(
-      (lastCall?.[1] as RequestInit | undefined)?.headers,
-    );
-    const sent = JSON.parse(headers.get(ETAGS_HEADER) ?? '{}');
-    // the base's etag wins over the live copy's for a key the base holds
-    expect(sent.widget).toBe('etag-widget');
-    expect(sent.page).toBe('etag-page');
-
-    // the raw response is returned: keeping the claimed copies is the
-    // caller's merge, not this one's
-    expect(result.widget).toBeUndefined();
-    expect(result[`${ETAG_ID_PREFIX}page`]).toBe('etag-page-2');
   });
 });

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -295,4 +295,32 @@ describe('isValidEtag', () => {
     expect(isValidEtag('tag-☃')).toBe(false);
     expect(isValidEtag(123)).toBe(false);
   });
+
+  it('a prefetch claims the etags of its base', async () => {
+    fetchRscStore[CACHED_ETAGS] = { widget: 'etag-live', page: 'etag-page' };
+    testHoisted.elements = {
+      page: <div>b</div>,
+      [`${ETAG_ID_PREFIX}page`]: 'etag-page-2',
+    };
+    const result = await prefetchRsc('R/bar', undefined, {
+      unstable_base: {
+        widget: <div>w</div>,
+        [`${ETAG_ID_PREFIX}widget`]: 'etag-widget',
+      },
+    });
+
+    const lastCall = vi.mocked(globalThis.fetch).mock.calls.at(-1);
+    const headers = new Headers(
+      (lastCall?.[1] as RequestInit | undefined)?.headers,
+    );
+    const sent = JSON.parse(headers.get(ETAGS_HEADER) ?? '{}');
+    // the base's etag wins over the live copy's for a key the base holds
+    expect(sent.widget).toBe('etag-widget');
+    expect(sent.page).toBe('etag-page');
+
+    // the raw response is returned: keeping the claimed copies is the
+    // caller's merge, not this one's
+    expect(result.widget).toBeUndefined();
+    expect(result[`${ETAG_ID_PREFIX}page`]).toBe('etag-page-2');
+  });
 });

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -108,18 +108,6 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     view.unmount();
   });
 
-  it('sends the cached tags in the etags request header', () => {
-    fetchRscStore[CACHED_ETAGS] = { page: 'etag-foo' };
-
-    void prefetchRsc('R/bar');
-
-    // requestRsc built the request init with the cached tags as a header.
-    const fetchSpy = globalThis.fetch as ReturnType<typeof vi.fn>;
-    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
-    const header = (init.headers as Record<string, string>)[ETAGS_HEADER];
-    expect(JSON.parse(header as string)).toEqual({ page: 'etag-foo' });
-  });
-
   it('isImmutableElement detects the immutable sentinel by tag', () => {
     const elements = {
       [`${ETAG_ID_PREFIX}static`]: IMMUTABLE_ETAG,
@@ -213,6 +201,18 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     view.unmount();
   });
 
+  it('a prefetch without a base claims nothing', async () => {
+    fetchRscStore[CACHED_ETAGS] = { widget: 'etag-live' };
+    testHoisted.elements = { page: <div>b</div> };
+    await prefetchRsc('R/bar');
+
+    const lastCall = vi.mocked(globalThis.fetch).mock.calls.at(-1);
+    const headers = new Headers(
+      (lastCall?.[1] as RequestInit | undefined)?.headers,
+    );
+    expect(JSON.parse(headers.get(ETAGS_HEADER) ?? 'null')).toEqual({});
+  });
+
   it('a prefetch claims the etags of its base and returns the merge', async () => {
     fetchRscStore[CACHED_ETAGS] = { widget: 'etag-live', page: 'etag-page' };
     testHoisted.elements = {
@@ -231,9 +231,10 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
       (lastCall?.[1] as RequestInit | undefined)?.headers,
     );
     const sent = JSON.parse(headers.get(ETAGS_HEADER) ?? '{}');
-    // the base's etag wins over the live copy's for a key the base holds
+    // only the base's etags are claimed: a live copy the prefetch does not
+    // retain must not let the server omit an element
     expect(sent.widget).toBe('etag-widget');
-    expect(sent.page).toBe('etag-page');
+    expect(sent.page).toBeUndefined();
 
     // a key the response omits is kept from the base, with its etag: a
     // caller cannot claim copies it does not keep

--- a/packages/waku/tests/prefetch-cache.test.ts
+++ b/packages/waku/tests/prefetch-cache.test.ts
@@ -102,6 +102,46 @@ describe('router prefetch cache', () => {
     expect(store.get('/p')).toEqual({ a: 1 });
   });
 
+  it('passes the stored entry to the fetcher as the base', async () => {
+    const cache: PrefetchCache = new Map();
+    const store: PrefetchedElementsStore = new Map();
+    await startAndSettle(cache, store, '/p', 'q=a', { a: 1 });
+    let received: unknown = 'unset';
+    startPrefetch(
+      cache,
+      store,
+      '/p',
+      'q=b',
+      (base) => {
+        received = base;
+        return new Promise(() => {});
+      },
+      undefined,
+    );
+    expect(received).toEqual({ a: 1 });
+  });
+
+  it('passes no base while the first prefetch is in flight', async () => {
+    const cache: PrefetchCache = new Map();
+    const store: PrefetchedElementsStore = new Map();
+    startPrefetch(cache, store, '/p', 'q=a', () => new Promise(() => {}), {
+      mode: 'always',
+    });
+    let received: unknown = 'unset';
+    startPrefetch(
+      cache,
+      store,
+      '/p',
+      'q=b',
+      (base) => {
+        received = base;
+        return new Promise(() => {});
+      },
+      undefined,
+    );
+    expect(received).toBeUndefined();
+  });
+
   it('releases only an unfulfilled reservation', async () => {
     const cache: PrefetchCache = new Map();
     const store: PrefetchedElementsStore = new Map();

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2536,6 +2536,48 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a repeat prefetch claims the stored response as its base', async () => {
+    const first = {
+      [unstable_getRouteSlotId('/next')]: <div>next-shell</div>,
+      [ROUTE_ID]: ['/next', ''],
+      [IS_STATIC_ID]: false,
+    };
+    vi.mocked(prefetchRsc).mockReturnValue(resolvedThenable(first));
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      capture.router!.prefetch('/next');
+      await flush();
+    });
+    expect(vi.mocked(prefetchRsc).mock.calls.at(0)?.[2]).toEqual({});
+
+    await act(async () => {
+      capture.router!.prefetch('/next?q=b');
+      await flush();
+    });
+    expect(vi.mocked(prefetchRsc).mock.calls.at(1)?.[2]).toEqual({
+      unstable_base: expect.objectContaining({
+        [unstable_getRouteSlotId('/next')]: expect.anything(),
+      }),
+    });
+
+    view.unmount();
+  });
+
   test('mode once dedupes concurrent prefetches by rscPath', async () => {
     const pending = createDeferred<Record<string, unknown>>();
     vi.mocked(prefetchRsc).mockReturnValue(pending.promise);


### PR DESCRIPTION
A repeat prefetch of a route previously re-downloaded everything the session store already held, because prefetch requests only sent the live page's etags.

`unstable_prefetchRsc` now takes an `unstable_base` option: elements the client already holds for the path. Their etags are sent with the request, so the server only renders and sends what changed. The router passes the session store's entry and merges the response over it, so every claimed copy is kept, and a repeat prefetch is nearly free on the wire.

This also closes a gap in instant navigation: a navigation that adopts a prefetched response serves stored copies for omitted keys, and those omissions are now proven against the stored copies' etags.

Follow-up to #2184.