### PR TITLE
refactor(define-router): split config utils

### DIFF
--- a/packages/waku/src/router/define-router-utils/config-serialization.ts
+++ b/packages/waku/src/router/define-router-utils/config-serialization.ts
@@ -1,0 +1,176 @@
+import { pathSpecAsString } from '../isomorphic-utils/path-spec.js';
+import type { PathSpec } from '../isomorphic-utils/path-spec.js';
+import type {
+  ApiConfig,
+  RouteConfig,
+  RuntimeConfig,
+  SerializableConfig,
+  SliceConfig,
+  SlotId,
+} from './config-types.js';
+
+export const pathSpecKey = (p: PathSpec) => JSON.stringify(p);
+
+export const toSerializable = (c: RuntimeConfig): SerializableConfig => {
+  if (c.type === 'route') {
+    const {
+      rootElement,
+      routeElement,
+      elements,
+      searchCodec: _searchCodec,
+      ...rest
+    } = c;
+    const {
+      renderer: _rootRenderer,
+      getEtagFromOption: _rootGetEtag,
+      ...rootElementRest
+    } = rootElement;
+    const {
+      renderer: _routeRenderer,
+      getEtagFromOption: _routeGetEtag,
+      ...routeElementRest
+    } = routeElement;
+    return {
+      ...rest,
+      rootElement: rootElementRest,
+      routeElement: routeElementRest,
+      elements: Object.fromEntries(
+        Object.entries(elements).map(
+          ([id, { renderer: _r, getEtagFromOption: _g, ...elRest }]) => [
+            id,
+            elRest,
+          ],
+        ),
+      ),
+    };
+  }
+  if (c.type === 'api') {
+    const { handler: _handler, ...rest } = c;
+    return rest;
+  }
+  const { renderer: _r, getEtagFromParams: _g, ...rest } = c;
+  return rest;
+};
+
+const noRuntimeFn = (what: string): never => {
+  throw new Error(
+    `defineRouter: no runtime function found for ${what}; rebuild required`,
+  );
+};
+
+// `rootElement.renderer` and per-id element renderers are shared
+// across routes - any one is a valid fallback for another.
+export const mergeWithRuntimeConfigs = (
+  serializableConfigs: SerializableConfig[],
+  runtimeConfigs: RuntimeConfig[],
+): RuntimeConfig[] => {
+  const runtimeRouteByPath = new Map<string, RouteConfig>();
+  const runtimeApiByPath = new Map<string, ApiConfig>();
+  const runtimeSliceById = new Map<string, SliceConfig>();
+  for (const c of runtimeConfigs) {
+    if (c.type === 'route') {
+      runtimeRouteByPath.set(pathSpecKey(c.path), c);
+    } else if (c.type === 'api') {
+      runtimeApiByPath.set(pathSpecKey(c.path), c);
+    } else {
+      runtimeSliceById.set(c.id, c);
+    }
+  }
+  const sharedRootRenderer = runtimeConfigs.find(
+    (c): c is RouteConfig => c.type === 'route',
+  )?.rootElement.renderer;
+  const sharedElementRenderers = new Map<
+    SlotId,
+    RouteConfig['elements'][string]['renderer']
+  >();
+  for (const c of runtimeConfigs) {
+    if (c.type !== 'route') {
+      continue;
+    }
+    for (const [id, el] of Object.entries(c.elements)) {
+      if (!sharedElementRenderers.has(id)) {
+        sharedElementRenderers.set(id, el.renderer);
+      }
+    }
+  }
+  return serializableConfigs.map((c) => {
+    if (c.type === 'route') {
+      const runtimeItem = runtimeRouteByPath.get(pathSpecKey(c.path));
+      const label = `route ${pathSpecAsString(c.path)}`;
+      const elements: RouteConfig['elements'] = {};
+      for (const [id, val] of Object.entries(c.elements)) {
+        const elementSpec = runtimeItem?.elements[id];
+        elements[id] = {
+          isStatic: val.isStatic,
+          renderer:
+            elementSpec?.renderer ??
+            sharedElementRenderers.get(id) ??
+            (() => noRuntimeFn(`element "${id}" of ${label}`)),
+          ...(elementSpec?.getEtagFromOption
+            ? { getEtagFromOption: elementSpec.getEtagFromOption }
+            : {}),
+          ...(val.sourceFile ? { sourceFile: val.sourceFile } : {}),
+        };
+      }
+      return {
+        type: 'route',
+        path: c.path,
+        isStatic: c.isStatic,
+        ...(c.pathPattern !== undefined ? { pathPattern: c.pathPattern } : {}),
+        rootElement: {
+          isStatic: c.rootElement.isStatic,
+          renderer:
+            runtimeItem?.rootElement.renderer ??
+            sharedRootRenderer ??
+            (() => noRuntimeFn(`rootElement of ${label}`)),
+          ...(runtimeItem?.rootElement.getEtagFromOption
+            ? { getEtagFromOption: runtimeItem.rootElement.getEtagFromOption }
+            : {}),
+          ...(c.rootElement.sourceFile
+            ? { sourceFile: c.rootElement.sourceFile }
+            : {}),
+        },
+        routeElement: {
+          isStatic: c.routeElement.isStatic,
+          renderer:
+            runtimeItem?.routeElement.renderer ??
+            (() => noRuntimeFn(`routeElement of ${label}`)),
+          ...(runtimeItem?.routeElement.getEtagFromOption
+            ? { getEtagFromOption: runtimeItem.routeElement.getEtagFromOption }
+            : {}),
+        },
+        elements,
+        ...(c.noSsr !== undefined ? { noSsr: c.noSsr } : {}),
+        ...(c.slices !== undefined ? { slices: c.slices } : {}),
+        ...(runtimeItem?.searchCodec !== undefined
+          ? { searchCodec: runtimeItem.searchCodec }
+          : {}),
+      };
+    }
+    if (c.type === 'api') {
+      const runtimeItem = runtimeApiByPath.get(pathSpecKey(c.path));
+      return {
+        type: 'api',
+        path: c.path,
+        isStatic: c.isStatic,
+        handler:
+          runtimeItem?.handler ??
+          (async () => noRuntimeFn(`api ${pathSpecAsString(c.path)}`)),
+        ...(c.sourceFile ? { sourceFile: c.sourceFile } : {}),
+      };
+    }
+    const runtimeItem = runtimeSliceById.get(c.id);
+    return {
+      type: 'slice',
+      id: c.id,
+      ...(c.pathSpec !== undefined ? { pathSpec: c.pathSpec } : {}),
+      isStatic: c.isStatic,
+      renderer:
+        runtimeItem?.renderer ?? (async () => noRuntimeFn(`slice ${c.id}`)),
+      ...(runtimeItem?.getEtagFromParams
+        ? { getEtagFromParams: runtimeItem.getEtagFromParams }
+        : {}),
+      ...(c.sourceFile ? { sourceFile: c.sourceFile } : {}),
+    };
+  });
+};

--- a/packages/waku/src/router/define-router-utils/config-types.ts
+++ b/packages/waku/src/router/define-router-utils/config-types.ts
@@ -1,0 +1,99 @@
+import type { ReactNode } from 'react';
+import type { PathSpec } from '../isomorphic-utils/path-spec.js';
+import type { Unstable_SearchCodec } from '../isomorphic-utils/search-codec-registry.js';
+
+export type ApiHandler = (
+  req: Request,
+  apiContext: { params: Record<string, string | string[]> },
+) => Promise<Response>;
+
+export type HandlerInterceptor = <T>(next: () => Promise<T>) => Promise<T>;
+
+export type SlotId = string;
+
+export type RendererOption = { routePath: string; query: string | undefined };
+
+export type GetEtagFromOption = (
+  option: RendererOption,
+) => Promise<string | undefined>;
+export type GetEtagFromParams = (
+  params?: Record<string, string | string[]>,
+) => Promise<string | undefined>;
+
+export type RouteConfig = {
+  type: 'route';
+  path: PathSpec;
+  isStatic: boolean;
+  pathPattern?: PathSpec;
+  rootElement: {
+    isStatic: boolean;
+    renderer: (option: RendererOption) => ReactNode;
+    getEtagFromOption?: GetEtagFromOption;
+    sourceFile?: string;
+  };
+  routeElement: {
+    isStatic: boolean;
+    renderer: (option: RendererOption) => ReactNode;
+    getEtagFromOption?: GetEtagFromOption;
+  };
+  elements: Record<
+    SlotId,
+    {
+      isStatic: boolean;
+      renderer: (option: RendererOption) => ReactNode;
+      getEtagFromOption?: GetEtagFromOption;
+      sourceFile?: string;
+    }
+  >;
+  noSsr?: boolean;
+  slices?: string[];
+  searchCodec?: Unstable_SearchCodec<any>;
+};
+
+export type ApiConfig = {
+  type: 'api';
+  path: PathSpec;
+  isStatic: boolean;
+  handler: ApiHandler;
+  sourceFile?: string;
+};
+
+export type SliceConfig = {
+  type: 'slice';
+  id: string;
+  pathSpec?: PathSpec;
+  isStatic: boolean;
+  renderer: (params?: Record<string, string | string[]>) => Promise<ReactNode>;
+  getEtagFromParams?: GetEtagFromParams;
+  sourceFile?: string;
+};
+
+export type RuntimeConfig = RouteConfig | ApiConfig | SliceConfig;
+
+export type SerializableRouteConfig = Omit<
+  RouteConfig,
+  'rootElement' | 'routeElement' | 'elements' | 'searchCodec'
+> & {
+  rootElement: Omit<
+    RouteConfig['rootElement'],
+    'renderer' | 'getEtagFromOption'
+  >;
+  routeElement: Omit<
+    RouteConfig['routeElement'],
+    'renderer' | 'getEtagFromOption'
+  >;
+  elements: Record<
+    SlotId,
+    Omit<RouteConfig['elements'][string], 'renderer' | 'getEtagFromOption'>
+  >;
+};
+
+export type SerializableApiConfig = Omit<ApiConfig, 'handler'>;
+
+export type SerializableSliceConfig = Omit<
+  SliceConfig,
+  'renderer' | 'getEtagFromParams'
+>;
+
+export type SerializableConfig =
+  SerializableRouteConfig | SerializableApiConfig | SerializableSliceConfig;

--- a/packages/waku/src/router/define-router.tsx
+++ b/packages/waku/src/router/define-router.tsx
@@ -13,6 +13,22 @@ import type {
 } from '../minimal/server.js';
 import { deserializeRsc, serializeRsc } from '../server.js';
 import { INTERNAL_ServerRouter } from './client.js';
+import {
+  mergeWithRuntimeConfigs,
+  pathSpecKey,
+  toSerializable,
+} from './define-router-utils/config-serialization.js';
+import type {
+  ApiHandler,
+  GetEtagFromParams,
+  HandlerInterceptor,
+  RendererOption,
+  RouteConfig,
+  RuntimeConfig,
+  SerializableConfig,
+  SliceConfig,
+  SlotId,
+} from './define-router-utils/config-types.js';
 import { path2regexp } from './define-router-utils/path-spec.js';
 import {
   getHeaders,
@@ -52,11 +68,6 @@ import {
 } from './isomorphic-utils/route-path.js';
 import type { Unstable_SearchCodec } from './isomorphic-utils/search-codec-registry.js';
 
-export type ApiHandler = (
-  req: Request,
-  apiContext: { params: Record<string, string | string[]> },
-) => Promise<Response>;
-
 const parseRscParams = (
   rscParams: unknown,
 ): {
@@ -73,8 +84,6 @@ const parseRscParams = (
   return { query: '' };
 };
 
-export type HandlerInterceptor = <T>(next: () => Promise<T>) => Promise<T>;
-
 export {
   getRequest as unstable_getRequest,
   getHeaders as unstable_getHeaders,
@@ -82,6 +91,7 @@ export {
   getRscParams as unstable_getRscParams,
   setNonce as unstable_setNonce,
 };
+export type { ApiHandler, HandlerInterceptor };
 
 const is404 = (pathSpec: PathSpec) =>
   pathSpec.length === 1 &&
@@ -131,8 +141,6 @@ export function unstable_redirect<Path extends RoutePath = RoutePath>(
   }
   throw createCustomError('Redirect', { status, location });
 }
-
-type SlotId = string;
 
 type RouteEntries = {
   elements: Record<string, unknown>;
@@ -197,264 +205,11 @@ const assertNonReservedSlotId = (slotId: SlotId) => {
   }
 };
 
-type RendererOption = { routePath: string; query: string | undefined };
-
-type GetEtagFromOption = (
-  option: RendererOption,
-) => Promise<string | undefined>;
-type GetEtagFromParams = (
-  params?: Record<string, string | string[]>,
-) => Promise<string | undefined>;
-
 const bindEtag = <A,>(
   getEtag: ((arg: A) => Promise<string | undefined>) | undefined,
   arg: A,
 ): (() => Promise<string | undefined>) | undefined =>
   getEtag && (() => getEtag(arg));
-
-type RouteConfig = {
-  type: 'route';
-  path: PathSpec;
-  isStatic: boolean;
-  pathPattern?: PathSpec;
-  rootElement: {
-    isStatic: boolean;
-    renderer: (option: RendererOption) => ReactNode;
-    getEtagFromOption?: GetEtagFromOption;
-    sourceFile?: string;
-  };
-  routeElement: {
-    isStatic: boolean;
-    renderer: (option: RendererOption) => ReactNode;
-    getEtagFromOption?: GetEtagFromOption;
-  };
-  elements: Record<
-    SlotId,
-    {
-      isStatic: boolean;
-      renderer: (option: RendererOption) => ReactNode;
-      getEtagFromOption?: GetEtagFromOption;
-      sourceFile?: string;
-    }
-  >;
-  noSsr?: boolean;
-  slices?: string[];
-  searchCodec?: Unstable_SearchCodec<any>;
-};
-
-type ApiConfig = {
-  type: 'api';
-  path: PathSpec;
-  isStatic: boolean;
-  handler: ApiHandler;
-  sourceFile?: string;
-};
-
-type SliceConfig = {
-  type: 'slice';
-  id: string;
-  pathSpec?: PathSpec;
-  isStatic: boolean;
-  renderer: (params?: Record<string, string | string[]>) => Promise<ReactNode>;
-  getEtagFromParams?: GetEtagFromParams;
-  sourceFile?: string;
-};
-
-type RuntimeConfig = RouteConfig | ApiConfig | SliceConfig;
-
-type SerializableRouteConfig = Omit<
-  RouteConfig,
-  'rootElement' | 'routeElement' | 'elements' | 'searchCodec'
-> & {
-  rootElement: Omit<
-    RouteConfig['rootElement'],
-    'renderer' | 'getEtagFromOption'
-  >;
-  routeElement: Omit<
-    RouteConfig['routeElement'],
-    'renderer' | 'getEtagFromOption'
-  >;
-  elements: Record<
-    SlotId,
-    Omit<RouteConfig['elements'][string], 'renderer' | 'getEtagFromOption'>
-  >;
-};
-
-type SerializableApiConfig = Omit<ApiConfig, 'handler'>;
-
-type SerializableSliceConfig = Omit<
-  SliceConfig,
-  'renderer' | 'getEtagFromParams'
->;
-
-type SerializableConfig =
-  SerializableRouteConfig | SerializableApiConfig | SerializableSliceConfig;
-
-const toSerializable = (c: RuntimeConfig): SerializableConfig => {
-  if (c.type === 'route') {
-    const {
-      rootElement,
-      routeElement,
-      elements,
-      searchCodec: _searchCodec,
-      ...rest
-    } = c;
-    const {
-      renderer: _rootRenderer,
-      getEtagFromOption: _rootGetEtag,
-      ...rootElementRest
-    } = rootElement;
-    const {
-      renderer: _routeRenderer,
-      getEtagFromOption: _routeGetEtag,
-      ...routeElementRest
-    } = routeElement;
-    return {
-      ...rest,
-      rootElement: rootElementRest,
-      routeElement: routeElementRest,
-      elements: Object.fromEntries(
-        Object.entries(elements).map(
-          ([id, { renderer: _r, getEtagFromOption: _g, ...elRest }]) => [
-            id,
-            elRest,
-          ],
-        ),
-      ),
-    };
-  }
-  if (c.type === 'api') {
-    const { handler: _handler, ...rest } = c;
-    return rest;
-  }
-  const { renderer: _r, getEtagFromParams: _g, ...rest } = c;
-  return rest;
-};
-
-const pathSpecKey = (p: PathSpec) => JSON.stringify(p);
-
-const noRuntimeFn = (what: string): never => {
-  throw new Error(
-    `defineRouter: no runtime function found for ${what}; rebuild required`,
-  );
-};
-
-// `rootElement.renderer` and per-id element renderers are shared
-// across routes - any one is a valid fallback for another.
-const mergeWithRuntimeConfigs = (
-  serializableConfigs: SerializableConfig[],
-  runtimeConfigs: RuntimeConfig[],
-): RuntimeConfig[] => {
-  const runtimeRouteByPath = new Map<string, RouteConfig>();
-  const runtimeApiByPath = new Map<string, ApiConfig>();
-  const runtimeSliceById = new Map<string, SliceConfig>();
-  for (const c of runtimeConfigs) {
-    if (c.type === 'route') {
-      runtimeRouteByPath.set(pathSpecKey(c.path), c);
-    } else if (c.type === 'api') {
-      runtimeApiByPath.set(pathSpecKey(c.path), c);
-    } else {
-      runtimeSliceById.set(c.id, c);
-    }
-  }
-  const sharedRootRenderer = runtimeConfigs.find(
-    (c): c is RouteConfig => c.type === 'route',
-  )?.rootElement.renderer;
-  const sharedElementRenderers = new Map<
-    SlotId,
-    RouteConfig['elements'][string]['renderer']
-  >();
-  for (const c of runtimeConfigs) {
-    if (c.type !== 'route') {
-      continue;
-    }
-    for (const [id, el] of Object.entries(c.elements)) {
-      if (!sharedElementRenderers.has(id)) {
-        sharedElementRenderers.set(id, el.renderer);
-      }
-    }
-  }
-  return serializableConfigs.map((c) => {
-    if (c.type === 'route') {
-      const runtimeItem = runtimeRouteByPath.get(pathSpecKey(c.path));
-      const label = `route ${pathSpecAsString(c.path)}`;
-      const elements: RouteConfig['elements'] = {};
-      for (const [id, val] of Object.entries(c.elements)) {
-        const elementSpec = runtimeItem?.elements[id];
-        elements[id] = {
-          isStatic: val.isStatic,
-          renderer:
-            elementSpec?.renderer ??
-            sharedElementRenderers.get(id) ??
-            (() => noRuntimeFn(`element "${id}" of ${label}`)),
-          ...(elementSpec?.getEtagFromOption
-            ? { getEtagFromOption: elementSpec.getEtagFromOption }
-            : {}),
-          ...(val.sourceFile ? { sourceFile: val.sourceFile } : {}),
-        };
-      }
-      return {
-        type: 'route',
-        path: c.path,
-        isStatic: c.isStatic,
-        ...(c.pathPattern !== undefined ? { pathPattern: c.pathPattern } : {}),
-        rootElement: {
-          isStatic: c.rootElement.isStatic,
-          renderer:
-            runtimeItem?.rootElement.renderer ??
-            sharedRootRenderer ??
-            (() => noRuntimeFn(`rootElement of ${label}`)),
-          ...(runtimeItem?.rootElement.getEtagFromOption
-            ? { getEtagFromOption: runtimeItem.rootElement.getEtagFromOption }
-            : {}),
-          ...(c.rootElement.sourceFile
-            ? { sourceFile: c.rootElement.sourceFile }
-            : {}),
-        },
-        routeElement: {
-          isStatic: c.routeElement.isStatic,
-          renderer:
-            runtimeItem?.routeElement.renderer ??
-            (() => noRuntimeFn(`routeElement of ${label}`)),
-          ...(runtimeItem?.routeElement.getEtagFromOption
-            ? { getEtagFromOption: runtimeItem.routeElement.getEtagFromOption }
-            : {}),
-        },
-        elements,
-        ...(c.noSsr !== undefined ? { noSsr: c.noSsr } : {}),
-        ...(c.slices !== undefined ? { slices: c.slices } : {}),
-        ...(runtimeItem?.searchCodec !== undefined
-          ? { searchCodec: runtimeItem.searchCodec }
-          : {}),
-      };
-    }
-    if (c.type === 'api') {
-      const runtimeItem = runtimeApiByPath.get(pathSpecKey(c.path));
-      return {
-        type: 'api',
-        path: c.path,
-        isStatic: c.isStatic,
-        handler:
-          runtimeItem?.handler ??
-          (async () => noRuntimeFn(`api ${pathSpecAsString(c.path)}`)),
-        ...(c.sourceFile ? { sourceFile: c.sourceFile } : {}),
-      };
-    }
-    const runtimeItem = runtimeSliceById.get(c.id);
-    return {
-      type: 'slice',
-      id: c.id,
-      ...(c.pathSpec !== undefined ? { pathSpec: c.pathSpec } : {}),
-      isStatic: c.isStatic,
-      renderer:
-        runtimeItem?.renderer ?? (async () => noRuntimeFn(`slice ${c.id}`)),
-      ...(runtimeItem?.getEtagFromParams
-        ? { getEtagFromParams: runtimeItem.getEtagFromParams }
-        : {}),
-      ...(c.sourceFile ? { sourceFile: c.sourceFile } : {}),
-    };
-  });
-};
 
 const getRouterPrefetchCode = (path2moduleIds: Record<string, string[]>) => {
   const moduleIdSet = new Set<string>();

--- a/packages/waku/tests/define-router-config.test.ts
+++ b/packages/waku/tests/define-router-config.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeWithRuntimeConfigs,
+  pathSpecKey,
+  toSerializable,
+} from '../src/router/define-router-utils/config-serialization.js';
+import type {
+  ApiConfig,
+  RouteConfig,
+  SerializableRouteConfig,
+  SliceConfig,
+} from '../src/router/define-router-utils/config-types.js';
+import type { PathSpec } from '../src/router/isomorphic-utils/path-spec.js';
+
+const path = (name: string): PathSpec => [{ type: 'literal', name }];
+const option = { routePath: '/foo', query: undefined };
+
+const makeRoute = (name: string): RouteConfig => ({
+  type: 'route',
+  path: path(name),
+  isStatic: false,
+  rootElement: {
+    isStatic: false,
+    renderer: () => `root:${name}`,
+    getEtagFromOption: async () => `etag-root:${name}`,
+  },
+  routeElement: {
+    isStatic: false,
+    renderer: () => `route:${name}`,
+  },
+  elements: {
+    main: {
+      isStatic: false,
+      renderer: () => `main:${name}`,
+      getEtagFromOption: async () => `etag-main:${name}`,
+      sourceFile: `${name}/main.tsx`,
+    },
+  },
+  searchCodec: { id: `codec:${name}` } as NonNullable<
+    RouteConfig['searchCodec']
+  >,
+});
+
+const makeApi = (name: string): ApiConfig => ({
+  type: 'api',
+  path: path(name),
+  isStatic: true,
+  handler: async () => new Response(`api:${name}`),
+  sourceFile: `${name}/api.ts`,
+});
+
+const makeSlice = (id: string): SliceConfig => ({
+  type: 'slice',
+  id,
+  isStatic: true,
+  renderer: async () => `slice:${id}`,
+  getEtagFromParams: async () => `etag-slice:${id}`,
+});
+
+describe('toSerializable', () => {
+  it('strips renderer and etag functions (and searchCodec) from a route', () => {
+    const s = toSerializable(makeRoute('foo')) as SerializableRouteConfig;
+    expect('searchCodec' in s).toBe(false);
+    expect('renderer' in s.rootElement).toBe(false);
+    expect('getEtagFromOption' in s.rootElement).toBe(false);
+    expect('renderer' in s.routeElement).toBe(false);
+    expect('renderer' in s.elements.main!).toBe(false);
+    expect('getEtagFromOption' in s.elements.main!).toBe(false);
+    // non-function metadata is preserved
+    expect(s.isStatic).toBe(false);
+    expect(s.path).toEqual(path('foo'));
+    expect(s.elements.main!.sourceFile).toBe('foo/main.tsx');
+  });
+
+  it('strips the api handler and the slice renderer/etag', () => {
+    const sApi = toSerializable(makeApi('bar'));
+    expect('handler' in sApi).toBe(false);
+    expect(sApi).toMatchObject({
+      type: 'api',
+      isStatic: true,
+      sourceFile: 'bar/api.ts',
+    });
+
+    const sSlice = toSerializable(makeSlice('sliceA'));
+    expect('renderer' in sSlice).toBe(false);
+    expect('getEtagFromParams' in sSlice).toBe(false);
+    expect(sSlice).toMatchObject({
+      type: 'slice',
+      id: 'sliceA',
+      isStatic: true,
+    });
+  });
+});
+
+describe('mergeWithRuntimeConfigs', () => {
+  it('restores runtime functions by matching path and slice id', async () => {
+    const route = makeRoute('foo');
+    const api = makeApi('bar');
+    const slice = makeSlice('sliceA');
+    const merged = mergeWithRuntimeConfigs(
+      [toSerializable(route), toSerializable(api), toSerializable(slice)],
+      [route, api, slice],
+    );
+    const mRoute = merged.find((c) => c.type === 'route') as RouteConfig;
+    expect(mRoute.rootElement.renderer(option)).toBe('root:foo');
+    expect(await mRoute.rootElement.getEtagFromOption!(option)).toBe(
+      'etag-root:foo',
+    );
+    expect(mRoute.elements.main!.renderer(option)).toBe('main:foo');
+
+    const mApi = merged.find((c) => c.type === 'api') as ApiConfig;
+    expect(
+      await (
+        await mApi.handler(new Request('http://x/'), { params: {} })
+      ).text(),
+    ).toBe('api:bar');
+
+    const mSlice = merged.find((c) => c.type === 'slice') as SliceConfig;
+    expect(await mSlice.renderer()).toBe('slice:sliceA');
+  });
+
+  it('falls back to the shared root renderer for a route with no runtime match', () => {
+    const routeA = makeRoute('a');
+    const routeB = makeRoute('b');
+    // only routeA is present at runtime
+    const merged = mergeWithRuntimeConfigs(
+      [toSerializable(routeA), toSerializable(routeB)],
+      [routeA],
+    );
+    const mB = merged.find(
+      (c) =>
+        c.type === 'route' && pathSpecKey(c.path) === pathSpecKey(path('b')),
+    ) as RouteConfig;
+    expect(mB.rootElement.renderer(option)).toBe('root:a');
+  });
+
+  it('falls back to a shared named-element renderer', () => {
+    const routeA = makeRoute('a');
+    const routeB = makeRoute('b');
+    const merged = mergeWithRuntimeConfigs(
+      [toSerializable(routeA), toSerializable(routeB)],
+      [routeA],
+    );
+    const mB = merged.find(
+      (c) =>
+        c.type === 'route' && pathSpecKey(c.path) === pathSpecKey(path('b')),
+    ) as RouteConfig;
+    expect(mB.elements.main!.renderer(option)).toBe('main:a');
+  });
+
+  it('throws the rebuild-required error when no runtime function exists', async () => {
+    const route = makeRoute('foo');
+    const api = makeApi('bar');
+    const slice = makeSlice('sliceA');
+    // empty runtime configs: no matches and no shared fallbacks
+    const merged = mergeWithRuntimeConfigs(
+      [toSerializable(route), toSerializable(api), toSerializable(slice)],
+      [],
+    );
+    const mRoute = merged.find((c) => c.type === 'route') as RouteConfig;
+    expect(() => mRoute.rootElement.renderer(option)).toThrow(
+      'no runtime function found',
+    );
+    expect(() => mRoute.routeElement.renderer(option)).toThrow(
+      'rebuild required',
+    );
+
+    const mApi = merged.find((c) => c.type === 'api') as ApiConfig;
+    await expect(
+      mApi.handler(new Request('http://x/'), { params: {} }),
+    ).rejects.toThrow('no runtime function found');
+
+    const mSlice = merged.find((c) => c.type === 'slice') as SliceConfig;
+    await expect(mSlice.renderer()).rejects.toThrow('rebuild required');
+  });
+
+  it('does not serialize searchCodec but restores it from runtime config', () => {
+    const route = makeRoute('foo');
+    const merged = mergeWithRuntimeConfigs([toSerializable(route)], [route]);
+    const mRoute = merged.find((c) => c.type === 'route') as RouteConfig;
+    expect(mRoute.searchCodec).toBe(route.searchCodec);
+
+    // with no runtime match the codec stays absent
+    const withoutRuntime = mergeWithRuntimeConfigs([toSerializable(route)], []);
+    const mRouteNoRuntime = withoutRuntime.find(
+      (c) => c.type === 'route',
+    ) as RouteConfig;
+    expect('searchCodec' in mRouteNoRuntime).toBe(false);
+  });
+});
+
+describe('pathSpecKey', () => {
+  it('is stable for equal specs and distinct for different specs', () => {
+    expect(pathSpecKey(path('foo'))).toBe(pathSpecKey(path('foo')));
+    expect(pathSpecKey(path('foo'))).not.toBe(pathSpecKey(path('bar')));
+  });
+});


### PR DESCRIPTION
just moving logic to a new file.