### PR TITLE
feat(router): apply fetched elements atomically with the route commit

### DIFF
--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -212,6 +212,7 @@ type Refetch = (
       pin: (key: string) => boolean;
       base?: Elements;
     };
+    unstable_onApply?: (apply: () => void) => void;
   },
 ) => Promise<Elements>;
 
@@ -564,6 +565,15 @@ export const Root = ({
       });
     }
     setElements((prev) => mergeElementsPromise(prev, dataWithoutErrors));
+    const onApply = options?.unstable_onApply;
+    if (onApply) {
+      return Promise.resolve(data).then((resolved) => {
+        onApply(() => {
+          setElements((prev) => mergeElementsPromise(prev, resolved));
+        });
+        return resolved;
+      });
+    }
     return data;
   }, []);
   return (

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1029,10 +1029,12 @@ const InnerRouter = ({
   );
 
   const abortRef = useRef<AbortController | null>(null);
+  const applyElementsRef = useRef<(() => void) | null>(null);
 
   const changeRoute: ChangeRoute = useCallback(
     async (nextRoute, options) => {
       abortRef.current?.abort();
+      applyElementsRef.current = null;
       const abortController = new AbortController();
       abortRef.current = abortController;
       const isAborted = () => abortController.signal.aborted;
@@ -1059,6 +1061,9 @@ const InnerRouter = ({
               window.history.pushState(window.history.state, '', routeUrl);
               window.location.reload();
             },
+            unstable_onApply: (apply) => {
+              applyElementsRef.current = apply;
+            },
             ...(cached ? { unstable_prefetched: cached.promise } : {}),
           });
         },
@@ -1077,6 +1082,8 @@ const InnerRouter = ({
         if (isAborted()) {
           return;
         }
+        const applyElements = applyElementsRef.current;
+        applyElementsRef.current = null;
         const value = deriveCommitted({
           destination,
           attempted: nextRoute,
@@ -1094,8 +1101,12 @@ const InnerRouter = ({
           emitRouteChangeEvent('complete', value.route);
         };
         if (isSameRoute(destination.route, nextRoute)) {
-          void startTransitionFn(commit);
+          void startTransitionFn(() => {
+            applyElements?.();
+            commit();
+          });
         } else {
+          applyElements?.();
           commit();
         }
       };

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -920,6 +920,47 @@ describe('minimal/client refetch scenarios', () => {
     };
   };
 
+  test('unstable_onApply provides an apply callback once data resolves', async () => {
+    const view = await mount({ _value: null, main: 'M1' }, () => (
+      <Suspense fallback={<span>loading</span>}>
+        <Slot id="main" />
+      </Suspense>
+    ));
+    expect(view.container.textContent).toBe('M1');
+
+    let apply: (() => void) | undefined;
+    let resolveB: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveB = resolve;
+      }),
+    );
+    await act(async () => {
+      void view.refetch()('R/next.txt', undefined, {
+        unstable_onApply: (a) => {
+          apply = a;
+        },
+      });
+    });
+    // not called while the data is pending
+    expect(apply).toBeUndefined();
+
+    await act(async () => {
+      resolveB({ main: 'M2' });
+      await wait();
+    });
+    expect(apply).toBeDefined();
+    expect(view.container.textContent).toBe('M2');
+
+    // applying again in a later batch keeps the same merged content
+    await act(async () => {
+      apply!();
+    });
+    expect(view.container.textContent).toBe('M2');
+
+    view.unmount();
+  });
+
   test('suspend: a default slot suspends on b, then shows b', async () => {
     const view = await mount({ _value: null, main: 'M1' }, () => (
       <Suspense fallback={<span>loading</span>}>


### PR DESCRIPTION
Adds an unstable_onApply option to refetch in the minimal client. The router uses it to merge the fetched elements again in the same batch as the route commit, so the committed route always has its elements even when the first merge render is delayed. The eager merge is kept as is.