### PR TITLE
fix(router): reset the error boundary only when the route changes

### DIFF
--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -733,7 +733,7 @@ const FollowError = ({
       targetRef.current = undefined;
       reset();
     }
-  });
+  }, [route, reset]);
   useEffect(() => {
     // ensure a single re-fetch per error on StrictMode
     // https://github.com/wakujs/waku/pull/1512


### PR DESCRIPTION
Follow up: #2193

The arrival effect in FollowError ran after every render, so a follow whose
target equals the current route could reset the boundary before the follow
committed. The same error was then rethrown and already marked as handled,
leaving the boundary stuck with empty content. With route in the dependency
list, the effect runs only when the route changes, which every commit does
by creating a new route object.