### PR TITLE
feat(core): action fallback

### DIFF
--- a/docs/guides/csp.mdx
+++ b/docs/guides/csp.mdx
@@ -108,7 +108,7 @@ const generateNonce = () => {
 
 export default adapter({
   handleRequest: async (input, { renderRsc, renderHtml }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App /> });
     }
     if (input.type === 'custom' && input.pathname === '/') {

--- a/docs/guides/csp.mdx
+++ b/docs/guides/csp.mdx
@@ -111,7 +111,7 @@ export default adapter({
     if (input.type === 'rsc') {
       return renderRsc({ App: <App /> });
     }
-    if (input.type === 'custom' && input.pathname === '/') {
+    if (input.type === 'http' && input.pathname === '/') {
       const nonce = generateNonce();
       const response = await renderHtml(
         await renderRsc({ App: <App /> }),

--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -92,10 +92,10 @@ import App from './components/App.js';
 
 const handlers = defineHandlers({
   handleRequest: async (input, { renderRsc, renderHtml }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
     }
-    if (input.type === 'custom' && input.pathname === '/') {
+    if (input.type === 'http' && input.pathname === '/') {
       const rscPath = '';
       return renderHtml(
         await renderRsc({ App: <App name="Waku" /> }),
@@ -152,7 +152,7 @@ if ((globalThis as any).__WAKU_HYDRATE__) {
 
 In the example above, a request to `/` looks like this:
 
-1. The adapter receives `GET /` and calls `handleRequest` with `input.type === 'custom'`.
+1. The adapter receives `GET /` and calls `handleRequest` with `input.type === 'http'`.
 2. `handleRequest` renders an RSC payload with `renderRsc(...)`.
 3. `handleRequest` passes that payload to `renderHtml(...)` together with an HTML tree containing `<Slot id="App" />`.
 4. The browser loads `src/waku.client.tsx`.
@@ -192,12 +192,11 @@ export default adapter({
 
 The `input` argument is one of the following shapes:
 
-| `input.type` | When it is used                                                      | Extra fields           |
-| ------------ | -------------------------------------------------------------------- | ---------------------- |
-| `component`  | RSC payload fetches initiated by `Root` or `useRefetch`              | `rscPath`, `rscParams` |
-| `function`   | Server function calls                                                | `fn`, `args`           |
-| `action`     | Server action submissions                                            | `fn`                   |
-| `custom`     | Ordinary HTTP requests such as document requests or custom endpoints | none                   |
+| `input.type` | When it is used                                                                          | Extra fields           |
+| ------------ | ---------------------------------------------------------------------------------------- | ---------------------- |
+| `rsc`        | RSC payload fetches initiated by `Root` or `useRefetch`                                  | `rscPath`, `rscParams` |
+| `call`       | Server function calls                                                                    | `fn`, `args`           |
+| `http`       | Ordinary HTTP requests such as document requests, custom endpoints, and form submissions | `tryAction?`           |
 
 Every input also includes:
 
@@ -211,20 +210,20 @@ from deeper components and server functions.
 
 Typical handling patterns:
 
-`component` requests usually return an RSC payload:
+`rsc` requests usually return an RSC payload:
 
 ```tsx
-if (input.type === 'component') {
+if (input.type === 'rsc') {
   return renderRsc({
     App: <App name={input.rscPath || 'Waku'} />,
   });
 }
 ```
 
-`function` requests usually execute the server function and return its result with the `value` option:
+`call` requests usually execute the server function and return its result with the `value` option:
 
 ```tsx
-if (input.type === 'function') {
+if (input.type === 'call') {
   const value = await input.fn(...input.args);
   return renderRsc({}, { value });
 }
@@ -233,26 +232,33 @@ if (input.type === 'function') {
 If a server function should also update the rendered server elements, return the updated elements and pass the function result with `value`:
 
 ```tsx
-if (input.type === 'function') {
+if (input.type === 'call') {
   const value = await input.fn(...input.args);
   return renderRsc({ App: <App name="Updated" /> }, { value });
 }
 ```
 
-`action` requests often re-render HTML and pass `formState`. `input.fn()`
-resolves `{ action: true, formState }` for a decoded server action, or
-`{ action: false, formData }` with the parsed form data when the multipart
-body contains no server action reference (a plain HTML form or a crawler) —
-route that to the same logic as a custom `POST`:
+On multipart `POST` requests, which may be no-JS server action submissions,
+the input carries `tryAction`. Calling it consumes the request body
+and resolves `{ action: true, formState }` for a decoded server action, or
+`{ action: false, formData }` with the parsed form data when the body
+contains no server action reference (a plain HTML form or a crawler) —
+route that to your ordinary `POST` handling. Requests without
+`tryAction` cannot be action submissions, and their body stays
+untouched unless you read it:
 
 ```tsx
-if (input.type === 'action' && input.pathname === '/') {
-  const result = await input.fn();
-  if (!result.action) {
-    // an ordinary multipart form: treat it like a custom POST
-    await handlePost(result.formData);
+if (input.type === 'http' && input.pathname === '/') {
+  let formState;
+  if (input.tryAction) {
+    const result = await input.tryAction();
+    if (result.action) {
+      formState = result.formState;
+    } else {
+      // an ordinary multipart form: treat it like any other POST
+      await handlePost(result.formData);
+    }
   }
-  const formState = result.action ? result.formState : undefined;
   return renderHtml(
     await renderRsc({ App: <App name="Waku" /> }),
     <Slot id="App" />,
@@ -264,10 +270,10 @@ if (input.type === 'action' && input.pathname === '/') {
 }
 ```
 
-`custom` requests are where you implement document rendering and custom endpoints:
+`http` requests are where you implement document rendering and custom endpoints:
 
 ```tsx
-if (input.type === 'custom' && input.pathname === '/') {
+if (input.type === 'http' && input.pathname === '/') {
   return renderHtml(
     await renderRsc({ App: <App name="Waku" /> }),
     <Slot id="App" />,
@@ -275,7 +281,7 @@ if (input.type === 'custom' && input.pathname === '/') {
   );
 }
 
-if (input.type === 'custom' && input.pathname === '/api/hello') {
+if (input.type === 'http' && input.pathname === '/api/hello') {
   return new Response('world');
 }
 ```
@@ -370,7 +376,7 @@ handleBuild: async ({ saveBuildMetadata }) => {
 },
 
 handleRequest: async (input, { renderRsc, loadBuildMetadata }) => {
-  if (input.type === 'component') {
+  if (input.type === 'rsc') {
     return renderRsc({
       App: (
         <App metadata={(await loadBuildMetadata(BUILD_METADATA_KEY)) || 'Empty'} />
@@ -543,10 +549,10 @@ Use `renderHtml(...)` for document requests and leave `handleBuild` empty:
 ```tsx
 export default adapter({
   handleRequest: async (input, { renderRsc, renderHtml }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
     }
-    if (input.type === 'custom' && input.pathname === '/') {
+    if (input.type === 'http' && input.pathname === '/') {
       return renderHtml(
         await renderRsc({ App: <App name="Waku" /> }),
         <Slot id="App" />,
@@ -561,10 +567,10 @@ export default adapter({
 
 #### Custom API endpoints
 
-Use `input.type === 'custom'` and return a `Response` directly:
+Use `input.type === 'http'` and return a `Response` directly:
 
 ```tsx
-if (input.type === 'custom' && input.pathname === '/api/hello') {
+if (input.type === 'http' && input.pathname === '/api/hello') {
   return new Response('world');
 }
 ```
@@ -574,7 +580,7 @@ if (input.type === 'custom' && input.pathname === '/api/hello') {
 Server functions typically return their result with the `value` option, and may optionally return updated server elements in the same payload:
 
 ```tsx
-if (input.type === 'function') {
+if (input.type === 'call') {
   const value = await input.fn(...input.args);
   return renderRsc({ App: <App name="Updated" /> }, { value });
 }
@@ -585,11 +591,8 @@ if (input.type === 'function') {
 Server actions often return HTML rather than a bare RSC payload so that the same flow works with or without JavaScript:
 
 ```tsx
-if (
-  (input.type === 'action' || input.type === 'custom') &&
-  input.pathname === '/'
-) {
-  const result = input.type === 'action' ? await input.fn() : undefined;
+if (input.type === 'http' && input.pathname === '/') {
+  const result = input.tryAction ? await input.tryAction() : undefined;
   const formState = result?.action ? result.formState : undefined;
   return renderHtml(
     await renderRsc({ App: <App name="Waku" /> }),

--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -239,11 +239,20 @@ if (input.type === 'function') {
 }
 ```
 
-`action` requests often re-render HTML and pass `formState`:
+`action` requests often re-render HTML and pass `formState`. `input.fn()`
+resolves `{ action: true, formState }` for a decoded server action, or
+`{ action: false, formData }` with the parsed form data when the multipart
+body contains no server action reference (a plain HTML form or a crawler) —
+route that to the same logic as a custom `POST`:
 
 ```tsx
 if (input.type === 'action' && input.pathname === '/') {
-  const formState = await input.fn();
+  const result = await input.fn();
+  if (!result.action) {
+    // an ordinary multipart form: treat it like a custom POST
+    await handlePost(result.formData);
+  }
+  const formState = result.action ? result.formState : undefined;
   return renderHtml(
     await renderRsc({ App: <App name="Waku" /> }),
     <Slot id="App" />,
@@ -580,7 +589,8 @@ if (
   (input.type === 'action' || input.type === 'custom') &&
   input.pathname === '/'
 ) {
-  const formState = input.type === 'action' ? await input.fn() : undefined;
+  const result = input.type === 'action' ? await input.fn() : undefined;
+  const formState = result?.action ? result.formState : undefined;
   return renderHtml(
     await renderRsc({ App: <App name="Waku" /> }),
     <Slot id="App" />,

--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -243,7 +243,10 @@ the input carries `tryAction`. Calling it consumes the request body
 and resolves `{ action: true, formState }` for a decoded server action, or
 `{ action: false, formData }` with the parsed form data when the body
 contains no server action reference (a plain HTML form or a crawler) —
-route that to your ordinary `POST` handling. Requests without
+route that to your ordinary `POST` handling. `tryAction` is memoized, so
+calling it again returns the same result, and it rejects cross-origin
+requests only when they carry an action reference: an ordinary
+cross-origin form post is delivered as form data. Requests without
 `tryAction` cannot be action submissions, and their body stays
 untouched unless you read it:
 

--- a/docs/guides/no-ssr.mdx
+++ b/docs/guides/no-ssr.mdx
@@ -60,7 +60,7 @@ const router = fsRouter(import.meta.glob('./**/*.tsx', { base: './pages' }));
 
 export default adapter({
   handleRequest: async (input, utils) => {
-    if (input.type === 'custom') {
+    if (input.type === 'http') {
       return 'fallback';
     }
     return router.handleRequest(input, utils);
@@ -75,7 +75,7 @@ You can also make this conditional:
 
 ```tsx
 handleRequest: async (input, utils) => {
-  if (input.type === 'custom' && input.pathname.startsWith('/app')) {
+  if (input.type === 'http' && input.pathname.startsWith('/app')) {
     return 'fallback';
   }
   return router.handleRequest(input, utils);

--- a/e2e/fixtures/minimal-examples/src/waku.server.tsx
+++ b/e2e/fixtures/minimal-examples/src/waku.server.tsx
@@ -47,7 +47,7 @@ const appForMode = (
 export default adapter(
   {
     handleRequest: async (input, { renderRsc, renderHtml }) => {
-      if (input.type === 'component') {
+      if (input.type === 'rsc') {
         if (input.rscPath === 'island') {
           return renderRsc({
             'slice:dynamic': (
@@ -62,10 +62,10 @@ export default adapter(
           App: appForMode(mode, input.rscPath || 'Waku', input.rscParams),
         });
       }
-      if (input.type === 'custom' && input.pathname === '/api/hello') {
+      if (input.type === 'http' && input.pathname === '/api/hello') {
         return new Response('world');
       }
-      if (input.type === 'custom') {
+      if (input.type === 'http') {
         const mode = modeFromPathname(input.pathname);
         const cookies = cookie.parseCookie(
           input.req.headers.get('cookie') || '',

--- a/e2e/fixtures/rsc-asset/src/waku.server.tsx
+++ b/e2e/fixtures/rsc-asset/src/waku.server.tsx
@@ -3,10 +3,10 @@ import App from './components/App.js';
 
 export default adapter({
   handleRequest: async (input, { renderRsc }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
     }
-    if (input.type === 'function') {
+    if (input.type === 'call') {
       const value = await input.fn(...input.args);
       return renderRsc({}, { value });
     }

--- a/e2e/fixtures/rsc-basic/src/waku.server.tsx
+++ b/e2e/fixtures/rsc-basic/src/waku.server.tsx
@@ -6,7 +6,7 @@ const BUILD_MATADATA_VALUE = 'metadata-value';
 
 export default adapter({
   handleRequest: async (input, { renderRsc, loadBuildMetadata }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({
         App: (
           <App
@@ -17,7 +17,7 @@ export default adapter({
         ),
       });
     }
-    if (input.type === 'function') {
+    if (input.type === 'call') {
       const value = await input.fn(...input.args);
       return renderRsc({}, { value });
     }

--- a/e2e/fixtures/rsc-css-modules/src/waku.server.tsx
+++ b/e2e/fixtures/rsc-css-modules/src/waku.server.tsx
@@ -3,10 +3,10 @@ import App from './components/App.js';
 
 export default adapter({
   handleRequest: async (input, { renderRsc }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
     }
-    if (input.type === 'function') {
+    if (input.type === 'call') {
       const value = await input.fn(...input.args);
       return renderRsc({}, { value });
     }

--- a/e2e/fixtures/ssr-basic/src/components/MixedForms.tsx
+++ b/e2e/fixtures/ssr-basic/src/components/MixedForms.tsx
@@ -1,0 +1,54 @@
+import { StatefulForm } from './StatefulForm.js';
+
+let echo = 'none';
+
+export const receivePlainPost = (formData: FormData) => {
+  echo = `custom:${String(formData.get('plain-field') || '')}`;
+};
+
+async function submitAction(formData: FormData) {
+  'use server';
+  echo = `action:${String(formData.get('name') || '')}`;
+}
+
+async function submitStateful(prev: string, _formData: FormData) {
+  'use server';
+  echo = 'action:stateful';
+  return `updated:${prev}`;
+}
+
+async function submitPermalink(prev: string, _formData: FormData) {
+  'use server';
+  echo = 'action:permalink';
+  return `updated:${prev}`;
+}
+
+export const MixedForms = () => (
+  <html>
+    <head>
+      <title>Mixed Forms</title>
+    </head>
+    <body>
+      <h2>Mixed Forms</h2>
+      <p data-testid="echo">{echo}</p>
+      <form action={submitAction}>
+        <input name="name" aria-label="Name" />
+        <button type="submit" data-testid="action-submit">
+          Action
+        </button>
+      </form>
+      <StatefulForm action={submitStateful} />
+      <StatefulForm
+        action={submitPermalink}
+        idPrefix="permalink"
+        permalink="/mixed-forms"
+      />
+      <form method="post" encType="multipart/form-data">
+        <input name="plain-field" defaultValue="plain-value" />
+        <button type="submit" data-testid="plain-submit">
+          Plain
+        </button>
+      </form>
+    </body>
+  </html>
+);

--- a/e2e/fixtures/ssr-basic/src/components/StatefulForm.tsx
+++ b/e2e/fixtures/ssr-basic/src/components/StatefulForm.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useActionState } from 'react';
+
+export const StatefulForm = ({
+  action,
+  idPrefix = 'stateful',
+  permalink,
+}: {
+  action: (prev: string, formData: FormData) => Promise<string>;
+  idPrefix?: string;
+  permalink?: string;
+}) => {
+  const [state, formAction] = useActionState(action, 'initial', permalink);
+  return (
+    <form action={formAction}>
+      <p data-testid={`${idPrefix}-state`}>{state}</p>
+      <button type="submit" data-testid={`${idPrefix}-submit`}>
+        Stateful
+      </button>
+    </form>
+  );
+};

--- a/e2e/fixtures/ssr-basic/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-basic/src/waku.client.tsx
@@ -9,6 +9,10 @@ if (window.location.pathname === '/test') {
   rscPath = 'test';
   slotId = 'TestApp';
 }
+if (window.location.pathname === '/mixed-forms') {
+  rscPath = 'mixed-forms';
+  slotId = 'MixedForms';
+}
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-basic/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-basic/src/waku.server.tsx
@@ -6,7 +6,7 @@ import TestApp from './components/test-app.js';
 
 export default adapter({
   handleRequest: async (input, { renderRsc, renderHtml }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       if (input.rscPath === 'test') {
         return renderRsc({ TestApp: <TestApp /> });
       }
@@ -15,30 +15,25 @@ export default adapter({
       }
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
     }
-    if (input.type === 'function') {
+    if (input.type === 'call') {
       const value = await input.fn(...input.args);
       return renderRsc({}, { value });
     }
-    if (input.type === 'action' && input.pathname === '/mixed-forms') {
-      const result = await input.fn();
-      if (!result.action) {
-        receivePlainPost(result.formData);
-      }
-      return renderHtml(
-        await renderRsc({ MixedForms: <MixedForms /> }),
-        <Slot id="MixedForms" />,
-        {
-          rscPath: 'mixed-forms',
-          formState: (result.action ? result.formState : undefined) as never,
-        },
-      );
-    }
-    if (input.type === 'custom') {
+    if (input.type === 'http') {
       if (input.pathname === '/mixed-forms') {
+        let formState: unknown;
+        if (input.tryAction) {
+          const result = await input.tryAction();
+          if (result.action) {
+            formState = result.formState;
+          } else {
+            receivePlainPost(result.formData);
+          }
+        }
         return renderHtml(
           await renderRsc({ MixedForms: <MixedForms /> }),
           <Slot id="MixedForms" />,
-          { rscPath: 'mixed-forms' },
+          { rscPath: 'mixed-forms', formState: formState as never },
         );
       }
       if (input.pathname === '/') {

--- a/e2e/fixtures/ssr-basic/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-basic/src/waku.server.tsx
@@ -1,6 +1,7 @@
 import adapter from 'waku/adapters/default';
 import { Slot } from 'waku/minimal/client';
 import App from './components/App.js';
+import { MixedForms, receivePlainPost } from './components/MixedForms.js';
 import TestApp from './components/test-app.js';
 
 export default adapter({
@@ -9,13 +10,37 @@ export default adapter({
       if (input.rscPath === 'test') {
         return renderRsc({ TestApp: <TestApp /> });
       }
+      if (input.rscPath === 'mixed-forms') {
+        return renderRsc({ MixedForms: <MixedForms /> });
+      }
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
     }
     if (input.type === 'function') {
       const value = await input.fn(...input.args);
       return renderRsc({}, { value });
     }
+    if (input.type === 'action' && input.pathname === '/mixed-forms') {
+      const result = await input.fn();
+      if (!result.action) {
+        receivePlainPost(result.formData);
+      }
+      return renderHtml(
+        await renderRsc({ MixedForms: <MixedForms /> }),
+        <Slot id="MixedForms" />,
+        {
+          rscPath: 'mixed-forms',
+          formState: (result.action ? result.formState : undefined) as never,
+        },
+      );
+    }
     if (input.type === 'custom') {
+      if (input.pathname === '/mixed-forms') {
+        return renderHtml(
+          await renderRsc({ MixedForms: <MixedForms /> }),
+          <Slot id="MixedForms" />,
+          { rscPath: 'mixed-forms' },
+        );
+      }
       if (input.pathname === '/') {
         return renderHtml(
           await renderRsc({ App: <App name="Waku" /> }),

--- a/e2e/fixtures/ssr-context-provider/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-context-provider/src/waku.server.tsx
@@ -4,14 +4,14 @@ import App from './components/app.js';
 
 export default adapter({
   handleRequest: async (input, { renderRsc, renderHtml }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App /> });
     }
-    if (input.type === 'function') {
+    if (input.type === 'call') {
       const value = await input.fn(...input.args);
       return renderRsc({}, { value });
     }
-    if (input.type === 'custom' && input.pathname === '/') {
+    if (input.type === 'http' && input.pathname === '/') {
       return renderHtml(await renderRsc({ App: <App /> }), <Slot id="App" />, {
         rscPath: '',
       });

--- a/e2e/fixtures/ssr-nonce/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-nonce/src/waku.server.tsx
@@ -7,10 +7,10 @@ const TEST_NONCE = 'test-nonce-12345';
 
 export default adapter({
   handleRequest: async (input, { renderRsc, renderHtml }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App /> });
     }
-    if (input.type === 'custom' && input.pathname === '/') {
+    if (input.type === 'http' && input.pathname === '/') {
       const response = await renderHtml(
         await renderRsc({ App: <App /> }),
         <Slot id="App" />,

--- a/e2e/fixtures/ssr-swr/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-swr/src/waku.server.tsx
@@ -4,14 +4,14 @@ import App from './components/App.js';
 
 export default adapter({
   handleRequest: async (input, { renderRsc, renderHtml }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
     }
-    if (input.type === 'function') {
+    if (input.type === 'call') {
       const value = await input.fn(...input.args);
       return renderRsc({}, { value });
     }
-    if (input.type === 'custom' && input.pathname === '/') {
+    if (input.type === 'http' && input.pathname === '/') {
       return renderHtml(
         await renderRsc({ App: <App name="Waku" /> }),
         <Slot id="App" />,

--- a/e2e/fixtures/ssr-target-bundle/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-target-bundle/src/waku.server.tsx
@@ -4,14 +4,14 @@ import App from './components/App.js';
 
 export default adapter({
   handleRequest: async (input, { renderRsc, renderHtml }) => {
-    if (input.type === 'component') {
+    if (input.type === 'rsc') {
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
     }
-    if (input.type === 'function') {
+    if (input.type === 'call') {
       const value = await input.fn(...input.args);
       return renderRsc({}, { value });
     }
-    if (input.type === 'custom' && input.pathname === '/') {
+    if (input.type === 'http' && input.pathname === '/') {
       return renderHtml(
         await renderRsc({ App: <App name="Waku" /> }),
         <Slot id="App" />,

--- a/e2e/fixtures/tanstack-router/src/waku.server.tsx
+++ b/e2e/fixtures/tanstack-router/src/waku.server.tsx
@@ -9,7 +9,7 @@ export default adapter({
     if (result) {
       return result;
     }
-    if (input.type === 'custom') {
+    if (input.type === 'http') {
       return router.handleRequest({ ...input, pathname: '/' }, utils);
     }
   },

--- a/e2e/ssr-basic.spec.ts
+++ b/e2e/ssr-basic.spec.ts
@@ -15,6 +15,33 @@ test.describe(`ssr-basic`, () => {
     await stopApp();
   });
 
+  test('mixed forms without js', async ({ browser }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+    try {
+      await page.goto(`http://localhost:${port}/mixed-forms`);
+      // a plain multipart form resolves as { action: false } with its data
+      await page.getByTestId('plain-submit').click();
+      await expect(page.getByTestId('echo')).toHaveText('custom:plain-value');
+      await page.getByLabel('Name').fill('nojs');
+      await page.getByTestId('action-submit').click();
+      await expect(page.getByTestId('echo')).toHaveText('action:nojs');
+      // useActionState: the POST response renders with the returned state
+      await page.getByTestId('stateful-submit').click();
+      await expect(page.getByTestId('echo')).toHaveText('action:stateful');
+      await expect(page.getByTestId('stateful-state')).toHaveText(
+        'updated:initial',
+      );
+      // useActionState with a bare permalink works as-is
+      await page.getByTestId('permalink-submit').click();
+      await expect(page.getByTestId('echo')).toHaveText('action:permalink');
+      expect(new URL(page.url()).pathname).toBe('/mixed-forms');
+    } finally {
+      await page.close();
+      await context.close();
+    }
+  });
+
   test('increase counter', async ({ page }) => {
     await page.goto(`http://localhost:${port}/`);
     await waitForHydration(page);

--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -36,20 +36,19 @@ export type Unstable_EmitFile = (
 
 export type Unstable_HandleRequest = (
   input: (
-    | { type: 'component'; rscPath: string; rscParams: unknown }
+    | { type: 'rsc'; rscPath: string; rscParams: unknown }
     | {
-        type: 'function';
+        type: 'call';
         fn: (...args: unknown[]) => Promise<unknown>;
         args: unknown[];
       }
     | {
-        type: 'action';
-        fn: () => Promise<
+        type: 'http';
+        tryAction?: () => Promise<
           | { action: true; formState: unknown }
           | { action: false; formData: FormData }
         >;
       }
-    | { type: 'custom' }
   ) & {
     pathname: string;
     req: Request;

--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -44,7 +44,10 @@ export type Unstable_HandleRequest = (
       }
     | {
         type: 'action';
-        fn: () => Promise<unknown>;
+        fn: () => Promise<
+          | { action: true; formState: unknown }
+          | { action: false; formData: FormData }
+        >;
       }
     | { type: 'custom' }
   ) & {

--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -72,19 +72,26 @@ export async function getInput(
       contentType.startsWith('multipart/form-data')
     ) {
       // possibly a no-js server action submission (progressive enhancement)
-      validateServerActionRequest(req);
+      let parsing:
+        | Promise<
+            | { action: true; formState: unknown }
+            | { action: false; formData: FormData }
+          >
+        | undefined;
       input = {
         type: 'http',
-        tryAction: async () => {
-          const formData = (await getActionBody(req)) as FormData;
-          const decodedAction = await decodeAction(formData);
-          if (typeof decodedAction !== 'function') {
-            return { action: false as const, formData };
-          }
-          const result = await decodedAction();
-          const formState = await decodeFormState(result, formData);
-          return { action: true as const, formState };
-        },
+        tryAction: () =>
+          (parsing ??= (async () => {
+            const formData = (await getActionBody(req)) as FormData;
+            const decodedAction = await decodeAction(formData);
+            if (typeof decodedAction !== 'function') {
+              return { action: false as const, formData };
+            }
+            validateServerActionRequest(req);
+            const result = await decodedAction();
+            const formState = await decodeFormState(result, formData);
+            return { action: true as const, formState };
+          })()),
         pathname,
         req,
         etags,

--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -79,11 +79,11 @@ export async function getInput(
           const formData = (await getActionBody(req)) as FormData;
           const decodedAction = await decodeAction(formData);
           if (typeof decodedAction !== 'function') {
-            // multipart/form-data POST without an action reference (e.g. crawlers)
-            throw createCustomError('Bad Request', { status: 400 });
+            return { action: false as const, formData };
           }
           const result = await decodedAction();
-          return await decodeFormState(result, formData);
+          const formState = await decodeFormState(result, formData);
+          return { action: true as const, formState };
         },
         pathname,
         req,

--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -39,7 +39,7 @@ export async function getInput(
       const args = await decodeReply(body, { temporaryReferences });
       const action = await loadServerAction(actionId);
       input = {
-        type: 'function',
+        type: 'call',
         fn: action as never,
         args,
         pathname,
@@ -57,7 +57,7 @@ export async function getInput(
         });
       }
       input = {
-        type: 'component',
+        type: 'rsc',
         rscPath,
         rscParams,
         pathname,
@@ -71,11 +71,11 @@ export async function getInput(
       typeof contentType === 'string' &&
       contentType.startsWith('multipart/form-data')
     ) {
-      // server action: no js (progressive enhancement)
+      // possibly a no-js server action submission (progressive enhancement)
       validateServerActionRequest(req);
       input = {
-        type: 'action',
-        fn: async () => {
+        type: 'http',
+        tryAction: async () => {
           const formData = (await getActionBody(req)) as FormData;
           const decodedAction = await decodeAction(formData);
           if (typeof decodedAction !== 'function') {
@@ -92,7 +92,7 @@ export async function getInput(
     } else {
       // POST API request
       input = {
-        type: 'custom',
+        type: 'http',
         pathname,
         req,
         etags,
@@ -101,7 +101,7 @@ export async function getInput(
   } else {
     // SSR
     input = {
-      type: 'custom',
+      type: 'http',
       pathname,
       req,
       etags,

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -1005,7 +1005,7 @@ export function unstable_defineRouter(fns: {
             const { value, entries: rerendered } = await withRerender(() =>
               input.fn(),
             );
-            formState = value;
+            formState = value.action ? value.formState : undefined;
             entries = {
               elements: { ...entries.elements, ...rerendered.elements },
               etags: { ...entries.etags, ...rerendered.etags },

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -899,7 +899,7 @@ export function unstable_defineRouter(fns: {
         }
       };
 
-      if (input.type === 'component') {
+      if (input.type === 'rsc') {
         const sliceId = decodeSliceId(input.rscPath);
         if (sliceId !== null) {
           // LIMITATION: This is a single slice request.
@@ -943,7 +943,7 @@ export function unstable_defineRouter(fns: {
         return renderRsc(entries.elements, { etags: entries.etags });
       }
 
-      if (input.type === 'function') {
+      if (input.type === 'call') {
         try {
           const { value, entries } = await withRerender(() =>
             input.fn(...input.args),
@@ -969,7 +969,7 @@ export function unstable_defineRouter(fns: {
         }
       }
 
-      if (input.type === 'action' || input.type === 'custom') {
+      if (input.type === 'http') {
         const pathConfigItem = getPathConfigItem(input.pathname);
         if (pathConfigItem?.type === 'api') {
           const url = new URL(input.req.url);
@@ -1001,9 +1001,9 @@ export function unstable_defineRouter(fns: {
           const nonce = getNonce();
           const html = <INTERNAL_ServerRouter route={route} />;
           let formState: unknown;
-          if (input.type === 'action') {
-            const { value, entries: rerendered } = await withRerender(() =>
-              input.fn(),
+          if (input.tryAction) {
+            const { value, entries: rerendered } = await withRerender(
+              input.tryAction,
             );
             formState = value.action ? value.formState : undefined;
             entries = {

--- a/packages/waku/tests/define-router-action.test.ts
+++ b/packages/waku/tests/define-router-action.test.ts
@@ -187,7 +187,7 @@ describe('define-router action requests', () => {
         fn: async () => {
           message = 'after';
           unstable_rerenderRoute('/');
-          return 'form-state';
+          return { action: true as const, formState: 'form-state' };
         },
         pathname: '/',
         req: new Request('http://localhost/', { method: 'POST' }),
@@ -251,7 +251,7 @@ describe('define-router action requests', () => {
         fn: async () => {
           message = 'after';
           unstable_rerenderRoute('/');
-          return 'form-state';
+          return { action: true as const, formState: 'form-state' };
         },
         pathname: '/',
         req: new Request('http://localhost/', { method: 'POST' }),

--- a/packages/waku/tests/define-router-action.test.ts
+++ b/packages/waku/tests/define-router-action.test.ts
@@ -52,7 +52,7 @@ describe('define-router action requests', () => {
 
     await handleRequest(
       {
-        type: 'component',
+        type: 'rsc',
         pathname: '/RSC/R/about',
         rscPath: encodeRoutePath('/about'),
         rscParams: undefined,
@@ -94,7 +94,7 @@ describe('define-router action requests', () => {
 
     await handleRequest(
       {
-        type: 'function',
+        type: 'call',
         pathname: '/RSC/F/actions/submit.txt',
         fn: actionFn,
         args: ['arg'],
@@ -137,7 +137,7 @@ describe('define-router action requests', () => {
 
     await handleRequest(
       {
-        type: 'custom',
+        type: 'http',
         pathname: '/missing',
         req: new Request('http://localhost/missing'),
       },
@@ -183,8 +183,8 @@ describe('define-router action requests', () => {
 
     const res = await handleRequest(
       {
-        type: 'action',
-        fn: async () => {
+        type: 'http',
+        tryAction: async () => {
           message = 'after';
           unstable_rerenderRoute('/');
           return { action: true as const, formState: 'form-state' };
@@ -247,8 +247,8 @@ describe('define-router action requests', () => {
 
     const res = await handleRequest(
       {
-        type: 'action',
-        fn: async () => {
+        type: 'http',
+        tryAction: async () => {
           message = 'after';
           unstable_rerenderRoute('/');
           return { action: true as const, formState: 'form-state' };
@@ -301,8 +301,8 @@ describe('define-router action requests', () => {
 
     const res = await handleRequest(
       {
-        type: 'action',
-        fn: actionFn,
+        type: 'http',
+        tryAction: actionFn,
         pathname: '/api/form-data',
         req: new Request('http://localhost/api/form-data', {
           method: 'POST',

--- a/packages/waku/tests/define-router-etag.test.ts
+++ b/packages/waku/tests/define-router-etag.test.ts
@@ -62,7 +62,7 @@ const drive = async (
   let captured: Record<string, unknown> = {};
   await router.handleRequest(
     {
-      type: 'component',
+      type: 'rsc',
       pathname: '/foo',
       rscPath,
       rscParams: undefined,

--- a/packages/waku/tests/define-router-interceptors.test.ts
+++ b/packages/waku/tests/define-router-interceptors.test.ts
@@ -47,7 +47,7 @@ const callHandleRequest = (
 ) =>
   router.handleRequest(
     {
-      type: 'custom',
+      type: 'http',
       pathname,
       req: new Request(`http://localhost${pathname}`),
     },

--- a/packages/waku/tests/define-router-static-build.test.ts
+++ b/packages/waku/tests/define-router-static-build.test.ts
@@ -321,7 +321,7 @@ describe('define-router handleBuild', () => {
       loadBuildMetadata,
     };
     const makeReq = () => ({
-      type: 'component' as const,
+      type: 'rsc' as const,
       rscPath: 'R/foo',
       rscParams: undefined,
       pathname: '/foo',

--- a/packages/waku/tests/request.test.ts
+++ b/packages/waku/tests/request.test.ts
@@ -40,7 +40,7 @@ describe('getInput server action request validation', () => {
   it('accepts same-origin server function requests', async () => {
     const input = await makeInput(makeRequest({ origin: 'https://app.test' }));
 
-    expect(input.type).toBe('function');
+    expect(input.type).toBe('call');
   });
 
   it('rejects server function requests with non-POST methods', async () => {
@@ -84,13 +84,13 @@ describe('getInput server action request validation', () => {
       makeRequest({ 'sec-fetch-site': 'same-origin' }),
     );
 
-    expect(input.type).toBe('function');
+    expect(input.type).toBe('call');
   });
 
   it('accepts user-initiated server function requests (sec-fetch-site: none)', async () => {
     const input = await makeInput(makeRequest({ 'sec-fetch-site': 'none' }));
 
-    expect(input.type).toBe('function');
+    expect(input.type).toBe('call');
   });
 
   it('accepts server function requests after middleware rewrites origin', async () => {
@@ -102,7 +102,7 @@ describe('getInput server action request validation', () => {
       }),
     );
 
-    expect(input.type).toBe('function');
+    expect(input.type).toBe('call');
   });
 
   it('rejects cross-origin form action requests', async () => {
@@ -146,11 +146,11 @@ describe('getInput server action request validation', () => {
       vi.fn(),
     );
 
-    expect(input.type).toBe('action');
-    if (input.type !== 'action') {
+    expect(input.type).toBe('http');
+    if (input.type !== 'http') {
       throw new Error('unreachable');
     }
-    const result = await input.fn();
+    const result = await input.tryAction!();
     expect(result).toMatchObject({ action: false });
     if (result.action) {
       throw new Error('unreachable');

--- a/packages/waku/tests/request.test.ts
+++ b/packages/waku/tests/request.test.ts
@@ -128,7 +128,7 @@ describe('getInput server action request validation', () => {
     ).resolves.toBe(403);
   });
 
-  it('rejects form action requests without an action reference', async () => {
+  it('resolves form action requests without an action reference as form data', async () => {
     const formData = new FormData();
     formData.set('key', 'value');
 
@@ -150,7 +150,12 @@ describe('getInput server action request validation', () => {
     if (input.type !== 'action') {
       throw new Error('unreachable');
     }
-    await expect(getStatus(input.fn())).resolves.toBe(400);
+    const result = await input.fn();
+    expect(result).toMatchObject({ action: false });
+    if (result.action) {
+      throw new Error('unreachable');
+    }
+    expect(result.formData.get('key')).toBe('value');
   });
 });
 

--- a/packages/waku/tests/request.test.ts
+++ b/packages/waku/tests/request.test.ts
@@ -105,27 +105,82 @@ describe('getInput server action request validation', () => {
     expect(input.type).toBe('call');
   });
 
-  it('rejects cross-origin form action requests', async () => {
+  it('delivers cross-origin multipart posts without an action reference', async () => {
     const formData = new FormData();
     formData.set('key', 'value');
 
-    await expect(
-      getStatus(
-        getInput(
-          new Request('https://app.test/', {
-            method: 'POST',
-            body: formData,
-            headers: { origin: 'https://evil.test' },
-          }),
-          makeConfig(),
-          undefined,
-          vi.fn(),
-          vi.fn(),
-          vi.fn(),
-          vi.fn(),
-        ),
-      ),
-    ).resolves.toBe(403);
+    const input = await getInput(
+      new Request('https://app.test/', {
+        method: 'POST',
+        body: formData,
+        headers: { origin: 'https://evil.test' },
+      }),
+      makeConfig(),
+      undefined,
+      vi.fn(),
+      vi.fn().mockResolvedValue(null),
+      vi.fn(),
+      vi.fn(),
+    );
+
+    if (input.type !== 'http') {
+      throw new Error('unreachable');
+    }
+    await expect(input.tryAction!()).resolves.toMatchObject({ action: false });
+  });
+
+  it('rejects cross-origin posts only when an action is decoded', async () => {
+    const formData = new FormData();
+    formData.set('key', 'value');
+    const decodedAction = vi.fn();
+
+    const input = await getInput(
+      new Request('https://app.test/', {
+        method: 'POST',
+        body: formData,
+        headers: { origin: 'https://evil.test' },
+      }),
+      makeConfig(),
+      undefined,
+      vi.fn(),
+      vi.fn().mockResolvedValue(decodedAction),
+      vi.fn(),
+      vi.fn(),
+    );
+
+    if (input.type !== 'http') {
+      throw new Error('unreachable');
+    }
+    await expect(getStatus(input.tryAction!())).resolves.toBe(403);
+    expect(decodedAction).not.toHaveBeenCalled();
+  });
+
+  it('memoizes tryAction across calls', async () => {
+    const formData = new FormData();
+    formData.set('key', 'value');
+    const decodeAction = vi.fn().mockResolvedValue(null);
+
+    const input = await getInput(
+      new Request('https://app.test/', {
+        method: 'POST',
+        body: formData,
+        headers: { origin: 'https://app.test' },
+      }),
+      makeConfig(),
+      undefined,
+      vi.fn(),
+      decodeAction,
+      vi.fn(),
+      vi.fn(),
+    );
+
+    if (input.type !== 'http') {
+      throw new Error('unreachable');
+    }
+    const first = input.tryAction!();
+    expect(input.tryAction!()).toBe(first);
+    await first;
+    expect(decodeAction).toHaveBeenCalledTimes(1);
   });
 
   it('resolves form action requests without an action reference as form data', async () => {


### PR DESCRIPTION
## Motivation

Waku cannot identify a no-JS server action submission from the method and headers alone. The evidence, an `$ACTION_*` field, is inside the multipart body, which can only be read once. Every multipart POST was therefore classified as an action, so ordinary form posts and crawler probes hit the action path (a 500 before #2185, a 400 after) and their bodies were consumed by the framework.

We compared three approaches:

- #2191 marks the form action URL with a query param, so actions are identifiable before reading the body. It requires reproducing React's default `encodeFormAction` internals, and the marker stays in the document URL after a no-JS submission.
- #2201 removes the action type entirely and gives `handleRequest` raw decoding utils. It is the most flexible, but every handler must reproduce the decode protocol correctly.
- This PR admits that a multipart POST is only potentially an action until the body is read, and keeps the decoding centralized.

## Changes

- The `handleRequest` input types are now `rsc`, `call`, and `http`.
- A multipart POST is an `http` request with an optional `tryAction()`. Calling it consumes the body and resolves `{ action: true, formState }` for a decoded server action, or `{ action: false, formData }` for an ordinary form post, to route to regular POST handling.
- `tryAction` is memoized and rejects cross-origin requests only when they carry an action reference.
- `unstable_defineRouter` probes `tryAction` after the API route check, so API routes receive untouched bodies.

This is a breaking change to the unstable minimal API: `type: 'action'` and `type: 'custom'` are gone, and `component` and `function` are renamed.