### PR TITLE
test: cover server component performance tracks

### DIFF
--- a/docs/guides/performance-tracks.mdx
+++ b/docs/guides/performance-tracks.mdx
@@ -24,7 +24,7 @@ Both the initial SSR render and later client navigations contribute spans.
 
 This feature relies on React development internals, which Waku patches so that its RSC payload keeps the debug information React needs to build the track. That patch targets a specific React version, so mismatched versions are the usual cause of missing spans:
 
-- Keep `react`, `react-dom`, and `react-server-dom-webpack` on the version Waku pins, and make sure all three match each other.
+- Use matching versions of `react`, `react-dom`, and `react-server-dom-webpack`, and track the React release Waku is built against (its own dependencies are on the `19.2` line). A different React release is the usual cause of missing spans.
 - Some React versions emit the timing **markers** but drop the moved debug information during the client performance flush, so you may see track markers without named component spans.
 
 This is a development-only, best-effort aid; it has no effect on production builds.

--- a/docs/guides/performance-tracks.mdx
+++ b/docs/guides/performance-tracks.mdx
@@ -24,7 +24,7 @@ Both the initial SSR render and later client navigations contribute spans.
 
 This feature relies on React development internals, which Waku patches so that its RSC payload keeps the debug information React needs to build the track. That patch targets a specific React version, so mismatched versions are the usual cause of missing spans:
 
-- Use matching versions of `react`, `react-dom`, and `react-server-dom-webpack`, and track the React release Waku is built against (its own dependencies are on the `19.2` line). A different React release is the usual cause of missing spans.
+- The transform matches React's development build by an exact source string, so it is tied to the React version. It is currently verified against `react`, `react-dom`, and `react-server-dom-webpack` at `19.2.8` (Waku's own dependency, checked by an automated test). Use that version for all three packages; a different React release is the usual cause of missing spans.
 - Some React versions emit the timing **markers** but drop the moved debug information during the client performance flush, so you may see track markers without named component spans.
 
 This is a development-only, best-effort aid; it has no effect on production builds.

--- a/docs/guides/performance-tracks.mdx
+++ b/docs/guides/performance-tracks.mdx
@@ -1,0 +1,30 @@
+---
+slug: performance-tracks
+title: Server Components Performance Tracks
+description: View React's Server Components performance tracks for a Waku app in Chrome DevTools, and what to check when component spans do not appear.
+category: Advanced Setup
+order: 30
+---
+
+## What They Are
+
+React can emit [Server Components performance tracks](https://react.dev/reference/dev-tools/react-performance-tracks) — timing for how long each server component took to render, shown as a dedicated **Server Components** track in the Chrome DevTools Performance panel. Waku wires this up in the dev server, so there is nothing to configure.
+
+## Viewing the Track
+
+1. Run your app in development with `waku dev`.
+2. Open the page in Chrome and open DevTools.
+3. Go to the **Performance** panel and click **Record and reload**.
+4. Once the page has finished rendering, stop the recording.
+5. Find the **Server Components** track. Each server component appears as a span labeled with its render duration, and nested `await`s show up as a staircase.
+
+Both the initial SSR render and later client navigations contribute spans.
+
+## If Component Spans Do Not Appear
+
+This feature relies on React development internals, which Waku patches so that its RSC payload keeps the debug information React needs to build the track. That patch targets a specific React version, so mismatched versions are the usual cause of missing spans:
+
+- Keep `react`, `react-dom`, and `react-server-dom-webpack` on the version Waku pins, and make sure all three match each other.
+- Some React versions emit the timing **markers** but drop the moved debug information during the client performance flush, so you may see track markers without named component spans.
+
+This is a development-only, best-effort aid; it has no effect on production builds.

--- a/docs/guides/performance-tracks.mdx
+++ b/docs/guides/performance-tracks.mdx
@@ -16,15 +16,15 @@ React can emit [Server Components performance tracks](https://react.dev/referenc
 2. Open the page in Chrome and open DevTools.
 3. Go to the **Performance** panel and click **Record and reload**.
 4. Once the page has finished rendering, stop the recording.
-5. Find the **Server Components** track. Each server component appears as a span labeled with its render duration, and nested `await`s show up as a staircase.
+5. Find the **Server Components** track. Each server component appears as a named entry; on React 19.3 or newer the entries also carry render durations, and nested `await`s show up as a staircase.
 
-Both the initial SSR render and later client navigations contribute spans.
+Both the initial SSR render and later client navigations contribute entries.
 
 ## If Component Spans Do Not Appear
 
 This feature relies on React development internals, which Waku patches so that its RSC payload keeps the debug information React needs to build the track. That patch targets a specific React version, so mismatched versions are the usual cause of missing spans:
 
 - The transform matches React's development build by an exact source string, so it is tied to the React version. It is currently verified against `react`, `react-dom`, and `react-server-dom-webpack` at `19.2.8` (Waku's own dependency, checked by an automated test). Use that version for all three packages; a different React release is the usual cause of missing spans.
-- Some React versions emit the timing **markers** but drop the moved debug information during the client performance flush, so you may see track markers without named component spans.
+- On React 19.2.x each server component shows as a named marker in the track; the render **durations** (the staircase spans) require React 19.3 or newer.
 
 This is a development-only, best-effort aid; it has no effect on production builds.

--- a/e2e/fixtures/performance-track/package.json
+++ b/e2e/fixtures/performance-track/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "waku-fixture-performance-track",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev",
+    "build": "waku build",
+    "start": "waku start"
+  },
+  "dependencies": {
+    "react": "~19.2.8",
+    "react-dom": "~19.2.8",
+    "react-server-dom-webpack": "~19.2.8",
+    "waku": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3"
+  }
+}

--- a/e2e/fixtures/performance-track/src/components/perf-probe.tsx
+++ b/e2e/fixtures/performance-track/src/components/perf-probe.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode, Suspense } from 'react';
+
+// Awaits `delay` before rendering `children`. Because a child element only
+// renders once its parent resolves, nesting these produces a sequential
+// waterfall (300ms, then 500ms) that appears as a staircase in React's
+// "Server Components" performance track rather than overlapping spans.
+async function SlowServerComponent({
+  delay,
+  children,
+}: {
+  delay: number;
+  children: ReactNode;
+}) {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  return children;
+}
+
+// `pathname` keys the outer Suspense so the whole waterfall remounts on each
+// navigation, giving one fresh pair of SlowServerComponent spans per render.
+export function PerfProbe({ pathname }: { pathname: string }) {
+  return (
+    <section>
+      <h2>Nested Suspense</h2>
+      <Suspense key={pathname} fallback={<p>Loading...</p>}>
+        <SlowServerComponent delay={300}>
+          <p>SlowServerComponent resolved after 300ms</p>
+          <section>
+            <Suspense fallback={<p>Loading...</p>}>
+              <SlowServerComponent delay={500}>
+                <p>SlowServerComponent resolved after 500ms</p>
+              </SlowServerComponent>
+            </Suspense>
+          </section>
+        </SlowServerComponent>
+      </Suspense>
+    </section>
+  );
+}

--- a/e2e/fixtures/performance-track/src/components/perf-probe.tsx
+++ b/e2e/fixtures/performance-track/src/components/perf-probe.tsx
@@ -1,37 +1,57 @@
 import { type ReactNode, Suspense } from 'react';
 
-// Awaits `delay` before rendering `children`. Because a child element only
-// renders once its parent resolves, nesting these produces a sequential
-// waterfall (300ms, then 500ms) that appears as a staircase in React's
-// "Server Components" performance track rather than overlapping spans.
-async function SlowServerComponent({
-  delay,
-  children,
-}: {
-  delay: number;
-  children: ReactNode;
-}) {
+type SlowProps = { delay: number; children: ReactNode };
+
+// The span name in the performance track is the component function's name, so
+// Home and About use differently-named components. That lets each phase of the
+// e2e assert on its own route's spans and never be satisfied by the other's.
+async function HomeSlowServerComponent({ delay, children }: SlowProps) {
   await new Promise((resolve) => setTimeout(resolve, delay));
   return children;
 }
 
-// `pathname` keys the outer Suspense so the whole waterfall remounts on each
-// navigation, giving one fresh pair of SlowServerComponent spans per render.
-export function PerfProbe({ pathname }: { pathname: string }) {
+async function AboutSlowServerComponent({ delay, children }: SlowProps) {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  return children;
+}
+
+// Nesting the slow component makes a sequential waterfall (300ms, then 500ms)
+// that shows as a staircase in the "Server Components" track.
+export function HomePerfProbe() {
   return (
     <section>
       <h2>Nested Suspense</h2>
-      <Suspense key={pathname} fallback={<p>Loading...</p>}>
-        <SlowServerComponent delay={300}>
-          <p>SlowServerComponent resolved after 300ms</p>
+      <Suspense key="/" fallback={<p>Loading...</p>}>
+        <HomeSlowServerComponent delay={300}>
+          <p>HomeSlowServerComponent resolved after 300ms</p>
           <section>
             <Suspense fallback={<p>Loading...</p>}>
-              <SlowServerComponent delay={500}>
-                <p>SlowServerComponent resolved after 500ms</p>
-              </SlowServerComponent>
+              <HomeSlowServerComponent delay={500}>
+                <p>HomeSlowServerComponent resolved after 500ms</p>
+              </HomeSlowServerComponent>
             </Suspense>
           </section>
-        </SlowServerComponent>
+        </HomeSlowServerComponent>
+      </Suspense>
+    </section>
+  );
+}
+
+export function AboutPerfProbe() {
+  return (
+    <section>
+      <h2>Nested Suspense</h2>
+      <Suspense key="/about" fallback={<p>Loading...</p>}>
+        <AboutSlowServerComponent delay={300}>
+          <p>AboutSlowServerComponent resolved after 300ms</p>
+          <section>
+            <Suspense fallback={<p>Loading...</p>}>
+              <AboutSlowServerComponent delay={500}>
+                <p>AboutSlowServerComponent resolved after 500ms</p>
+              </AboutSlowServerComponent>
+            </Suspense>
+          </section>
+        </AboutSlowServerComponent>
       </Suspense>
     </section>
   );

--- a/e2e/fixtures/performance-track/src/pages/_layout.tsx
+++ b/e2e/fixtures/performance-track/src/pages/_layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import { Link } from 'waku';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <nav>
+        <Link to="/">Home</Link>
+        <Link to="/about">About</Link>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/e2e/fixtures/performance-track/src/pages/about.tsx
+++ b/e2e/fixtures/performance-track/src/pages/about.tsx
@@ -1,0 +1,10 @@
+import { PerfProbe } from '../components/perf-probe';
+
+export default function AboutPage() {
+  return (
+    <main>
+      <h1>About</h1>
+      <PerfProbe pathname="/about" />
+    </main>
+  );
+}

--- a/e2e/fixtures/performance-track/src/pages/about.tsx
+++ b/e2e/fixtures/performance-track/src/pages/about.tsx
@@ -1,10 +1,10 @@
-import { PerfProbe } from '../components/perf-probe';
+import { AboutPerfProbe } from '../components/perf-probe';
 
 export default function AboutPage() {
   return (
     <main>
       <h1>About</h1>
-      <PerfProbe pathname="/about" />
+      <AboutPerfProbe />
     </main>
   );
 }

--- a/e2e/fixtures/performance-track/src/pages/index.tsx
+++ b/e2e/fixtures/performance-track/src/pages/index.tsx
@@ -1,0 +1,10 @@
+import { PerfProbe } from '../components/perf-probe';
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <PerfProbe pathname="/" />
+    </main>
+  );
+}

--- a/e2e/fixtures/performance-track/src/pages/index.tsx
+++ b/e2e/fixtures/performance-track/src/pages/index.tsx
@@ -1,10 +1,10 @@
-import { PerfProbe } from '../components/perf-probe';
+import { HomePerfProbe } from '../components/perf-probe';
 
 export default function HomePage() {
   return (
     <main>
       <h1>Home</h1>
-      <PerfProbe pathname="/" />
+      <HomePerfProbe />
     </main>
   );
 }

--- a/e2e/fixtures/performance-track/tsconfig.json
+++ b/e2e/fixtures/performance-track/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/e2e/performance-track.spec.ts
+++ b/e2e/performance-track.spec.ts
@@ -1,4 +1,4 @@
-import type { CDPSession } from '@playwright/test';
+import type { CDPSession, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { prepareNormalSetup, test } from './utils.js';
 
@@ -16,35 +16,44 @@ test.describe('performance-track', () => {
     const { port, stopApp } = await startApp('DEV');
     try {
       const session = await page.context().newCDPSession(page);
-      await startTracing(session);
 
+      // Trace the initial SSR render on its own.
+      await startTracing(session);
       await page.goto(`http://localhost:${port}/`);
-      // Wait for the innermost step so the whole waterfall has resolved.
       await expect(
         page.getByText('SlowServerComponent resolved after 500ms'),
       ).toBeVisible();
+      await waitForPerformanceFlush(page);
+      const initialSpans = await stopTracingAndCollectSlowSpans(session);
+
+      // Trace the client navigation and its on-demand RSC request on its own.
+      await startTracing(session);
       await page.getByRole('link', { name: 'About' }).click();
       await expect(page.getByRole('heading', { name: 'About' })).toBeVisible();
       await expect(
         page.getByText('SlowServerComponent resolved after 500ms'),
       ).toBeVisible();
-      // Wait for React's deferred performance flush, which has no DOM signal.
-      // eslint-disable-next-line playwright/no-wait-for-timeout
-      await page.waitForTimeout(1000);
+      await waitForPerformanceFlush(page);
+      const navigationSpans = await stopTracingAndCollectSlowSpans(session);
 
-      const spans = await stopTracingAndCollectServerComponentSpans(session);
-      const slowSpans = spans.filter(
-        (span) => span.name === 'SlowServerComponent',
-      );
-      // Home and About each render a nested pair of SlowServerComponent spans;
-      // client navigation may also prefetch About, so assert the floor.
-      expect(slowSpans.length).toBeGreaterThanOrEqual(4);
-      expect(slowSpans.every((span) => span.duration >= 200)).toBe(true);
+      // Assert each phase independently so a broken SSR or navigation path
+      // cannot be hidden by spans from the other. Each renders the nested
+      // SlowServerComponent pair (300ms outer, 500ms inner).
+      for (const spans of [initialSpans, navigationSpans]) {
+        expect(spans.length).toBeGreaterThanOrEqual(2);
+        expect(spans.every((span) => span.duration >= 200)).toBe(true);
+      }
     } finally {
       await stopApp();
     }
   });
 });
+
+async function waitForPerformanceFlush(page: Page): Promise<void> {
+  // React flushes performance info on a deferred task with no DOM signal.
+  // eslint-disable-next-line playwright/no-wait-for-timeout
+  await page.waitForTimeout(1000);
+}
 
 //
 // CDP tracing helpers
@@ -56,9 +65,11 @@ test.describe('performance-track', () => {
 // this minimal shape follows Chrome's Trace Event Format instead:
 // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
 interface TraceEvent {
+  cat: string;
   name: string;
   ph: string;
   ts: number;
+  pid?: number;
   id?: string;
   id2?: { local?: string };
   args?: unknown;
@@ -78,25 +89,60 @@ async function startTracing(session: CDPSession): Promise<void> {
   });
 }
 
-async function stopTracingAndCollectServerComponentSpans(
+async function stopTracingAndCollectSlowSpans(
   session: CDPSession,
 ): Promise<ServerComponentSpan[]> {
   const events = await stopTracing(session);
-  const ends = new Map(
-    events
-      .filter((event) => event.ph === 'e')
-      .map((event) => [traceId(event), event]),
+  return collectServerComponentSpans(events).filter(
+    (span) => span.name === 'SlowServerComponent',
   );
+}
+
+function collectServerComponentSpans(
+  events: TraceEvent[],
+): ServerComponentSpan[] {
+  const ends = new Map<string, TraceEvent>();
+  for (const event of events) {
+    if (event.ph !== 'e') {
+      continue;
+    }
+    const key = asyncEventKey(event);
+    if (key !== undefined) {
+      ends.set(key, event);
+    }
+  }
   return events
     .filter(
       (event) =>
         event.ph === 'b' &&
         JSON.stringify(event.args).includes('Server Components'),
     )
-    .map((event) => ({
-      name: event.name.replaceAll('\u200b', ''),
-      duration: ((ends.get(traceId(event))?.ts ?? event.ts) - event.ts) / 1000,
-    }));
+    .flatMap((event) => {
+      const key = asyncEventKey(event);
+      if (key === undefined) {
+        return [];
+      }
+      const end = ends.get(key);
+      return [
+        {
+          name: event.name.replaceAll('\u200b', ''),
+          duration: ((end?.ts ?? event.ts) - event.ts) / 1000,
+        },
+      ];
+    });
+}
+
+// Chromium pairs nestable async events by category, name, and id (a local id is
+// only unique within its emitting process, so it is scoped by pid). Events with
+// no usable id are dropped rather than collapsed onto a shared key.
+function asyncEventKey(event: TraceEvent): string | undefined {
+  const localId = event.id2?.local;
+  const id = localId ?? event.id;
+  if (id === undefined) {
+    return undefined;
+  }
+  const scope = localId !== undefined ? event.pid : undefined;
+  return [event.cat, event.name, scope, id].join('\u0000');
 }
 
 async function stopTracing(session: CDPSession): Promise<TraceEvent[]> {
@@ -121,8 +167,4 @@ async function stopTracing(session: CDPSession): Promise<TraceEvent[]> {
   }
   await session.send('IO.close', { handle: stream });
   return (JSON.parse(trace) as { traceEvents: TraceEvent[] }).traceEvents;
-}
-
-function traceId(event: TraceEvent): string | undefined {
-  return event.id2?.local ?? event.id;
 }

--- a/e2e/performance-track.spec.ts
+++ b/e2e/performance-track.spec.ts
@@ -5,12 +5,17 @@ import { prepareNormalSetup, test } from './utils.js';
 const startApp = prepareNormalSetup('performance-track');
 
 test.describe('performance-track', () => {
-  // Server Components performance tracks are flaky and require a Chromium trace
-  // plus a React build that emits them, so this is opt-in via
-  // `TEST_PERFORMANCE_TRACK=1` for local runs and is not exercised in CI.
-  test.skip(!process.env.TEST_PERFORMANCE_TRACK);
+  // The "Server Components" performance track is a Chromium + dev feature. On
+  // Waku's pinned React (19.2.x) each component shows up as a named marker in
+  // the track rather than a duration span (spans need React 19.3+), so we
+  // assert the markers are present. They only appear because patch-rsdw
+  // recovers React's debug info for Waku's plain-object RSC payload, so this
+  // exercises that patch end to end.
   test.skip(({ browserName }) => browserName !== 'chromium', 'Chromium only');
   test.skip(({ mode }) => mode !== 'DEV', 'Dev only');
+  // The track entries land after React's deferred performance flush, whose
+  // timing varies on loaded CI runners, so retry rather than flake.
+  test.describe.configure({ retries: process.env.CI ? 2 : 0 });
 
   test('emits server component performance tracks', async ({ page }) => {
     const { port, stopApp } = await startApp('DEV');
@@ -24,7 +29,7 @@ test.describe('performance-track', () => {
         page.getByText('HomeSlowServerComponent resolved after 500ms'),
       ).toBeVisible();
       await waitForPerformanceFlush(page);
-      const initialSpans = collectServerComponentSpans(
+      const initialNames = serverComponentTrackNames(
         await stopTracing(session),
       );
 
@@ -36,24 +41,22 @@ test.describe('performance-track', () => {
         page.getByText('AboutSlowServerComponent resolved after 500ms'),
       ).toBeVisible();
       await waitForPerformanceFlush(page);
-      const navigationSpans = collectServerComponentSpans(
+      const navigationNames = serverComponentTrackNames(
         await stopTracing(session),
       );
 
-      // Each route uses a distinctly named component, so the SSR phase can only
-      // be satisfied by Home spans and the navigation phase only by About
-      // spans; a broken path in one cannot be masked by the other or by an
-      // About prefetch. Each renders the nested pair (300ms, then 500ms).
-      const homeSpans = initialSpans.filter(
-        (span) => span.name === 'HomeSlowServerComponent',
+      // Each route renders a distinctly named component twice (300ms, 500ms),
+      // so each phase must contribute its own two track entries. The per-route
+      // name means neither phase can be satisfied by the other, or by an About
+      // prefetch landing in the initial trace.
+      const homeEntries = initialNames.filter(
+        (name) => name === 'HomeSlowServerComponent',
       );
-      const aboutSpans = navigationSpans.filter(
-        (span) => span.name === 'AboutSlowServerComponent',
+      const aboutEntries = navigationNames.filter(
+        (name) => name === 'AboutSlowServerComponent',
       );
-      for (const spans of [homeSpans, aboutSpans]) {
-        expect(spans.length).toBeGreaterThanOrEqual(2);
-        expect(spans.every((span) => span.duration >= 200)).toBe(true);
-      }
+      expect(homeEntries.length).toBeGreaterThanOrEqual(2);
+      expect(aboutEntries.length).toBeGreaterThanOrEqual(2);
     } finally {
       await stopApp();
     }
@@ -63,7 +66,7 @@ test.describe('performance-track', () => {
 async function waitForPerformanceFlush(page: Page): Promise<void> {
   // React flushes performance info on a deferred task with no DOM signal.
   // eslint-disable-next-line playwright/no-wait-for-timeout
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(2000);
 }
 
 //
@@ -78,20 +81,10 @@ async function waitForPerformanceFlush(page: Page): Promise<void> {
 interface TraceEvent {
   cat: string;
   name: string;
-  ph: string;
-  ts: number;
-  pid?: number;
-  id?: string;
-  id2?: { local?: string };
-  args?: unknown;
 }
 
-// A named Server Components track entry with its measured duration (ms),
-// derived from paired begin/end trace events.
-interface ServerComponentSpan {
-  name: string;
-  duration: number;
-}
+// React prefixes each track entry name with a zero-width space.
+const zeroWidthSpace = String.fromCharCode(0x200b);
 
 async function startTracing(session: CDPSession): Promise<void> {
   await session.send('Tracing.start', {
@@ -100,51 +93,16 @@ async function startTracing(session: CDPSession): Promise<void> {
   });
 }
 
-function collectServerComponentSpans(
-  events: TraceEvent[],
-): ServerComponentSpan[] {
-  const ends = new Map<string, TraceEvent>();
-  for (const event of events) {
-    if (event.ph !== 'e') {
-      continue;
-    }
-    const key = asyncEventKey(event);
-    if (key !== undefined) {
-      ends.set(key, event);
-    }
-  }
+// Names React wrote to the "Server Components" performance track. Entries live
+// in the `blink.user_timing` category and reference the track in their args.
+function serverComponentTrackNames(events: TraceEvent[]): string[] {
   return events
     .filter(
       (event) =>
-        event.ph === 'b' &&
-        JSON.stringify(event.args)?.includes('Server Components') === true,
+        event.cat.includes('blink.user_timing') &&
+        JSON.stringify(event).includes('Server Components'),
     )
-    .flatMap((event) => {
-      const key = asyncEventKey(event);
-      if (key === undefined) {
-        return [];
-      }
-      const end = ends.get(key);
-      return [
-        {
-          name: event.name.replaceAll('\u200b', ''),
-          duration: ((end?.ts ?? event.ts) - event.ts) / 1000,
-        },
-      ];
-    });
-}
-
-// Chromium pairs nestable async events by category, name, and id (a local id is
-// only unique within its emitting process, so it is scoped by pid). Events with
-// no usable id are dropped rather than collapsed onto a shared key.
-function asyncEventKey(event: TraceEvent): string | undefined {
-  const localId = event.id2?.local;
-  const id = localId ?? event.id;
-  if (id === undefined) {
-    return undefined;
-  }
-  const scope = localId !== undefined ? event.pid : undefined;
-  return [event.cat, event.name, scope, id].join('\u0000');
+    .map((event) => event.name.split(zeroWidthSpace).join(''));
 }
 
 async function stopTracing(session: CDPSession): Promise<TraceEvent[]> {

--- a/e2e/performance-track.spec.ts
+++ b/e2e/performance-track.spec.ts
@@ -1,0 +1,128 @@
+import type { CDPSession } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { prepareNormalSetup, test } from './utils.js';
+
+const startApp = prepareNormalSetup('performance-track');
+
+test.describe('performance-track', () => {
+  // Server Components performance tracks are flaky and require a Chromium trace
+  // plus a React build that emits them, so this is opt-in via
+  // `TEST_PERFORMANCE_TRACK=1` for local runs and is not exercised in CI.
+  test.skip(!process.env.TEST_PERFORMANCE_TRACK);
+  test.skip(({ browserName }) => browserName !== 'chromium', 'Chromium only');
+  test.skip(({ mode }) => mode !== 'DEV', 'Dev only');
+
+  test('emits server component performance tracks', async ({ page }) => {
+    const { port, stopApp } = await startApp('DEV');
+    try {
+      const session = await page.context().newCDPSession(page);
+      await startTracing(session);
+
+      await page.goto(`http://localhost:${port}/`);
+      // Wait for the innermost step so the whole waterfall has resolved.
+      await expect(
+        page.getByText('SlowServerComponent resolved after 500ms'),
+      ).toBeVisible();
+      await page.getByRole('link', { name: 'About' }).click();
+      await expect(page.getByRole('heading', { name: 'About' })).toBeVisible();
+      await expect(
+        page.getByText('SlowServerComponent resolved after 500ms'),
+      ).toBeVisible();
+      // Wait for React's deferred performance flush, which has no DOM signal.
+      // eslint-disable-next-line playwright/no-wait-for-timeout
+      await page.waitForTimeout(1000);
+
+      const spans = await stopTracingAndCollectServerComponentSpans(session);
+      const slowSpans = spans.filter(
+        (span) => span.name === 'SlowServerComponent',
+      );
+      // Home and About each render a nested pair of SlowServerComponent spans;
+      // client navigation may also prefetch About, so assert the floor.
+      expect(slowSpans.length).toBeGreaterThanOrEqual(4);
+      expect(slowSpans.every((span) => span.duration >= 200)).toBe(true);
+    } finally {
+      await stopApp();
+    }
+  });
+});
+
+//
+// CDP tracing helpers
+//
+
+// We drive the CDP `Tracing` domain (Tracing.start / tracingComplete stream,
+// read via IO): https://chromedevtools.github.io/devtools-protocol/tot/Tracing/
+// CDP leaves the individual event opaque (`dataCollected.value: object[]`), so
+// this minimal shape follows Chrome's Trace Event Format instead:
+// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+interface TraceEvent {
+  name: string;
+  ph: string;
+  ts: number;
+  id?: string;
+  id2?: { local?: string };
+  args?: unknown;
+}
+
+// A named Server Components track entry with its measured duration (ms),
+// derived from paired begin/end trace events.
+interface ServerComponentSpan {
+  name: string;
+  duration: number;
+}
+
+async function startTracing(session: CDPSession): Promise<void> {
+  await session.send('Tracing.start', {
+    categories: '-*,devtools.timeline,blink.user_timing',
+    transferMode: 'ReturnAsStream',
+  });
+}
+
+async function stopTracingAndCollectServerComponentSpans(
+  session: CDPSession,
+): Promise<ServerComponentSpan[]> {
+  const events = await stopTracing(session);
+  const ends = new Map(
+    events
+      .filter((event) => event.ph === 'e')
+      .map((event) => [traceId(event), event]),
+  );
+  return events
+    .filter(
+      (event) =>
+        event.ph === 'b' &&
+        JSON.stringify(event.args).includes('Server Components'),
+    )
+    .map((event) => ({
+      name: event.name.replaceAll('\u200b', ''),
+      duration: ((ends.get(traceId(event))?.ts ?? event.ts) - event.ts) / 1000,
+    }));
+}
+
+async function stopTracing(session: CDPSession): Promise<TraceEvent[]> {
+  const tracingComplete = new Promise<string>((resolve, reject) => {
+    session.once('Tracing.tracingComplete', ({ stream }) => {
+      if (stream) {
+        resolve(stream);
+      } else {
+        reject(new Error('Trace stream is missing'));
+      }
+    });
+  });
+  await session.send('Tracing.end');
+  const stream = await tracingComplete;
+  let trace = '';
+  for (;;) {
+    const chunk = await session.send('IO.read', { handle: stream });
+    trace += chunk.data;
+    if (chunk.eof) {
+      break;
+    }
+  }
+  await session.send('IO.close', { handle: stream });
+  return (JSON.parse(trace) as { traceEvents: TraceEvent[] }).traceEvents;
+}
+
+function traceId(event: TraceEvent): string | undefined {
+  return event.id2?.local ?? event.id;
+}

--- a/e2e/performance-track.spec.ts
+++ b/e2e/performance-track.spec.ts
@@ -21,25 +21,36 @@ test.describe('performance-track', () => {
       await startTracing(session);
       await page.goto(`http://localhost:${port}/`);
       await expect(
-        page.getByText('SlowServerComponent resolved after 500ms'),
+        page.getByText('HomeSlowServerComponent resolved after 500ms'),
       ).toBeVisible();
       await waitForPerformanceFlush(page);
-      const initialSpans = await stopTracingAndCollectSlowSpans(session);
+      const initialSpans = collectServerComponentSpans(
+        await stopTracing(session),
+      );
 
       // Trace the client navigation and its on-demand RSC request on its own.
       await startTracing(session);
       await page.getByRole('link', { name: 'About' }).click();
       await expect(page.getByRole('heading', { name: 'About' })).toBeVisible();
       await expect(
-        page.getByText('SlowServerComponent resolved after 500ms'),
+        page.getByText('AboutSlowServerComponent resolved after 500ms'),
       ).toBeVisible();
       await waitForPerformanceFlush(page);
-      const navigationSpans = await stopTracingAndCollectSlowSpans(session);
+      const navigationSpans = collectServerComponentSpans(
+        await stopTracing(session),
+      );
 
-      // Assert each phase independently so a broken SSR or navigation path
-      // cannot be hidden by spans from the other. Each renders the nested
-      // SlowServerComponent pair (300ms outer, 500ms inner).
-      for (const spans of [initialSpans, navigationSpans]) {
+      // Each route uses a distinctly named component, so the SSR phase can only
+      // be satisfied by Home spans and the navigation phase only by About
+      // spans; a broken path in one cannot be masked by the other or by an
+      // About prefetch. Each renders the nested pair (300ms, then 500ms).
+      const homeSpans = initialSpans.filter(
+        (span) => span.name === 'HomeSlowServerComponent',
+      );
+      const aboutSpans = navigationSpans.filter(
+        (span) => span.name === 'AboutSlowServerComponent',
+      );
+      for (const spans of [homeSpans, aboutSpans]) {
         expect(spans.length).toBeGreaterThanOrEqual(2);
         expect(spans.every((span) => span.duration >= 200)).toBe(true);
       }
@@ -89,15 +100,6 @@ async function startTracing(session: CDPSession): Promise<void> {
   });
 }
 
-async function stopTracingAndCollectSlowSpans(
-  session: CDPSession,
-): Promise<ServerComponentSpan[]> {
-  const events = await stopTracing(session);
-  return collectServerComponentSpans(events).filter(
-    (span) => span.name === 'SlowServerComponent',
-  );
-}
-
 function collectServerComponentSpans(
   events: TraceEvent[],
 ): ServerComponentSpan[] {
@@ -115,7 +117,7 @@ function collectServerComponentSpans(
     .filter(
       (event) =>
         event.ph === 'b' &&
-        JSON.stringify(event.args).includes('Server Components'),
+        JSON.stringify(event.args)?.includes('Server Components') === true,
     )
     .flatMap((event) => {
       const key = asyncEventKey(event);

--- a/packages/waku/src/lib/utils/react-debug-channel.ts
+++ b/packages/waku/src/lib/utils/react-debug-channel.ts
@@ -1,5 +1,13 @@
 // This file should not include Node specific code.
 
+// TODO: this WS debug channel keeps dev payloads lean by offloading React's
+// Server Components debug info (component stacks, timing, console, async
+// metadata) out of the main Flight stream. Our transport is bespoke: paired
+// HMR events here plus the debug-id header hack in rsc-devtools.ts. Waku is
+// cited as prior art for a shared @vitejs/plugin-rsc debug-channel example
+// (https://github.com/vitejs/vite-plugin-react/issues/1306). Once that lands,
+// consider adopting it so we can delete our own transport and rsc-devtools.ts.
+
 import { base64ToBytes, bytesToBase64 } from './base64-web.js';
 
 export const DEBUG_ID_HEADER = 'X-Waku-Debug-Id';

--- a/packages/waku/src/lib/vite-plugins/patch-rsdw.ts
+++ b/packages/waku/src/lib/vite-plugins/patch-rsdw.ts
@@ -8,6 +8,12 @@ import type { Plugin } from 'vite';
 // objects. This transform relaxes that restriction so _debugInfo is recovered
 // from any object, which is needed for Waku's plain-object payloads to show
 // the "Server Components" track in Chrome DevTools Performance tab.
+//
+// TODO(react-19.3): once React 19.3 is the minimum, revisit whether reshaping
+// the RSC payload root into a value React's built-in recovery accepts (array,
+// async iterable, element, or lazy — see above) lets us delete this transform.
+// A thin wrapper like `[elements]` is unverified; confirm against React's
+// recovery logic first. Context: https://github.com/vitejs/vite-plugin-react/pull/1304
 const SEARCH = 'debugInfo = root._debugInfo;';
 const REPLACE = `
 ${SEARCH}

--- a/packages/waku/tests/patch-rsdw.test.ts
+++ b/packages/waku/tests/patch-rsdw.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { patchRsdwPlugin } from '../src/lib/vite-plugins/patch-rsdw.js';
+
+const require = createRequire(import.meta.url);
+
+const readRsdwClientDevBundle = () => {
+  const pkgJsonPath = require.resolve('react-server-dom-webpack/package.json');
+  const bundlePath = join(
+    dirname(pkgJsonPath),
+    'cjs',
+    'react-server-dom-webpack-client.browser.development.js',
+  );
+  return { id: bundlePath, code: readFileSync(bundlePath, 'utf8') };
+};
+
+const runTransform = (id: string, code: string): string | undefined => {
+  const { transform } = patchRsdwPlugin();
+  const fn = transform as
+    ((code: string, id: string) => string | undefined) | undefined;
+  return fn?.(code, id);
+};
+
+describe('patchRsdwPlugin', () => {
+  it('still rewrites the installed react-server-dom-webpack client dev bundle', () => {
+    const { id, code } = readRsdwClientDevBundle();
+    const result = runTransform(id, code);
+    // If a React upgrade changes these internals, the string match silently
+    // no-ops and _debugInfo recovery for the Server Components performance
+    // track is lost. Fail loudly here instead. See patch-rsdw.ts.
+    expect(typeof result).toBe('string');
+    expect(result).not.toBe(code);
+    expect(result).toContain('root._debugInfo');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,28 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  e2e/fixtures/performance-track:
+    dependencies:
+      react:
+        specifier: ~19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ~19.2.8
+        version: 19.2.8(react@19.2.8)
+      react-server-dom-webpack:
+        specifier: ~19.2.8
+        version: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.99.9)
+      waku:
+        specifier: latest
+        version: link:../../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+
   e2e/fixtures/react-compiler:
     dependencies:
       react:


### PR DESCRIPTION
  Adds tests and docs for the dev Server Components performance tracks from #1984.

- Chromium/dev e2e that checks each route's component shows in the Server Components track (SSR and client nav), which guards patch-rsdw end to end. Runs on CI.
- Unit test that fails if the patch-rsdw transform stops matching the installed React dev bundle.
- Docs guide for viewing the track.
- TODOs to revisit the RSDW patch and adopt a shared plugin-rsc debug channel helper if one lands (https://github.com/vitejs/vite-plugin-react/issues/1306).
