### PR TITLE
chore(e2e): fix the standalone fixture copy filter

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -12,7 +12,7 @@ import {
 import { createRequire } from 'node:module';
 import { createConnection, createServer } from 'node:net';
 import { tmpdir } from 'node:os';
-import { join, sep } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { error, info } from '@actions/core';
@@ -294,15 +294,12 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
       standaloneDirMap.set(packageManager, standaloneDir);
       const copyLabel = `[e2e] copy fixture (${fixtureName})`;
       console.time(copyLabel);
-      const excludedDirs = [
-        join(fixtureDir, 'node_modules'),
-        join(fixtureDir, 'dist'),
-      ];
+      const excludedDirNames = new Set(['node_modules', 'dist']);
       cpSync(fixtureDir, standaloneDir, {
         filter: (src) =>
-          excludedDirs.every(
-            (dir) => src !== dir && !src.startsWith(dir + sep),
-          ),
+          relative(fixtureDir, src)
+            .split(sep)
+            .every((part) => !excludedDirNames.has(part)),
         recursive: true,
       });
       console.timeEnd(copyLabel);

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -12,7 +12,7 @@ import {
 import { createRequire } from 'node:module';
 import { createConnection, createServer } from 'node:net';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { error, info } from '@actions/core';
@@ -294,10 +294,15 @@ export const prepareStandaloneSetup = (fixtureName: string) => {
       standaloneDirMap.set(packageManager, standaloneDir);
       const copyLabel = `[e2e] copy fixture (${fixtureName})`;
       console.time(copyLabel);
+      const excludedDirs = [
+        join(fixtureDir, 'node_modules'),
+        join(fixtureDir, 'dist'),
+      ];
       cpSync(fixtureDir, standaloneDir, {
-        filter: (src) => {
-          return !src.includes('node_modules') && !src.includes('dist');
-        },
+        filter: (src) =>
+          excludedDirs.every(
+            (dir) => src !== dir && !src.startsWith(dir + sep),
+          ),
         recursive: true,
       });
       console.timeEnd(copyLabel);


### PR DESCRIPTION
A substring match rejects the whole tree when the repository path itself contains "dist" or "node_modules". Same fix as the hmr copy in #2189.