### PR TITLE
refactor(router): extract navigation helpers and share slot id conventions

### DIFF
--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -1,9 +1,11 @@
 import {
   unstable_getErrorInfo as getErrorInfo,
+  unstable_isImmutableElement as isImmutableElement,
   unstable_removeBase as removeBase,
 } from '../../minimal/client.js';
 import { pathnameToRoutePath } from '../isomorphic-utils/route-path.js';
 import type { RouteProps } from '../isomorphic-utils/route-path.js';
+import { isMetaKey } from './elements-meta.js';
 
 // --- pure route and url helpers ---
 
@@ -167,3 +169,29 @@ export const deriveCommitted = (outcome: {
       : null,
   };
 };
+
+export const applyServerRedirect = (
+  prev: Committed,
+  redirect: RouteProps,
+): Committed => ({
+  ...prev,
+  route: redirect,
+  history:
+    redirect.path === '/404'
+      ? null
+      : { mode: 'replace', url: getRouteUrl(redirect) },
+});
+
+// --- instant navigation ---
+
+export const canCommitInstantly = (
+  routeSlotId: string,
+  resolvedElements: Record<string, unknown>,
+  prefetchedElements: Record<string, unknown> | null | undefined,
+) =>
+  isImmutableElement(resolvedElements, routeSlotId) ||
+  !!(prefetchedElements && isImmutableElement(prefetchedElements, routeSlotId));
+
+export const pinForSwr =
+  (getResolvedElements: () => Record<string, unknown>) => (key: string) =>
+    isMetaKey(key) || isImmutableElement(getResolvedElements(), key);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -40,16 +40,18 @@ import {
   getRouteFromElements,
   getServerRedirect,
   has404FromElements,
-  isMetaKey,
   isStaticFromElements,
 } from './client-utils/elements-meta.js';
 import {
+  applyServerRedirect,
+  canCommitInstantly,
   deriveCommitted,
   getRouteUrl,
   isSameRoute,
   parseRedirectUrl,
   parseRoute,
   pathnameToCurrentRoutePath,
+  pinForSwr,
   resolveFollowingErrors,
   writeUrlToHistory,
 } from './client-utils/navigate.js';
@@ -71,6 +73,8 @@ import {
   ROUTE_ID,
   encodeRoutePath,
   encodeSliceId,
+  getRouteSlotId,
+  getSliceSlotId,
 } from './isomorphic-utils/route-path.js';
 import type { RouteProps } from './isomorphic-utils/route-path.js';
 import {
@@ -815,9 +819,6 @@ const ThrowError = ({ error }: { error: unknown }) => {
   throw error;
 };
 
-const getRouteSlotId = (path: string) => 'route:' + path;
-const getSliceSlotId = (id: SliceId) => 'slice:' + id;
-
 const preloadRouteModules = (path: string) => {
   globalThis.__WAKU_ROUTER_PREFETCH__?.(path, (id) => {
     preloadModule(id, { as: 'script' });
@@ -1107,14 +1108,14 @@ const InnerRouter = ({
         const prefetchedElements =
           prefetchedElementsStoreRef.current.get(rscPath);
         const routeSlotId = getRouteSlotId(nextRoute.path);
-        const isStaticSlot = (key: string) =>
-          isImmutableElement(resolvedElementsRef.current, key);
         if (
-          isStaticSlot(routeSlotId) ||
-          (prefetchedElements &&
-            isImmutableElement(prefetchedElements, routeSlotId))
+          canCommitInstantly(
+            routeSlotId,
+            resolvedElementsRef.current,
+            prefetchedElements,
+          )
         ) {
-          const pin = (key: string) => isMetaKey(key) || isStaticSlot(key);
+          const pin = pinForSwr(() => resolvedElementsRef.current);
           const cached = getPrefetch(
             prefetchCacheRef.current,
             prefetchCacheKey(rscPath, nextRoute.query),
@@ -1137,13 +1138,17 @@ const InnerRouter = ({
             },
           );
           routeRef.current = nextRoute;
-          setCommitted({
-            route: nextRoute,
-            history: mode ? { mode, url: options.url } : null,
-            scroll: options.shouldScroll
-              ? { pathChanged: nextRoute.path !== routeBefore.path }
-              : null,
-          });
+          setCommitted(
+            deriveCommitted({
+              destination: { route: nextRoute, routeUrl: targetUrl },
+              attempted: nextRoute,
+              routeBefore,
+              history: mode,
+              historyUrl: options.url,
+              shouldScroll: options.shouldScroll,
+              getServerRedirect,
+            }),
+          );
           setErr(null);
           try {
             const elements = await dataPromise;
@@ -1153,14 +1158,7 @@ const InnerRouter = ({
             const redirect = getServerRedirect(elements, nextRoute);
             if (redirect) {
               routeRef.current = redirect;
-              setCommitted((prev) => ({
-                ...prev,
-                route: redirect,
-                history:
-                  redirect.path === '/404'
-                    ? null
-                    : { mode: 'replace', url: getRouteUrl(redirect) },
-              }));
+              setCommitted((prev) => applyServerRedirect(prev, redirect));
             }
             abortRef.current = null;
             emitRouteChangeEvent('complete', redirect ?? nextRoute);

--- a/packages/waku/src/router/define-router-utils/element-cache.ts
+++ b/packages/waku/src/router/define-router-utils/element-cache.ts
@@ -2,12 +2,14 @@ import type { ReactNode } from 'react';
 import { unstable_bytesToBase64 as bytesToBase64 } from '../../minimal/server.js';
 import { deserializeRsc, serializeRsc } from '../../server.js';
 import type { PathSpec } from '../isomorphic-utils/path-spec.js';
+import {
+  isRouteSlotId,
+  isSliceSlotId,
+} from '../isomorphic-utils/route-path.js';
 import { pathSpecKey } from './config-serialization.js';
 import type { SlotId } from './config-types.js';
 
 export const ROOT_SLOT_ID = 'root';
-export const ROUTE_SLOT_ID_PREFIX = 'route:';
-export const SLICE_SLOT_ID_PREFIX = 'slice:';
 
 export type CacheId = string;
 
@@ -52,8 +54,8 @@ export const getPathSpecCacheId = (pathSpec: PathSpec): CacheId =>
 export const assertNonReservedSlotId = (slotId: SlotId) => {
   if (
     slotId === ROOT_SLOT_ID ||
-    slotId.startsWith(ROUTE_SLOT_ID_PREFIX) ||
-    slotId.startsWith(SLICE_SLOT_ID_PREFIX) ||
+    isRouteSlotId(slotId) ||
+    isSliceSlotId(slotId) ||
     // Capitalized ids are reserved for define-router such as ROUTE_ID, IS_STATIC_ID, HAS404_ID
     /^[A-Z]/.test(slotId)
   ) {

--- a/packages/waku/src/router/define-router-utils/route-entries.tsx
+++ b/packages/waku/src/router/define-router-utils/route-entries.tsx
@@ -9,6 +9,8 @@ import {
   IS_STATIC_ID,
   ROUTE_ID,
   decodeRoutePath,
+  getRouteSlotId,
+  getSliceSlotId,
 } from '../isomorphic-utils/route-path.js';
 import type { ConfigRegistry } from './config-registry.js';
 import type {
@@ -19,8 +21,6 @@ import type {
 } from './config-types.js';
 import {
   ROOT_SLOT_ID,
-  ROUTE_SLOT_ID_PREFIX,
-  SLICE_SLOT_ID_PREFIX,
   getPathSpecCacheId,
   getSlotCacheId,
 } from './element-cache.js';
@@ -67,7 +67,7 @@ export const createRouteEntries = (configRegistry: ConfigRegistry) => {
     concreteId?: string,
     params?: Record<string, string | string[]>,
   ): Promise<ReactNode> => {
-    const slotId = SLICE_SLOT_ID_PREFIX + (concreteId ?? sliceConfig.id);
+    const slotId = getSliceSlotId(concreteId ?? sliceConfig.id);
     const cacheId = getSlotCacheId(slotId);
     const cached = elementCache.get(cacheId);
     if (cached) {
@@ -95,7 +95,7 @@ export const createRouteEntries = (configRegistry: ConfigRegistry) => {
       return null;
     }
     const { query } = parseRscParams(rscParams);
-    const routeId = ROUTE_SLOT_ID_PREFIX + routePath;
+    const routeId = getRouteSlotId(routePath);
     const routeTemplateCacheId = getPathSpecCacheId(pathConfigItem.path);
     const option: RendererOption = {
       routePath,
@@ -167,9 +167,9 @@ export const createRouteEntries = (configRegistry: ConfigRegistry) => {
       if (!sliceConfig) {
         throw new Error(`Slice not found: ${sliceId}`);
       }
-      elementSources[SLICE_SLOT_ID_PREFIX + sliceId] = makeElementSource(
+      elementSources[getSliceSlotId(sliceId)] = makeElementSource(
         sliceConfig.isStatic,
-        getSlotCacheId(SLICE_SLOT_ID_PREFIX + sliceId),
+        getSlotCacheId(getSliceSlotId(sliceId)),
         () => sliceConfig.renderer(sliceConfig.params),
         bindEtag(sliceConfig.getEtagFromParams, sliceConfig.params),
       );
@@ -204,7 +204,7 @@ export const createRouteEntries = (configRegistry: ConfigRegistry) => {
       return null;
     }
     const { sliceConfig, params: sliceParams } = found;
-    const sliceSlotId = SLICE_SLOT_ID_PREFIX + sliceId;
+    const sliceSlotId = getSliceSlotId(sliceId);
     return buildElements(
       {},
       {

--- a/packages/waku/src/router/isomorphic-utils/route-path.ts
+++ b/packages/waku/src/router/isomorphic-utils/route-path.ts
@@ -31,6 +31,19 @@ export function getComponentIds(routePath: string): readonly string[] {
   return ['root', ...Array.from(idSet)];
 }
 
+const ROUTE_SLOT_ID_PREFIX = 'route:';
+const SLICE_SLOT_ID_PREFIX = 'slice:';
+
+export const getRouteSlotId = (path: string) => ROUTE_SLOT_ID_PREFIX + path;
+
+export const getSliceSlotId = (id: string) => SLICE_SLOT_ID_PREFIX + id;
+
+export const isRouteSlotId = (slotId: string) =>
+  slotId.startsWith(ROUTE_SLOT_ID_PREFIX);
+
+export const isSliceSlotId = (slotId: string) =>
+  slotId.startsWith(SLICE_SLOT_ID_PREFIX);
+
 const ROUTE_PREFIX = 'R';
 const SLICE_PREFIX = 'S/';
 

--- a/packages/waku/tests/router-navigator.test.ts
+++ b/packages/waku/tests/router-navigator.test.ts
@@ -1,11 +1,16 @@
 /** @vitest-environment happy-dom */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createCustomError } from '../src/lib/utils/custom-errors.js';
+import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import {
+  applyServerRedirect,
+  canCommitInstantly,
   deriveCommitted,
+  pinForSwr,
   resolveFollowingErrors,
 } from '../src/router/client-utils/navigate.js';
 import type { ResolveDeps } from '../src/router/client-utils/navigate.js';
+import { ROUTE_ID } from '../src/router/isomorphic-utils/route-path.js';
 
 beforeEach(() => {
   vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
@@ -191,5 +196,76 @@ describe('deriveCommitted', () => {
     expect(committed.route.path).toBe('/404');
     expect(committed.history).toBeNull();
     expect(committed.scroll).toBeNull();
+  });
+});
+
+describe('canCommitInstantly', () => {
+  const immutable = (slotId: string) => ({
+    [ETAG_ID_PREFIX + slotId]: IMMUTABLE_ETAG,
+  });
+
+  test('true when the resolved elements hold an immutable route slot', () => {
+    expect(
+      canCommitInstantly('route:/a', immutable('route:/a'), undefined),
+    ).toBe(true);
+  });
+
+  test('true when only the prefetched elements hold it', () => {
+    expect(canCommitInstantly('route:/a', {}, immutable('route:/a'))).toBe(
+      true,
+    );
+  });
+
+  test('false without an immutable etag for the slot', () => {
+    expect(
+      canCommitInstantly(
+        'route:/a',
+        { [ETAG_ID_PREFIX + 'route:/a']: 'W/"mutable"' },
+        null,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('pinForSwr', () => {
+  const immutable = (slotId: string) => ({
+    [ETAG_ID_PREFIX + slotId]: IMMUTABLE_ETAG,
+  });
+
+  test('pins meta keys and immutable slots, not mutable ones', () => {
+    const pin = pinForSwr(() => immutable('layout:/'));
+    expect(pin(ROUTE_ID)).toBe(true);
+    expect(pin('layout:/')).toBe(true);
+    expect(pin('page:/a')).toBe(false);
+  });
+
+  test('reads the resolved elements at call time', () => {
+    let resolved: Record<string, unknown> = {};
+    const pin = pinForSwr(() => resolved);
+    expect(pin('layout:/')).toBe(false);
+    resolved = immutable('layout:/');
+    expect(pin('layout:/')).toBe(true);
+  });
+});
+
+describe('applyServerRedirect', () => {
+  const prev = {
+    route: route('/a'),
+    history: { mode: 'push', url: undefined },
+    scroll: { pathChanged: true },
+  } as const;
+
+  test('patches the route and replaces history with the redirect url', () => {
+    const next = applyServerRedirect(prev, route('/b'));
+    expect(next.route.path).toBe('/b');
+    expect(next.history?.mode).toBe('replace');
+    expect(next.history?.url?.pathname).toBe('/b');
+    expect(next.scroll).toEqual({ pathChanged: true });
+  });
+
+  test('drops the history write for the 404 route', () => {
+    const next = applyServerRedirect(prev, route('/404'));
+    expect(next.route.path).toBe('/404');
+    expect(next.history).toBeNull();
   });
 });

--- a/packages/waku/tests/rscPath.test.ts
+++ b/packages/waku/tests/rscPath.test.ts
@@ -8,6 +8,10 @@ import {
 import {
   decodeRoutePath,
   encodeRoutePath,
+  getRouteSlotId,
+  getSliceSlotId,
+  isRouteSlotId,
+  isSliceSlotId,
   pathnameToRoutePath,
 } from '../src/router/isomorphic-utils/route-path.js';
 
@@ -127,5 +131,22 @@ describe('decodeRoutePath', () => {
 describe('encodeRoutePath & decodeRoutePath', () => {
   test('escape _ prefix', () => {
     expect(decodeRoutePath(encodeRoutePath('/_root'))).toBe('/_root');
+  });
+});
+
+describe('slot ids', () => {
+  test('slot ids are part of the RSC payload format', () => {
+    expect(getRouteSlotId('/')).toBe('route:/');
+    expect(getRouteSlotId('/foo/bar')).toBe('route:/foo/bar');
+    expect(getSliceSlotId('slice001')).toBe('slice:slice001');
+  });
+
+  test('predicates only match ids from their own constructor', () => {
+    expect(isRouteSlotId(getRouteSlotId('/foo'))).toBe(true);
+    expect(isSliceSlotId(getRouteSlotId('/foo'))).toBe(false);
+    expect(isSliceSlotId(getSliceSlotId('foo'))).toBe(true);
+    expect(isRouteSlotId(getSliceSlotId('foo'))).toBe(false);
+    expect(isRouteSlotId('root')).toBe(false);
+    expect(isSliceSlotId('root')).toBe(false);
   });
 });


### PR DESCRIPTION
Moves the pure parts of changeRoute into client-utils/navigate.ts: canCommitInstantly (instant-commit eligibility), pinForSwr (the swr pin predicate, reading resolved elements at call time), and applyServerRedirect (the committed-value patch for a server redirect after an instant commit). The instant path's optimistic commit now goes through deriveCommitted instead of constructing the committed value inline.

The 'route:' and 'slice:' slot id conventions were defined separately in client.tsx and the define-router internals; both now come from isomorphic-utils/route-path.ts (getRouteSlotId, getSliceSlotId, isRouteSlotId, isSliceSlotId).

The new helpers are unit-tested in router-navigator.test.ts.