### PR TITLE
refactor(router): follow redirect and 404 errors in changeRoute

### DIFF
--- a/e2e/broken-links.spec.ts
+++ b/e2e/broken-links.spec.ts
@@ -1,6 +1,12 @@
 import { expect } from '@playwright/test';
 import { prepareNormalSetup, test, waitForHydration } from './utils.js';
 
+declare global {
+  interface Window {
+    __pushOutcome?: string;
+  }
+}
+
 const startApp = prepareNormalSetup('broken-links');
 
 test.describe('broken-links: normal server', () => {
@@ -68,6 +74,35 @@ test.describe('broken-links: normal server', () => {
       // Go back to the index page
       await page.getByRole('link', { name: 'Back' }).click();
       await expect(page.getByRole('heading')).toHaveText('Index');
+    });
+  });
+
+  test.describe('client side navigation', () => {
+    test('a thrown redirect on client navigation resolves the push', async ({
+      page,
+    }) => {
+      await page.goto(`http://localhost:${port}/`);
+      await waitForHydration(page);
+      await page.getByTestId('push-throw-redirect').click();
+      await expect(page.getByRole('heading')).toHaveText('Existing page');
+      expect(page.url()).toBe(`http://localhost:${port}/exists`);
+      // the navigation follows the redirect instead of rejecting
+      await expect
+        .poll(() => page.evaluate(() => window.__pushOutcome))
+        .toBe('resolved');
+      // Go back to the index page
+      await page.getByRole('link', { name: 'Back' }).click();
+      await expect(page.getByRole('heading')).toHaveText('Index');
+    });
+
+    test('a 404 on client navigation resolves the push', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/`);
+      await waitForHydration(page);
+      await page.getByTestId('push-missing').click();
+      await expect(page.getByRole('heading')).toHaveText('Custom not found');
+      await expect
+        .poll(() => page.evaluate(() => window.__pushOutcome))
+        .toBe('resolved');
     });
   });
 });

--- a/e2e/fixtures/broken-links/src/components/PushProbe.tsx
+++ b/e2e/fixtures/broken-links/src/components/PushProbe.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useRouter } from 'waku';
+
+declare global {
+  interface Window {
+    __pushOutcome?: string;
+  }
+}
+
+export function PushProbe() {
+  const router = useRouter();
+  const push = (to: string) => {
+    window.__pushOutcome = 'pending';
+    router.push(to as never).then(
+      () => {
+        window.__pushOutcome = 'resolved';
+      },
+      () => {
+        window.__pushOutcome = 'rejected';
+      },
+    );
+  };
+  return (
+    <p>
+      <button
+        data-testid="push-throw-redirect"
+        onClick={() => push('/throw-redirect')}
+      >
+        Push throw-redirect
+      </button>
+      <button data-testid="push-missing" onClick={() => push('/missing-page')}>
+        Push missing
+      </button>
+    </p>
+  );
+}

--- a/e2e/fixtures/broken-links/src/pages/index.tsx
+++ b/e2e/fixtures/broken-links/src/pages/index.tsx
@@ -1,9 +1,11 @@
 import { Link } from 'waku';
+import { PushProbe } from '../components/PushProbe';
 
 export default function Index() {
   return (
     <div>
       <h1>Index</h1>
+      <PushProbe />
       <p>
         <Link to="/exists">Existing page</Link>
       </p>

--- a/e2e/fixtures/broken-links/src/pages/throw-redirect.tsx
+++ b/e2e/fixtures/broken-links/src/pages/throw-redirect.tsx
@@ -1,0 +1,7 @@
+import { unstable_redirect as redirect } from 'waku/router/server';
+
+export default function ThrowRedirectPage() {
+  return redirect('/exists');
+}
+
+export const getConfig = async () => ({ render: 'dynamic' as const });

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1150,9 +1150,29 @@ const InnerRouter = ({
         }
         return undefined;
       };
-      const commitInTransition = (followed: boolean) => {
+      const targetUrl = url ?? getRouteUrl(nextRoute);
+      const commitNavigation = (destination: {
+        route: RouteProps;
+        routeUrl: URL;
+        elements?: Awaited<ReturnType<typeof refetch>>;
+      }) => {
         if (isAborted()) {
           return;
+        }
+        const followed = !isSameRoute(destination.route, nextRoute);
+        if (followed) {
+          nextRoute = destination.route;
+          url = mode ? destination.routeUrl : undefined;
+        }
+        if (destination.elements) {
+          const redirect = getRedirect(destination.elements);
+          if (redirect) {
+            nextRoute = redirect;
+            if (mode) {
+              mode = redirect.path === '/404' ? undefined : 'push';
+              url = undefined;
+            }
+          }
         }
         const commit = () => {
           commitRoute(nextRoute);
@@ -1166,10 +1186,9 @@ const InnerRouter = ({
         }
       };
       if (staticPathSetRef.current.has(nextRoute.path) || !shouldRefetch) {
-        commitInTransition(false);
+        commitNavigation({ route: nextRoute, routeUrl: targetUrl });
         return;
       }
-      const targetUrl = url ?? getRouteUrl(nextRoute);
       const fetchRoute = (route: RouteProps, routeUrl: URL) => {
         const rscPath = encodeRoutePath(route.path);
         // Reuse a prefetch (matched by path and query) within its ttl; an
@@ -1192,7 +1211,7 @@ const InnerRouter = ({
       const resolveFollowingErrors = async (
         route: RouteProps,
         routeUrl: URL,
-        errorToFollow?: unknown,
+        errorToFollow: unknown,
       ) => {
         for (let hops = 0; hops <= MAX_ERROR_HOPS; hops++) {
           if (errorToFollow) {
@@ -1202,7 +1221,12 @@ const InnerRouter = ({
               : undefined;
             if (redirectUrl) {
               if (redirectUrl.origin !== window.location.origin) {
-                return { externalUrl: redirectUrl };
+                if (mode && window.location.href !== targetUrl.href) {
+                  writeUrlToHistory(mode, targetUrl);
+                  setPendingHistory(null);
+                }
+                window.location.replace(redirectUrl.href);
+                return undefined;
               }
               route = parseRoute(redirectUrl);
               routeUrl = redirectUrl;
@@ -1240,34 +1264,6 @@ const InnerRouter = ({
         throw new Error('too many redirect or 404 follows', {
           cause: errorToFollow,
         });
-      };
-      const finishWith = (
-        resolved: Awaited<ReturnType<typeof resolveFollowingErrors>>,
-      ) => {
-        if ('externalUrl' in resolved) {
-          if (mode && window.location.href !== targetUrl.href) {
-            writeUrlToHistory(mode, targetUrl);
-            setPendingHistory(null);
-          }
-          window.location.replace(resolved.externalUrl.href);
-          return;
-        }
-        const followed = !isSameRoute(resolved.route, nextRoute);
-        if (followed) {
-          nextRoute = resolved.route;
-          url = mode ? resolved.routeUrl : undefined;
-        }
-        if (resolved.elements) {
-          const redirect = getRedirect(resolved.elements);
-          if (redirect) {
-            nextRoute = redirect;
-            if (mode) {
-              mode = redirect.path === '/404' ? undefined : 'push';
-              url = undefined;
-            }
-          }
-        }
-        commitInTransition(followed);
       };
       if (options.instant) {
         const rscPath = encodeRoutePath(nextRoute.path);
@@ -1330,7 +1326,14 @@ const InnerRouter = ({
             }
             mode = mode && 'replace';
             try {
-              finishWith(await resolveFollowingErrors(nextRoute, targetUrl, e));
+              const destination = await resolveFollowingErrors(
+                nextRoute,
+                targetUrl,
+                e,
+              );
+              if (destination) {
+                commitNavigation(destination);
+              }
             } catch (e2) {
               if (isAborted()) {
                 return;
@@ -1344,7 +1347,14 @@ const InnerRouter = ({
         }
       }
       try {
-        finishWith(await resolveFollowingErrors(nextRoute, targetUrl));
+        const destination = await resolveFollowingErrors(
+          nextRoute,
+          targetUrl,
+          undefined,
+        );
+        if (destination) {
+          commitNavigation(destination);
+        }
       } catch (e) {
         if (isAborted()) {
           return;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -3,7 +3,6 @@
 import {
   Component,
   createContext,
-  startTransition,
   use,
   useCallback,
   useContext,
@@ -160,14 +159,11 @@ const isSameRoute = (next: RouteProps, prev: RouteProps) =>
 
 const MAX_ERROR_HOPS = 20;
 
-const classifyRedirectLocation = (location: string, base: string | URL) => {
+const parseRedirectUrl = (location: string, base: string | URL) => {
   const url = new URL(location, base);
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    return undefined;
-  }
-  return url.origin === window.location.origin
-    ? ({ kind: 'internal', url } as const)
-    : ({ kind: 'external', url } as const);
+  return url.protocol === 'http:' || url.protocol === 'https:'
+    ? url
+    : undefined;
 };
 
 const shouldScrollForRouteChange = (next: RouteProps, prev: RouteProps) =>
@@ -798,15 +794,14 @@ const Redirect = ({
     }
     handledErrorSet.add(error as object);
 
-    const target = classifyRedirectLocation(to, window.location.href);
-    if (!target) {
+    const url = parseRedirectUrl(to, window.location.href);
+    if (!url) {
       return;
     }
-    if (target.kind === 'external') {
-      window.location.replace(target.url.href);
+    if (url.origin !== window.location.origin) {
+      window.location.replace(url.href);
       return;
     }
-    const url = target.url;
     changeRoute(parseRoute(url), {
       shouldScroll: url.pathname !== window.location.pathname,
       mode: 'replace',
@@ -1155,25 +1150,26 @@ const InnerRouter = ({
         }
         return undefined;
       };
-      const commitInTransition = (followed = false) => {
+      const commitInTransition = (followed: boolean) => {
         if (isAborted()) {
           return;
         }
-        const transitionFn = followed ? startTransition : startTransitionFn;
-        void transitionFn(() => {
+        const commit = () => {
           commitRoute(nextRoute);
           routeChangeAbortRef.current = null;
           emitRouteChangeEvent('complete', nextRoute);
-        });
+        };
+        if (followed) {
+          commit();
+        } else {
+          void startTransitionFn(commit);
+        }
       };
       if (staticPathSetRef.current.has(nextRoute.path) || !shouldRefetch) {
-        commitInTransition();
+        commitInTransition(false);
         return;
       }
-      const targetUrl =
-        url instanceof URL
-          ? url
-          : new URL(url || getRouteUrl(nextRoute), window.location.href);
+      const targetUrl = url ?? getRouteUrl(nextRoute);
       const fetchRoute = (route: RouteProps, routeUrl: URL) => {
         const rscPath = encodeRoutePath(route.path);
         // Reuse a prefetch (matched by path and query) within its ttl; an
@@ -1193,39 +1189,31 @@ const InnerRouter = ({
           ...(cached ? { unstable_prefetched: cached.promise } : {}),
         });
       };
-      const followTarget = (
-        e: unknown,
-        attemptedUrl: URL,
-        route: RouteProps,
-      ) => {
-        const info = getErrorInfo(e);
-        if (info?.location) {
-          return classifyRedirectLocation(info.location, attemptedUrl);
-        }
-        if (info?.status === 404 && has404 && route.path !== '/404') {
-          return { kind: '404' } as const;
-        }
-        return undefined;
-      };
       const resolveFollowingErrors = async (
         route: RouteProps,
         routeUrl: URL,
         errorToFollow?: unknown,
       ) => {
-        for (let hops = errorToFollow ? 1 : 0; hops <= MAX_ERROR_HOPS; hops++) {
+        for (let hops = 0; hops <= MAX_ERROR_HOPS; hops++) {
           if (errorToFollow) {
-            const target = followTarget(errorToFollow, routeUrl, route);
-            if (!target) {
-              throw errorToFollow;
-            }
-            if (target.kind === 'external') {
-              return { externalUrl: target.url };
-            }
-            if (target.kind === 'internal') {
-              route = parseRoute(target.url);
-              routeUrl = target.url;
-            } else {
+            const info = getErrorInfo(errorToFollow);
+            const redirectUrl = info?.location
+              ? parseRedirectUrl(info.location, routeUrl)
+              : undefined;
+            if (redirectUrl) {
+              if (redirectUrl.origin !== window.location.origin) {
+                return { externalUrl: redirectUrl };
+              }
+              route = parseRoute(redirectUrl);
+              routeUrl = redirectUrl;
+            } else if (
+              info?.status === 404 &&
+              has404 &&
+              route.path !== '/404'
+            ) {
               route = parseRoute(new URL('/404', window.location.href));
+            } else {
+              throw errorToFollow;
             }
             errorToFollow = undefined;
           }
@@ -1335,11 +1323,6 @@ const InnerRouter = ({
           } catch (e) {
             if (isAborted()) {
               return;
-            }
-            if (!followTarget(e, targetUrl, nextRoute)) {
-              routeChangeAbortRef.current = null;
-              setErr(e);
-              throw e;
             }
             if (mode && window.location.href !== targetUrl.href) {
               writeUrlToHistory(mode, targetUrl);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -157,6 +157,8 @@ const isSameRoute = (next: RouteProps, prev: RouteProps) =>
   next.query === prev.query &&
   next.hash === prev.hash;
 
+const MAX_ERROR_HOPS = 20;
+
 const shouldScrollForRouteChange = (next: RouteProps, prev: RouteProps) =>
   isPathChange(next, prev) || isHashChange(next, prev);
 
@@ -177,6 +179,7 @@ const createRscParams = (query: string): URLSearchParams => {
 
 type ChangeRouteOptions = {
   shouldScroll: boolean;
+  scroll?: boolean | undefined;
   refetch?: boolean; // true: force refetch, false: don't refetch, undefined: auto-decide based on route change
   mode?: undefined | 'push' | 'replace';
   url?: URL | undefined;
@@ -291,6 +294,7 @@ export function useRouter() {
       const url = resolveRouteUrl(to, resolveCodec);
       await changeRoute(parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
+        scroll: options?.scroll,
         mode: 'push',
         url,
         instant: options?.unstable_instant,
@@ -306,6 +310,7 @@ export function useRouter() {
       const url = resolveRouteUrl(to, resolveCodec);
       await changeRoute(parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
+        scroll: options?.scroll,
         mode: 'replace',
         url,
         instant: options?.unstable_instant,
@@ -464,6 +469,7 @@ export function useSetSearch_UNSTABLE<Path extends RoutePath>({
       url.search = nextQuery;
       await changeRoute(parseRoute(url), {
         shouldScroll: options?.scroll ?? false,
+        scroll: options?.scroll,
         mode: options?.history ?? 'push',
         url,
       });
@@ -619,6 +625,7 @@ export function Link<Path extends RoutePath>({
       if (unstable_instant) {
         changeRoute(route, {
           shouldScroll: scroll ?? shouldScrollByDefault(url),
+          scroll,
           mode: 'push',
           url,
           instant: true,
@@ -627,6 +634,7 @@ export function Link<Path extends RoutePath>({
         startTransitionFn(async () => {
           await changeRoute(route, {
             shouldScroll: scroll ?? shouldScrollByDefault(url),
+            scroll,
             mode: 'push',
             url,
             startTransition: startTransitionFn,
@@ -1120,14 +1128,16 @@ const InnerRouter = ({
       const routeBeforeChange = routeRef.current;
       const shouldRefetch =
         options.refetch ?? !isSameRoute(nextRoute, routeBeforeChange);
-      const pathChanged = isPathChange(nextRoute, routeBeforeChange);
+      let shouldScroll = options.shouldScroll;
+      let followedError = false;
       const isStaticSlot = (key: string) =>
         isImmutableElement(resolvedElementsRef.current, key);
       const commitRoute = (route: RouteProps) => {
+        const pathChanged = isPathChange(route, routeBeforeChange);
         routeRef.current = route;
         setRoute(route);
         setErr(null);
-        setPendingScroll(options.shouldScroll ? { pathChanged } : null);
+        setPendingScroll(shouldScroll ? { pathChanged } : null);
         setPendingHistory(mode ? { mode, url } : null);
       };
       const getRedirect = (
@@ -1148,7 +1158,10 @@ const InnerRouter = ({
         if (isAborted()) {
           return;
         }
-        startTransitionFn(() => {
+        const transitionFn = followedError
+          ? (fn: TransitionFunction) => fn()
+          : startTransitionFn;
+        void transitionFn(() => {
           commitRoute(nextRoute);
           routeChangeAbortRef.current = null;
           emitRouteChangeEvent('complete', nextRoute);
@@ -1158,22 +1171,117 @@ const InnerRouter = ({
         commitInTransition();
         return;
       }
-      const rscPath = encodeRoutePath(nextRoute.path);
-      const rscParams = createRscParams(nextRoute.query);
-      const targetUrl = url || getRouteUrl(nextRoute);
-      const onBuildIdMismatch = () => {
-        window.history.pushState(window.history.state, '', targetUrl);
-        window.location.reload();
+      const fetchRoute = (route: RouteProps, routeUrl: URL) => {
+        const rscPath = encodeRoutePath(route.path);
+        // Reuse a prefetch (matched by path and query) within its ttl; an
+        // in-flight one is adopted as the data source (it resolves no later
+        // than a fresh request, and prefetches are not abortable anyway).
+        const cached = getPrefetch(
+          prefetchCacheRef.current,
+          prefetchCacheKey(rscPath, route.query),
+          Date.now(),
+        );
+        return refetch(rscPath, createRscParams(route.query), {
+          signal: abortController.signal,
+          onBuildIdMismatch: () => {
+            window.history.pushState(window.history.state, '', routeUrl);
+            window.location.reload();
+          },
+          ...(cached ? { unstable_prefetched: cached.promise } : {}),
+        });
       };
-      // Reuse a prefetch (matched by path and query) within its ttl; an
-      // in-flight one is adopted as the data source (it resolves no later
-      // than a fresh request, and prefetches are not abortable anyway).
-      const cached = getPrefetch(
-        prefetchCacheRef.current,
-        prefetchCacheKey(rscPath, nextRoute.query),
-        Date.now(),
-      );
+      const followTarget = (
+        e: unknown,
+        attemptedUrl: URL,
+        route: RouteProps,
+      ) => {
+        const info = getErrorInfo(e);
+        const redirectUrl = info?.location
+          ? new URL(info.location, attemptedUrl)
+          : undefined;
+        if (
+          redirectUrl &&
+          (redirectUrl.protocol === 'http:' ||
+            redirectUrl.protocol === 'https:')
+        ) {
+          return redirectUrl.hostname === window.location.hostname
+            ? ({ kind: 'redirect', url: redirectUrl } as const)
+            : ({ kind: 'external', url: redirectUrl } as const);
+        }
+        if (info?.status === 404 && has404 && route.path !== '/404') {
+          return { kind: '404' } as const;
+        }
+        return undefined;
+      };
+      type Resolved =
+        | {
+            route: RouteProps;
+            routeUrl: URL;
+            via404: boolean;
+            elements?: Awaited<ReturnType<typeof refetch>>;
+          }
+        | { externalUrl: URL };
+      const resolveFollowingErrors = async (
+        route: RouteProps,
+        routeUrl: URL,
+        hops: number,
+      ): Promise<Resolved> => {
+        if (
+          hops > 0 &&
+          (staticPathSetRef.current.has(route.path) ||
+            isSameRoute(route, routeBeforeChange))
+        ) {
+          return { route, routeUrl, via404: false };
+        }
+        try {
+          const elements = await fetchRoute(route, routeUrl);
+          return { route, routeUrl, via404: false, elements };
+        } catch (e) {
+          if (isAborted()) {
+            throw e;
+          }
+          return followFrom(e, route, routeUrl, hops);
+        }
+      };
+      const followFrom = async (
+        e: unknown,
+        route: RouteProps,
+        routeUrl: URL,
+        hops: number,
+      ): Promise<Resolved> => {
+        const target =
+          hops < MAX_ERROR_HOPS ? followTarget(e, routeUrl, route) : undefined;
+        if (!target) {
+          throw followTarget(e, routeUrl, route)
+            ? new Error('too many redirect or 404 follows', { cause: e })
+            : e;
+        }
+        if (target.kind === 'external') {
+          return { externalUrl: target.url };
+        }
+        if (target.kind === 'redirect') {
+          return resolveFollowingErrors(
+            parseRoute(target.url),
+            target.url,
+            hops + 1,
+          );
+        }
+        const resolved = await resolveFollowingErrors(
+          parseRoute(new URL('/404', window.location.href)),
+          routeUrl,
+          hops + 1,
+        );
+        return 'externalUrl' in resolved
+          ? resolved
+          : { ...resolved, via404: true };
+      };
+      const targetUrl =
+        url instanceof URL
+          ? url
+          : new URL(url || getRouteUrl(nextRoute), window.location.href);
+      let resolved: Resolved | undefined;
       if (options.instant) {
+        const rscPath = encodeRoutePath(nextRoute.path);
         const prefetchedElements =
           prefetchedElementsStoreRef.current.get(rscPath);
         const routeSlotId = getRouteSlotId(nextRoute.path);
@@ -1183,53 +1291,116 @@ const InnerRouter = ({
             isImmutableElement(prefetchedElements, routeSlotId))
         ) {
           const pin = (key: string) => isMetaKey(key) || isStaticSlot(key);
-          const dataPromise = refetch(rscPath, rscParams, {
-            signal: abortController.signal,
-            unstable_swr: {
-              pin,
-              ...(prefetchedElements ? { base: prefetchedElements } : {}),
+          const cached = getPrefetch(
+            prefetchCacheRef.current,
+            prefetchCacheKey(rscPath, nextRoute.query),
+            Date.now(),
+          );
+          const dataPromise = refetch(
+            rscPath,
+            createRscParams(nextRoute.query),
+            {
+              signal: abortController.signal,
+              unstable_swr: {
+                pin,
+                ...(prefetchedElements ? { base: prefetchedElements } : {}),
+              },
+              onBuildIdMismatch: () => {
+                window.history.pushState(window.history.state, '', targetUrl);
+                window.location.reload();
+              },
+              ...(cached ? { unstable_prefetched: cached.promise } : {}),
             },
-            onBuildIdMismatch,
-            ...(cached ? { unstable_prefetched: cached.promise } : {}),
-          });
+          );
           commitRoute(nextRoute);
-          return dataPromise.then(
-            (elements) => {
-              if (isAborted()) {
-                return;
+          try {
+            const elements = await dataPromise;
+            if (isAborted()) {
+              return;
+            }
+            routeChangeAbortRef.current = null;
+            const redirect = getRedirect(elements);
+            if (redirect) {
+              routeRef.current = redirect;
+              setRoute(redirect);
+              if (redirect.path !== '/404') {
+                setPendingHistory({
+                  mode: 'replace',
+                  url: getRouteUrl(redirect),
+                });
               }
-              routeChangeAbortRef.current = null;
-              const redirect = getRedirect(elements);
-              if (redirect) {
-                routeRef.current = redirect;
-                setRoute(redirect);
-                if (redirect.path !== '/404') {
-                  setPendingHistory({
-                    mode: 'replace',
-                    url: getRouteUrl(redirect),
-                  });
-                }
-              }
-              emitRouteChangeEvent('complete', redirect ?? nextRoute);
-            },
-            (e) => {
-              if (isAborted()) {
-                return;
-              }
+            }
+            emitRouteChangeEvent('complete', redirect ?? nextRoute);
+            return;
+          } catch (e) {
+            if (isAborted()) {
+              return;
+            }
+            if (!followTarget(e, targetUrl, nextRoute)) {
               routeChangeAbortRef.current = null;
               setErr(e);
               throw e;
-            },
-          );
+            }
+            if (mode && window.location.href !== targetUrl.href) {
+              writeUrlToHistory(mode, targetUrl);
+              setPendingHistory(null);
+            }
+            try {
+              resolved = await followFrom(e, nextRoute, targetUrl, 0);
+            } catch (e2) {
+              if (isAborted()) {
+                return;
+              }
+              routeChangeAbortRef.current = null;
+              setErr(e2);
+              throw e2;
+            }
+            if (!('externalUrl' in resolved)) {
+              mode = resolved.via404 ? undefined : mode && 'replace';
+            }
+          }
         }
       }
-      try {
-        const elements = await refetch(rscPath, rscParams, {
-          signal: abortController.signal,
-          onBuildIdMismatch,
-          ...(cached ? { unstable_prefetched: cached.promise } : {}),
-        });
-        const redirect = getRedirect(elements);
+      if (!resolved) {
+        try {
+          resolved = await resolveFollowingErrors(nextRoute, targetUrl, 0);
+        } catch (e) {
+          if (isAborted()) {
+            return;
+          }
+          routeChangeAbortRef.current = null;
+          // Write URL synchronously
+          // React may rollback transition state updates when the render throws
+          if (mode && window.location.pathname === prevPathname) {
+            writeUrlToHistory(mode, targetUrl);
+          }
+          setErr(e);
+          throw e;
+        }
+      }
+      if ('externalUrl' in resolved) {
+        if (mode && window.location.href !== targetUrl.href) {
+          writeUrlToHistory(mode, targetUrl);
+          setPendingHistory(null);
+        }
+        window.location.replace(resolved.externalUrl.href);
+        return;
+      }
+      if (!isSameRoute(resolved.route, nextRoute)) {
+        followedError = true;
+        nextRoute = resolved.route;
+        url =
+          mode && resolved.routeUrl.origin === window.location.origin
+            ? resolved.routeUrl
+            : undefined;
+        shouldScroll =
+          options.scroll ??
+          (resolved.via404
+            ? true
+            : shouldScrollForRouteChange(nextRoute, routeBeforeChange));
+      }
+      if (resolved.elements) {
+        const redirect = getRedirect(resolved.elements);
         if (redirect) {
           nextRoute = redirect;
           if (mode) {
@@ -1237,24 +1408,13 @@ const InnerRouter = ({
             url = undefined;
           }
         }
-      } catch (e) {
-        if (isAborted()) {
-          return;
-        }
-        routeChangeAbortRef.current = null;
-        // Write URL synchronously
-        // React may rollback transition state updates when the render throws
-        if (mode && window.location.pathname === prevPathname) {
-          writeUrlToHistory(mode, targetUrl);
-        }
-        setErr(e);
-        throw e;
       }
       commitInTransition();
     },
     [
       emitRouteChangeEvent,
       refetch,
+      has404,
       staticPathSetRef,
       resolvedElementsRef,
       prefetchCacheRef,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -190,7 +190,6 @@ const createRscParams = (query: string): URLSearchParams => {
 
 type ChangeRouteOptions = {
   shouldScroll: boolean;
-  scroll?: boolean | undefined;
   refetch?: boolean; // true: force refetch, false: don't refetch, undefined: auto-decide based on route change
   mode?: undefined | 'push' | 'replace';
   url?: URL | undefined;
@@ -305,7 +304,6 @@ export function useRouter() {
       const url = resolveRouteUrl(to, resolveCodec);
       await changeRoute(parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
-        scroll: options?.scroll,
         mode: 'push',
         url,
         instant: options?.unstable_instant,
@@ -321,7 +319,6 @@ export function useRouter() {
       const url = resolveRouteUrl(to, resolveCodec);
       await changeRoute(parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
-        scroll: options?.scroll,
         mode: 'replace',
         url,
         instant: options?.unstable_instant,
@@ -480,7 +477,6 @@ export function useSetSearch_UNSTABLE<Path extends RoutePath>({
       url.search = nextQuery;
       await changeRoute(parseRoute(url), {
         shouldScroll: options?.scroll ?? false,
-        scroll: options?.scroll,
         mode: options?.history ?? 'push',
         url,
       });
@@ -636,7 +632,6 @@ export function Link<Path extends RoutePath>({
       if (unstable_instant) {
         changeRoute(route, {
           shouldScroll: scroll ?? shouldScrollByDefault(url),
-          scroll,
           mode: 'push',
           url,
           instant: true,
@@ -645,7 +640,6 @@ export function Link<Path extends RoutePath>({
         startTransitionFn(async () => {
           await changeRoute(route, {
             shouldScroll: scroll ?? shouldScrollByDefault(url),
-            scroll,
             mode: 'push',
             url,
             startTransition: startTransitionFn,
@@ -1137,8 +1131,6 @@ const InnerRouter = ({
       const routeBeforeChange = routeRef.current;
       const shouldRefetch =
         options.refetch ?? !isSameRoute(nextRoute, routeBeforeChange);
-      let shouldScroll = options.shouldScroll;
-      let followedError = false;
       const isStaticSlot = (key: string) =>
         isImmutableElement(resolvedElementsRef.current, key);
       const commitRoute = (route: RouteProps) => {
@@ -1146,7 +1138,7 @@ const InnerRouter = ({
         routeRef.current = route;
         setRoute(route);
         setErr(null);
-        setPendingScroll(shouldScroll ? { pathChanged } : null);
+        setPendingScroll(options.shouldScroll ? { pathChanged } : null);
         setPendingHistory(mode ? { mode, url } : null);
       };
       const getRedirect = (
@@ -1163,13 +1155,11 @@ const InnerRouter = ({
         }
         return undefined;
       };
-      const commitInTransition = () => {
+      const commitInTransition = (followed = false) => {
         if (isAborted()) {
           return;
         }
-        const transitionFn = followedError
-          ? startTransition
-          : startTransitionFn;
+        const transitionFn = followed ? startTransition : startTransitionFn;
         void transitionFn(() => {
           commitRoute(nextRoute);
           routeChangeAbortRef.current = null;
@@ -1180,6 +1170,10 @@ const InnerRouter = ({
         commitInTransition();
         return;
       }
+      const targetUrl =
+        url instanceof URL
+          ? url
+          : new URL(url || getRouteUrl(nextRoute), window.location.href);
       const fetchRoute = (route: RouteProps, routeUrl: URL) => {
         const rscPath = encodeRoutePath(route.path);
         // Reuse a prefetch (matched by path and query) within its ttl; an
@@ -1213,20 +1207,11 @@ const InnerRouter = ({
         }
         return undefined;
       };
-      type Resolved =
-        | {
-            route: RouteProps;
-            routeUrl: URL;
-            via404: boolean;
-            elements?: Awaited<ReturnType<typeof refetch>>;
-          }
-        | { externalUrl: URL };
       const resolveFollowingErrors = async (
         route: RouteProps,
         routeUrl: URL,
         errorToFollow?: unknown,
-      ): Promise<Resolved> => {
-        let via404 = false;
+      ) => {
         for (let hops = errorToFollow ? 1 : 0; hops <= MAX_ERROR_HOPS; hops++) {
           if (errorToFollow) {
             const target = followTarget(errorToFollow, routeUrl, route);
@@ -1236,7 +1221,6 @@ const InnerRouter = ({
             if (target.kind === 'external') {
               return { externalUrl: target.url };
             }
-            via404 = target.kind === '404';
             if (target.kind === 'internal') {
               route = parseRoute(target.url);
               routeUrl = target.url;
@@ -1250,11 +1234,14 @@ const InnerRouter = ({
             (staticPathSetRef.current.has(route.path) ||
               isSameRoute(route, routeBeforeChange))
           ) {
-            return { route, routeUrl, via404 };
+            return { route, routeUrl };
           }
           try {
-            const elements = await fetchRoute(route, routeUrl);
-            return { route, routeUrl, via404, elements };
+            return {
+              route,
+              routeUrl,
+              elements: await fetchRoute(route, routeUrl),
+            };
           } catch (e) {
             if (isAborted()) {
               throw e;
@@ -1266,11 +1253,34 @@ const InnerRouter = ({
           cause: errorToFollow,
         });
       };
-      const targetUrl =
-        url instanceof URL
-          ? url
-          : new URL(url || getRouteUrl(nextRoute), window.location.href);
-      let resolved: Resolved | undefined;
+      const finishWith = (
+        resolved: Awaited<ReturnType<typeof resolveFollowingErrors>>,
+      ) => {
+        if ('externalUrl' in resolved) {
+          if (mode && window.location.href !== targetUrl.href) {
+            writeUrlToHistory(mode, targetUrl);
+            setPendingHistory(null);
+          }
+          window.location.replace(resolved.externalUrl.href);
+          return;
+        }
+        const followed = !isSameRoute(resolved.route, nextRoute);
+        if (followed) {
+          nextRoute = resolved.route;
+          url = mode ? resolved.routeUrl : undefined;
+        }
+        if (resolved.elements) {
+          const redirect = getRedirect(resolved.elements);
+          if (redirect) {
+            nextRoute = redirect;
+            if (mode) {
+              mode = redirect.path === '/404' ? undefined : 'push';
+              url = undefined;
+            }
+          }
+        }
+        commitInTransition(followed);
+      };
       if (options.instant) {
         const rscPath = encodeRoutePath(nextRoute.path);
         const prefetchedElements =
@@ -1322,7 +1332,6 @@ const InnerRouter = ({
               }
             }
             emitRouteChangeEvent('complete', redirect ?? nextRoute);
-            return;
           } catch (e) {
             if (isAborted()) {
               return;
@@ -1336,8 +1345,9 @@ const InnerRouter = ({
               writeUrlToHistory(mode, targetUrl);
               setPendingHistory(null);
             }
+            mode = mode && 'replace';
             try {
-              resolved = await resolveFollowingErrors(nextRoute, targetUrl, e);
+              finishWith(await resolveFollowingErrors(nextRoute, targetUrl, e));
             } catch (e2) {
               if (isAborted()) {
                 return;
@@ -1346,58 +1356,25 @@ const InnerRouter = ({
               setErr(e2);
               throw e2;
             }
-            if (!('externalUrl' in resolved)) {
-              mode = resolved.via404 ? undefined : mode && 'replace';
-            }
           }
+          return;
         }
       }
-      if (!resolved) {
-        try {
-          resolved = await resolveFollowingErrors(nextRoute, targetUrl, 0);
-        } catch (e) {
-          if (isAborted()) {
-            return;
-          }
-          routeChangeAbortRef.current = null;
-          // Write URL synchronously
-          // React may rollback transition state updates when the render throws
-          if (mode && window.location.pathname === prevPathname) {
-            writeUrlToHistory(mode, targetUrl);
-          }
-          setErr(e);
-          throw e;
+      try {
+        finishWith(await resolveFollowingErrors(nextRoute, targetUrl));
+      } catch (e) {
+        if (isAborted()) {
+          return;
         }
-      }
-      if ('externalUrl' in resolved) {
-        if (mode && window.location.href !== targetUrl.href) {
+        routeChangeAbortRef.current = null;
+        // Write URL synchronously
+        // React may rollback transition state updates when the render throws
+        if (mode && window.location.pathname === prevPathname) {
           writeUrlToHistory(mode, targetUrl);
-          setPendingHistory(null);
         }
-        window.location.replace(resolved.externalUrl.href);
-        return;
+        setErr(e);
+        throw e;
       }
-      if (!isSameRoute(resolved.route, nextRoute)) {
-        followedError = true;
-        nextRoute = resolved.route;
-        url = mode ? resolved.routeUrl : undefined;
-        shouldScroll =
-          options.scroll ??
-          (resolved.via404
-            ? true
-            : shouldScrollForRouteChange(nextRoute, routeBeforeChange));
-      }
-      if (resolved.elements) {
-        const redirect = getRedirect(resolved.elements);
-        if (redirect) {
-          nextRoute = redirect;
-          if (mode) {
-            mode = redirect.path === '/404' ? undefined : 'push';
-            url = undefined;
-          }
-        }
-      }
-      commitInTransition();
     },
     [
       emitRouteChangeEvent,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -3,6 +3,7 @@
 import {
   Component,
   createContext,
+  startTransition,
   use,
   useCallback,
   useContext,
@@ -158,6 +159,16 @@ const isSameRoute = (next: RouteProps, prev: RouteProps) =>
   next.hash === prev.hash;
 
 const MAX_ERROR_HOPS = 20;
+
+const classifyRedirectLocation = (location: string, base: string | URL) => {
+  const url = new URL(location, base);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return undefined;
+  }
+  return url.origin === window.location.origin
+    ? ({ kind: 'internal', url } as const)
+    : ({ kind: 'external', url } as const);
+};
 
 const shouldScrollForRouteChange = (next: RouteProps, prev: RouteProps) =>
   isPathChange(next, prev) || isHashChange(next, prev);
@@ -793,21 +804,19 @@ const Redirect = ({
     }
     handledErrorSet.add(error as object);
 
-    const url = new URL(to, window.location.href);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    const target = classifyRedirectLocation(to, window.location.href);
+    if (!target) {
       return;
     }
-    if (url.hostname !== window.location.hostname) {
-      window.location.replace(url.href);
+    if (target.kind === 'external') {
+      window.location.replace(target.url.href);
       return;
     }
-    const currentPath = window.location.pathname;
-    const newPath = url.pathname !== currentPath;
-    const historyUrl = url.origin === window.location.origin ? url : undefined;
+    const url = target.url;
     changeRoute(parseRoute(url), {
-      shouldScroll: newPath,
+      shouldScroll: url.pathname !== window.location.pathname,
       mode: 'replace',
-      url: historyUrl,
+      url,
     })
       .then(() => {
         handledErrorSet.delete(error as object);
@@ -1159,7 +1168,7 @@ const InnerRouter = ({
           return;
         }
         const transitionFn = followedError
-          ? (fn: TransitionFunction) => fn()
+          ? startTransition
           : startTransitionFn;
         void transitionFn(() => {
           commitRoute(nextRoute);
@@ -1196,17 +1205,8 @@ const InnerRouter = ({
         route: RouteProps,
       ) => {
         const info = getErrorInfo(e);
-        const redirectUrl = info?.location
-          ? new URL(info.location, attemptedUrl)
-          : undefined;
-        if (
-          redirectUrl &&
-          (redirectUrl.protocol === 'http:' ||
-            redirectUrl.protocol === 'https:')
-        ) {
-          return redirectUrl.hostname === window.location.hostname
-            ? ({ kind: 'redirect', url: redirectUrl } as const)
-            : ({ kind: 'external', url: redirectUrl } as const);
+        if (info?.location) {
+          return classifyRedirectLocation(info.location, attemptedUrl);
         }
         if (info?.status === 404 && has404 && route.path !== '/404') {
           return { kind: '404' } as const;
@@ -1224,56 +1224,47 @@ const InnerRouter = ({
       const resolveFollowingErrors = async (
         route: RouteProps,
         routeUrl: URL,
-        hops: number,
+        errorToFollow?: unknown,
       ): Promise<Resolved> => {
-        if (
-          hops > 0 &&
-          (staticPathSetRef.current.has(route.path) ||
-            isSameRoute(route, routeBeforeChange))
-        ) {
-          return { route, routeUrl, via404: false };
-        }
-        try {
-          const elements = await fetchRoute(route, routeUrl);
-          return { route, routeUrl, via404: false, elements };
-        } catch (e) {
-          if (isAborted()) {
-            throw e;
+        let via404 = false;
+        for (let hops = errorToFollow ? 1 : 0; hops <= MAX_ERROR_HOPS; hops++) {
+          if (errorToFollow) {
+            const target = followTarget(errorToFollow, routeUrl, route);
+            if (!target) {
+              throw errorToFollow;
+            }
+            if (target.kind === 'external') {
+              return { externalUrl: target.url };
+            }
+            via404 = target.kind === '404';
+            if (target.kind === 'internal') {
+              route = parseRoute(target.url);
+              routeUrl = target.url;
+            } else {
+              route = parseRoute(new URL('/404', window.location.href));
+            }
+            errorToFollow = undefined;
           }
-          return followFrom(e, route, routeUrl, hops);
+          if (
+            hops > 0 &&
+            (staticPathSetRef.current.has(route.path) ||
+              isSameRoute(route, routeBeforeChange))
+          ) {
+            return { route, routeUrl, via404 };
+          }
+          try {
+            const elements = await fetchRoute(route, routeUrl);
+            return { route, routeUrl, via404, elements };
+          } catch (e) {
+            if (isAborted()) {
+              throw e;
+            }
+            errorToFollow = e;
+          }
         }
-      };
-      const followFrom = async (
-        e: unknown,
-        route: RouteProps,
-        routeUrl: URL,
-        hops: number,
-      ): Promise<Resolved> => {
-        const target =
-          hops < MAX_ERROR_HOPS ? followTarget(e, routeUrl, route) : undefined;
-        if (!target) {
-          throw followTarget(e, routeUrl, route)
-            ? new Error('too many redirect or 404 follows', { cause: e })
-            : e;
-        }
-        if (target.kind === 'external') {
-          return { externalUrl: target.url };
-        }
-        if (target.kind === 'redirect') {
-          return resolveFollowingErrors(
-            parseRoute(target.url),
-            target.url,
-            hops + 1,
-          );
-        }
-        const resolved = await resolveFollowingErrors(
-          parseRoute(new URL('/404', window.location.href)),
-          routeUrl,
-          hops + 1,
-        );
-        return 'externalUrl' in resolved
-          ? resolved
-          : { ...resolved, via404: true };
+        throw new Error('too many redirect or 404 follows', {
+          cause: errorToFollow,
+        });
       };
       const targetUrl =
         url instanceof URL
@@ -1346,7 +1337,7 @@ const InnerRouter = ({
               setPendingHistory(null);
             }
             try {
-              resolved = await followFrom(e, nextRoute, targetUrl, 0);
+              resolved = await resolveFollowingErrors(nextRoute, targetUrl, e);
             } catch (e2) {
               if (isAborted()) {
                 return;
@@ -1389,10 +1380,7 @@ const InnerRouter = ({
       if (!isSameRoute(resolved.route, nextRoute)) {
         followedError = true;
         nextRoute = resolved.route;
-        url =
-          mode && resolved.routeUrl.origin === window.location.origin
-            ? resolved.routeUrl
-            : undefined;
+        url = mode ? resolved.routeUrl : undefined;
         shouldScroll =
           options.scroll ??
           (resolved.via404

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3916,12 +3916,60 @@ describe('Router integration', () => {
       slots: ['/404'],
       meta: { [HAS404_ID]: true },
     });
+    window.history.replaceState(null, '', '/start');
+    const lengthBefore = window.history.length;
     await act(async () => {
       await router.push('/missing');
       await flush();
     });
     expect(refetch).toHaveBeenCalledTimes(2);
     expect(capture.router!.path).toBe('/404');
+    // the address bar keeps the requested url as one new entry
+    expect(window.location.pathname).toBe('/missing');
+    expect(window.history.length).toBe(lengthBefore + 1);
+    view.unmount();
+  });
+
+  test('a redirect that lands on a missing route goes to the 404 route', async () => {
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 307, location: '/gone' } },
+        { reject: { status: 404 } },
+        { resolve: { [ROUTE_ID]: ['/404', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/404'],
+      meta: { [HAS404_ID]: true },
+    });
+    await act(async () => {
+      await router.push('/moved');
+      await flush();
+    });
+    expect(refetch).toHaveBeenCalledTimes(3);
+    expect(capture.router!.path).toBe('/404');
+    view.unmount();
+  });
+
+  test('a query-only navigation that redirects to another pathname keeps its scroll', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 307, location: '/login' } },
+        { resolve: { [ROUTE_ID]: ['/login', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/login'],
+    });
+    window.history.replaceState(null, '', '/start?page=1');
+    await act(async () => {
+      await router.push('/start?page=2');
+      await flush();
+    });
+    // the attempted query update does not scroll, and the redirect
+    // inherits that decision
+    expect(capture.router!.path).toBe('/login');
+    expect(scrollToSpy).not.toHaveBeenCalled();
+    scrollToSpy.mockRestore();
     view.unmount();
   });
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3182,6 +3182,863 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a navigation follows a redirect error inline', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: '/next' }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/next', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/next')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/moved');
+      await flush();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(2);
+    expect(capture.router.path).toBe('/next');
+
+    view.unmount();
+  });
+
+  test('an instant navigation resolves a relative redirect against the attempted url', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: 'login' }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/account/login', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const profileSlotId = unstable_getRouteSlotId('/account/profile');
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [profileSlotId]: <div>profile</div>,
+      [unstable_getRouteSlotId('/account/login')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      // mark the attempted route static so the instant branch engages
+      [`${ETAG_ID_PREFIX}${profileSlotId}`]: IMMUTABLE_ETAG,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    // the rejection can arrive before the history effect writes the
+    // attempted url, so the previous url must not be the base
+    const pushStateSpy = vi
+      .spyOn(window.history, 'pushState')
+      .mockImplementation(() => {});
+    const replaceStateSpy = vi
+      .spyOn(window.history, 'replaceState')
+      .mockImplementation(() => {});
+    try {
+      await act(async () => {
+        await capture.router!.push('/account/profile', {
+          unstable_instant: true,
+        });
+        await flush();
+      });
+    } finally {
+      pushStateSpy.mockRestore();
+      replaceStateSpy.mockRestore();
+    }
+
+    // "login" resolves against /account/profile, not the previous url
+    expect(refetch.mock.calls[1]?.[0]).toBe(
+      unstable_encodeRoutePath('/account/login'),
+    );
+    expect(capture.router.path).toBe('/account/login');
+
+    view.unmount();
+  });
+
+  test('an instant redirect keeps the attempted history entry', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: 'login' }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/account/login', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const profileSlotId = unstable_getRouteSlotId('/account/profile');
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [profileSlotId]: <div>profile</div>,
+      [unstable_getRouteSlotId('/account/login')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [`${ETAG_ID_PREFIX}${profileSlotId}`]: IMMUTABLE_ETAG,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    const lengthBefore = window.history.length;
+    await act(async () => {
+      await capture.router!.push('/account/profile', {
+        unstable_instant: true,
+      });
+      await flush();
+    });
+
+    // the attempted entry is pushed, then replaced by the redirect
+    expect(window.location.pathname).toBe('/account/login');
+    expect(window.history.length).toBe(lengthBefore + 1);
+    expect(capture.router.path).toBe('/account/login');
+
+    view.unmount();
+  });
+
+  test('an instant 404 keeps the attempted url in the address bar', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(createCustomError('nf', { status: 404 })),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/404', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const profileSlotId = unstable_getRouteSlotId('/account/profile');
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [profileSlotId]: <div>profile</div>,
+      [unstable_getRouteSlotId('/404')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [HAS404_ID]: true,
+      [`${ETAG_ID_PREFIX}${profileSlotId}`]: IMMUTABLE_ETAG,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    const lengthBefore = window.history.length;
+    await act(async () => {
+      await capture.router!.push('/account/profile', {
+        unstable_instant: true,
+      });
+      await flush();
+    });
+
+    // the 404 route renders while the address bar keeps the attempted url
+    expect(capture.router.path).toBe('/404');
+    expect(window.location.pathname).toBe('/account/profile');
+    expect(window.history.length).toBe(lengthBefore + 1);
+
+    view.unmount();
+  });
+
+  test('a redirect that keeps the attempted pathname still scrolls', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', {
+            status: 307,
+            location: '/account/profile?login=1',
+          }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/account/profile', 'login=1'],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/account/profile')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/account/profile');
+      await flush();
+    });
+
+    // the visible navigation is from /start, so the page scrolls even
+    // though the redirect keeps the attempted pathname
+    expect(capture.router.path).toBe('/account/profile');
+    expect(scrollToSpy).toHaveBeenCalled();
+
+    scrollToSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a query-only navigation that redirects writes one history entry', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: '/login' }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/login', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/products')]: <Probe />,
+      [unstable_getRouteSlotId('/login')]: <Probe />,
+      [ROUTE_ID]: ['/products', 'page=1'],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/products', query: 'page=1', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    window.history.replaceState(null, '', '/products?page=1');
+    const lengthBefore = window.history.length;
+    await act(async () => {
+      await capture.router!.push('/products?page=2');
+      await flush();
+    });
+
+    // the attempted entry is written once, then replaced by the redirect
+    expect(capture.router.path).toBe('/login');
+    expect(window.location.pathname).toBe('/login');
+    expect(window.history.length).toBe(lengthBefore + 1);
+
+    view.unmount();
+  });
+
+  test('a slow redirect after an instant error writes one attempted entry', async () => {
+    let resolveSecond!: (value: Record<string, unknown>) => void;
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: 'login' }),
+        ),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const profileSlotId = unstable_getRouteSlotId('/account/profile');
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [profileSlotId]: <div>profile</div>,
+      [unstable_getRouteSlotId('/account/login')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [`${ETAG_ID_PREFIX}${profileSlotId}`]: IMMUTABLE_ETAG,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    window.history.replaceState(null, '', '/start');
+    const lengthBefore = window.history.length;
+    let pushPromise: Promise<void> | undefined;
+    await act(async () => {
+      pushPromise = capture.router!.push('/account/profile', {
+        unstable_instant: true,
+      });
+      // flush the attempted route's commit while the redirect is pending
+      await flush();
+    });
+    await act(async () => {
+      resolveSecond({
+        [ROUTE_ID]: ['/account/login', ''],
+        [IS_STATIC_ID]: false,
+      });
+      await pushPromise;
+      await flush();
+    });
+
+    expect(window.location.pathname).toBe('/account/login');
+    expect(window.history.length).toBe(lengthBefore + 1);
+
+    view.unmount();
+  });
+
+  test('a redirect keeps an explicit scroll false option', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: '/next' }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/next', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/next')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/moved', { scroll: false });
+      await flush();
+    });
+
+    expect(capture.router.path).toBe('/next');
+    expect(scrollToSpy).not.toHaveBeenCalled();
+
+    scrollToSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a query-only redirect keeps an explicit scroll true option', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', {
+            status: 307,
+            location: '/products?page=3',
+          }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/products', 'page=3'],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/products')]: <Probe />,
+      [ROUTE_ID]: ['/products', 'page=1'],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/products', query: 'page=1', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    window.history.replaceState(null, '', '/products?page=1');
+    await act(async () => {
+      await capture.router!.push('/products?page=2', { scroll: true });
+      await flush();
+    });
+
+    expect(capture.router.query).toBe('page=3');
+    expect(scrollToSpy).toHaveBeenCalled();
+
+    scrollToSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a link with scroll false keeps it through a redirect', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: '/next' }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/next', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: (
+        <div>
+          <Probe />
+          <Link to={'/moved' as never} scroll={false}>
+            go
+          </Link>
+        </div>
+      ),
+      [unstable_getRouteSlotId('/next')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      view.container.querySelector('a')!.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+        }),
+      );
+      await flush();
+    });
+
+    expect(capture.router.path).toBe('/next');
+    expect(scrollToSpy).not.toHaveBeenCalled();
+
+    scrollToSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a two-hop redirect keeps scroll false and one history entry', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: '/b' }),
+        ),
+      )
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: '/c' }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/c', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/c')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    window.history.replaceState(null, '', '/start');
+    const lengthBefore = window.history.length;
+    await act(async () => {
+      await capture.router!.push('/a', { scroll: false });
+      await flush();
+    });
+
+    expect(capture.router.path).toBe('/c');
+    expect(window.location.pathname).toBe('/c');
+    expect(window.history.length).toBe(lengthBefore + 1);
+    expect(scrollToSpy).not.toHaveBeenCalled();
+
+    scrollToSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a redirect cycle stops at the hop limit and rejects', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
+      Promise.reject(
+        createCustomError('moved', { status: 307, location: '/a' }),
+      ),
+    );
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    testHoisted.elements = elements;
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <ErrorBoundary>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </ErrorBoundary>
+      </Unstable_SearchCodecsProvider>,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    try {
+      await act(async () => {
+        await expect(capture.router!.push('/a')).rejects.toThrow(
+          'too many redirect or 404 follows',
+        );
+        await flush();
+      });
+      // the original fetch plus one follow per allowed hop
+      expect(refetch).toHaveBeenCalledTimes(21);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('an instant redirect scrolls when the visible navigation changed paths', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', {
+            status: 307,
+            location: '/account/profile?login=1',
+          }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/account/profile', 'login=1'],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const profileSlotId = unstable_getRouteSlotId('/account/profile');
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [profileSlotId]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [`${ETAG_ID_PREFIX}${profileSlotId}`]: IMMUTABLE_ETAG,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/account/profile', {
+        unstable_instant: true,
+      });
+      await flush();
+    });
+
+    // the visible navigation is /start -> /account/profile?login=1, so
+    // the redirect scrolls even though it only changed the query
+    expect(capture.router.query).toBe('login=1');
+    expect(scrollToSpy).toHaveBeenCalled();
+
+    scrollToSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a redirect back to the current route does not scroll', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: '/start' }),
+        ),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/a');
+      await flush();
+    });
+
+    expect(capture.router.path).toBe('/start');
+    expect(scrollToSpy).not.toHaveBeenCalled();
+
+    scrollToSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a navigation during a redirect follow aborts the chain', async () => {
+    let resolveSecond!: (value: Record<string, unknown>) => void;
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          createCustomError('moved', { status: 307, location: '/slow' }),
+        ),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/other', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/slow')]: <Probe />,
+      [unstable_getRouteSlotId('/other')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    let firstPush: Promise<void> | undefined;
+    await act(async () => {
+      firstPush = capture.router!.push('/a');
+      firstPush.catch(() => {});
+      await flush();
+    });
+    // the follow to /slow is in flight; a second navigation supersedes it
+    await act(async () => {
+      await capture.router!.push('/other');
+      await flush();
+    });
+    await act(async () => {
+      resolveSecond({
+        [ROUTE_ID]: ['/slow', ''],
+        [IS_STATIC_ID]: false,
+      });
+      await flush();
+    });
+
+    expect(capture.router.path).toBe('/other');
+
+    view.unmount();
+  });
+
+  test('a 404 error on navigation goes to the 404 route inline', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(createCustomError('nf', { status: 404 })),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/404', ''],
+        [IS_STATIC_ID]: false,
+      });
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/404')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [HAS404_ID]: true,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/missing');
+      await flush();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(2);
+    expect(capture.router.path).toBe('/404');
+
+    view.unmount();
+  });
+
+  test('a 404 error on navigation without a 404 route rejects', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch.mockImplementationOnce(() =>
+      Promise.reject(createCustomError('nf', { status: 404 })),
+    );
+    vi.mocked(useRefetch).mockReturnValue(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [HAS404_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await expect(capture.router!.push('/missing')).rejects.toThrow('nf');
+      await flush();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+  });
+
   test('custom 404 handling without a /404 page keeps Not Found fallback', async () => {
     const ThrowNotFound = () => {
       throw createCustomError('not-found', { status: 404 });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3824,7 +3824,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a redirect back to the current route does not scroll', async () => {
+  test('a redirect back to the current route scrolls like the attempted navigation', async () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
@@ -3839,7 +3839,7 @@ describe('Router integration', () => {
       await flush();
     });
     expect(capture.router!.path).toBe('/start');
-    expect(scrollToSpy).not.toHaveBeenCalled();
+    expect(scrollToSpy).toHaveBeenCalled();
     scrollToSpy.mockRestore();
     view.unmount();
   });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3182,29 +3182,43 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a navigation follows a redirect error inline', async () => {
+  const renderFollowRouter = async ({
+    responses,
+    slots = [],
+    meta = {},
+  }: {
+    responses: (
+      | { reject: { status: number; location?: string } }
+      | { resolve: Record<string, unknown> }
+    )[];
+    slots?: string[];
+    meta?: Record<string, unknown>;
+  }) => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
-    refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: '/next' }),
-        ),
-      )
-      .mockResolvedValueOnce({
-        [ROUTE_ID]: ['/next', ''],
-        [IS_STATIC_ID]: false,
-      });
+    for (const response of responses) {
+      if ('reject' in response) {
+        refetch.mockImplementationOnce(() =>
+          Promise.reject(createCustomError('follow-error', response.reject)),
+        );
+      } else {
+        refetch.mockResolvedValueOnce(response.resolve);
+      }
+    }
     vi.mocked(useRefetch).mockReturnValue(refetch);
-
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const elements = {
       [unstable_getRouteSlotId('/start')]: <Probe />,
-      [unstable_getRouteSlotId('/next')]: <Probe />,
+      ...Object.fromEntries(
+        slots.map((path) => [
+          unstable_getRouteSlotId(path),
+          <Probe key={path} />,
+        ]),
+      ),
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
+      ...meta,
     };
-
     const view = await renderRouter(
       { initialRoute: { path: '/start', query: '', hash: '' } },
       elements,
@@ -3212,15 +3226,23 @@ describe('Router integration', () => {
     if (!capture.router) {
       throw new Error('router not initialized');
     }
+    return { view, refetch, capture, router: capture.router };
+  };
 
+  test('a navigation follows a redirect error inline', async () => {
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 307, location: '/next' } },
+        { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/next'],
+    });
     await act(async () => {
-      await capture.router!.push('/moved');
+      await router.push('/moved');
       await flush();
     });
-
     expect(refetch).toHaveBeenCalledTimes(2);
-    expect(capture.router.path).toBe('/next');
-
+    expect(capture.router!.path).toBe('/next');
     view.unmount();
   });
 
@@ -3550,44 +3572,19 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
-    refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: '/next' }),
-        ),
-      )
-      .mockResolvedValueOnce({
-        [ROUTE_ID]: ['/next', ''],
-        [IS_STATIC_ID]: false,
-      });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
-
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    const elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [unstable_getRouteSlotId('/next')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-    };
-
-    const view = await renderRouter(
-      { initialRoute: { path: '/start', query: '', hash: '' } },
-      elements,
-    );
-    if (!capture.router) {
-      throw new Error('router not initialized');
-    }
-
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 307, location: '/next' } },
+        { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/next'],
+    });
     await act(async () => {
-      await capture.router!.push('/moved', { scroll: false });
+      await router.push('/moved', { scroll: false });
       await flush();
     });
-
-    expect(capture.router.path).toBe('/next');
+    expect(capture.router!.path).toBe('/next');
     expect(scrollToSpy).not.toHaveBeenCalled();
-
     scrollToSpy.mockRestore();
     view.unmount();
   });
@@ -3704,53 +3701,24 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
-    refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: '/b' }),
-        ),
-      )
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: '/c' }),
-        ),
-      )
-      .mockResolvedValueOnce({
-        [ROUTE_ID]: ['/c', ''],
-        [IS_STATIC_ID]: false,
-      });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
-
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    const elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [unstable_getRouteSlotId('/c')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-    };
-
-    const view = await renderRouter(
-      { initialRoute: { path: '/start', query: '', hash: '' } },
-      elements,
-    );
-    if (!capture.router) {
-      throw new Error('router not initialized');
-    }
-
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 307, location: '/b' } },
+        { reject: { status: 307, location: '/c' } },
+        { resolve: { [ROUTE_ID]: ['/c', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/c'],
+    });
     window.history.replaceState(null, '', '/start');
     const lengthBefore = window.history.length;
     await act(async () => {
-      await capture.router!.push('/a', { scroll: false });
+      await router.push('/a', { scroll: false });
       await flush();
     });
-
-    expect(capture.router.path).toBe('/c');
+    expect(capture.router!.path).toBe('/c');
     expect(window.location.pathname).toBe('/c');
     expect(window.history.length).toBe(lengthBefore + 1);
     expect(scrollToSpy).not.toHaveBeenCalled();
-
     scrollToSpy.mockRestore();
     view.unmount();
   });
@@ -3860,43 +3828,18 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
-    refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: '/start' }),
-        ),
-      )
-      .mockResolvedValueOnce({
-        [ROUTE_ID]: ['/start', ''],
-        [IS_STATIC_ID]: false,
-      });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
-
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    const elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-    };
-
-    const view = await renderRouter(
-      { initialRoute: { path: '/start', query: '', hash: '' } },
-      elements,
-    );
-    if (!capture.router) {
-      throw new Error('router not initialized');
-    }
-
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 307, location: '/start' } },
+        { resolve: { [ROUTE_ID]: ['/start', ''], [IS_STATIC_ID]: false } },
+      ],
+    });
     await act(async () => {
-      await capture.router!.push('/a');
+      await router.push('/a');
       await flush();
     });
-
-    expect(capture.router.path).toBe('/start');
+    expect(capture.router!.path).toBe('/start');
     expect(scrollToSpy).not.toHaveBeenCalled();
-
     scrollToSpy.mockRestore();
     view.unmount();
   });
@@ -3965,77 +3908,33 @@ describe('Router integration', () => {
   });
 
   test('a 404 error on navigation goes to the 404 route inline', async () => {
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
-    refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(createCustomError('nf', { status: 404 })),
-      )
-      .mockResolvedValueOnce({
-        [ROUTE_ID]: ['/404', ''],
-        [IS_STATIC_ID]: false,
-      });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
-
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    const elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [unstable_getRouteSlotId('/404')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-      [HAS404_ID]: true,
-    };
-
-    const view = await renderRouter(
-      { initialRoute: { path: '/start', query: '', hash: '' } },
-      elements,
-    );
-    if (!capture.router) {
-      throw new Error('router not initialized');
-    }
-
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 404 } },
+        { resolve: { [ROUTE_ID]: ['/404', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/404'],
+      meta: { [HAS404_ID]: true },
+    });
     await act(async () => {
-      await capture.router!.push('/missing');
+      await router.push('/missing');
       await flush();
     });
-
     expect(refetch).toHaveBeenCalledTimes(2);
-    expect(capture.router.path).toBe('/404');
-
+    expect(capture.router!.path).toBe('/404');
     view.unmount();
   });
 
   test('a 404 error on navigation without a 404 route rejects', async () => {
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
-    refetch.mockImplementationOnce(() =>
-      Promise.reject(createCustomError('nf', { status: 404 })),
-    );
-    vi.mocked(useRefetch).mockReturnValue(refetch);
-
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    const elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-      [HAS404_ID]: false,
-    };
-
-    const view = await renderRouter(
-      { initialRoute: { path: '/start', query: '', hash: '' } },
-      elements,
-    );
-    if (!capture.router) {
-      throw new Error('router not initialized');
-    }
-
+    const { view, refetch, router } = await renderFollowRouter({
+      responses: [{ reject: { status: 404 } }],
+      meta: { [HAS404_ID]: false },
+    });
     await act(async () => {
-      await expect(capture.router!.push('/missing')).rejects.toThrow('nf');
+      await expect(router.push('/missing')).rejects.toThrow('follow-error');
       await flush();
     });
-
     expect(refetch).toHaveBeenCalledTimes(1);
-
     view.unmount();
   });
 
@@ -4213,7 +4112,7 @@ describe('Router integration', () => {
     }
   });
 
-  test('redirect error with same hostname but different origin stays in client navigation', async () => {
+  test('redirect error with a different origin leaves the app', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const ThrowRedirect = () => {
@@ -4242,10 +4141,10 @@ describe('Router integration', () => {
     try {
       await flush();
 
-      expect(replaceLocationSpy).not.toHaveBeenCalled();
-      expect(capture.router?.path).toBe('/target');
-      expect(capture.router?.query).toBe('ok=1');
-      expect(getRefetchMock()).toHaveBeenCalledWith(
+      expect(replaceLocationSpy).toHaveBeenCalledWith(
+        'http://localhost:4321/target?ok=1',
+      );
+      expect(getRefetchMock()).not.toHaveBeenCalledWith(
         unstable_encodeRoutePath('/target'),
         expect.any(URLSearchParams),
         expect.anything(),


### PR DESCRIPTION
When a client navigation's fetch rejects with a redirect or 404 error, changeRoute now follows it directly instead of rendering the error and navigating again from the error boundary's effect. The navigation promise resolves after following instead of rejecting, with no error render in between. The boundary keeps NotFound and Redirect for errors revived at initial load.