### PR TITLE
refactor(e2e): reduce the test matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,7 @@ on:
       - 'packages/**'
       - 'templates/**'
       - 'e2e/**'
+      - 'playwright.config.ts'
       - '.github/workflows/e2e.yml'
       - 'pnpm-lock.yaml'
   pull_request:
@@ -15,6 +16,7 @@ on:
       - 'packages/**'
       - 'templates/**'
       - 'e2e/**'
+      - 'playwright.config.ts'
       - '.github/workflows/e2e.yml'
       - 'pnpm-lock.yaml'
   workflow_call:
@@ -75,7 +77,7 @@ jobs:
           if-no-files-found: error
 
   e2e:
-    name: E2E on ${{ matrix.os }} (Node ${{ matrix.version }}) - (${{ matrix.shared }}/4)${{ inputs.react_version && format(' with react@{0}', inputs.react_version) || '' }}
+    name: E2E ${{ matrix.target.name }} - (${{ matrix.shared }}/4)${{ inputs.react_version && format(' with react@{0}', inputs.react_version) || '' }}
     needs:
       - build
     strategy:
@@ -83,19 +85,33 @@ jobs:
       matrix:
         shared: [1, 2, 3, 4]
         shardTotal: [4]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        version: [26.0.0, 24.0.0, 22.15.0]
-        exclude:
-          - os: macos-latest
+        target:
+          - name: ubuntu-node-26
+            os: ubuntu-latest
+            version: 26.0.0
+            suite: full-matrix
+          - name: ubuntu-node-24
+            os: ubuntu-latest
             version: 24.0.0
-          - os: windows-latest
-            version: 24.0.0
-          - os: macos-latest
+            suite: full-matrix
+          - name: ubuntu-node-22
+            os: ubuntu-latest
             version: 22.15.0
-          - os: windows-latest
-            version: 22.15.0
+            suite: full-matrix
+          - name: windows-node-26
+            os: windows-latest
+            version: 26.0.0
+            suite: full-matrix
+          - name: macos-node-26
+            os: macos-latest
+            version: 26.0.0
+            suite: full-matrix
+          - name: ubuntu-node-lts
+            os: ubuntu-latest
+            version: lts/*
+            suite: ubuntu-lts
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -104,7 +120,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.version }}
+          node-version: ${{ matrix.target.version }}
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
       - if: runner.os == 'Windows'
         run: choco install yq -y
@@ -132,19 +148,20 @@ jobs:
         env:
           SHARD: ${{ matrix.shared }}
           SHARD_TOTAL: ${{ matrix.shardTotal }}
+          E2E_SUITE: ${{ matrix.target.suite }}
           TEMP_DIR: ${{ runner.temp }}
           VITE_EXPERIMENTAL_WAKU_ROUTER: true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: playwright-report-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.shared }}
+          name: playwright-report-${{ matrix.target.name }}-${{ matrix.shared }}
           path: test-results/
           retention-days: 30
           if-no-files-found: ignore
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: output-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.shared }}
+          name: output-${{ matrix.target.name }}-${{ matrix.shared }}
           path: |
             **/dist
             **/node_modules/.vite

--- a/e2e/base-path.spec.ts
+++ b/e2e/base-path.spec.ts
@@ -118,19 +118,17 @@ test.describe(`base-path`, () => {
   });
 
   // eslint-disable-next-line playwright/expect-expect
-  test('basic DEV', async ({ page, mode }) => {
-    test.skip(mode !== 'DEV', 'DEV only test');
+  test('basic DEV', { tag: '@dev' }, async ({ page }) => {
     await basicTest(page, `http://localhost:${port}/custom/base/`);
   });
 
   // eslint-disable-next-line playwright/expect-expect
-  test('basic PRD', async ({ page, mode }) => {
-    test.skip(mode !== 'PRD', 'PRD only test');
+  test('basic PRD', { tag: '@prd' }, async ({ page }) => {
     await basicTest(page, `http://localhost:${port}/custom/base/`);
 
     // test static
     await stopApp();
-    ({ port, stopApp } = await startApp(mode, {
+    ({ port, stopApp } = await startApp('PRD', {
       cmd: 'pnpm start-static',
     }));
     await basicTest(page, `http://localhost:${port}/custom/base/`);

--- a/e2e/broken-links.spec.ts
+++ b/e2e/broken-links.spec.ts
@@ -107,12 +107,7 @@ test.describe('broken-links: normal server', () => {
   });
 });
 
-test.describe('broken-links: static server', () => {
-  test.skip(
-    ({ mode }) => mode !== 'PRD',
-    'static tests are only relevant in production mode',
-  );
-
+test.describe('broken-links: static server', { tag: '@prd' }, () => {
   test.describe('client side navigation', () => {
     let port: number;
     let stopApp: () => Promise<void>;

--- a/e2e/cache-tag.spec.ts
+++ b/e2e/cache-tag.spec.ts
@@ -3,11 +3,6 @@ import { prepareNormalSetup, test, waitForHydration } from './utils.js';
 
 const startApp = prepareNormalSetup('cache-tag');
 
-test.skip(
-  ({ browserName }) => browserName !== 'chromium',
-  'One browser is enough for this server-behavior test.',
-);
-
 test.describe('cache-tag', () => {
   let port: number;
   let stopApp: () => Promise<void>;

--- a/e2e/cloudflare-adapter.prd.spec.ts
+++ b/e2e/cloudflare-adapter.prd.spec.ts
@@ -3,18 +3,13 @@ import { prepareNormalSetup, test } from './utils.js';
 
 const startApp = prepareNormalSetup('cloudflare-adapter');
 
-// The cloudflare adapter behavior is browser-agnostic, so chromium is enough.
-test.skip(({ browserName }) => browserName !== 'chromium');
-// This spec runs `wrangler dev` against the built output, which requires the PRD build step.
-test.skip(({ mode }) => mode !== 'PRD');
-
 test.describe('cloudflare adapter', () => {
   let port: number;
   let stopApp: () => Promise<void>;
   let buildResult: { stdout: string; stderr: string } | undefined;
 
-  test.beforeAll(async ({ mode }) => {
-    ({ port, stopApp, buildResult } = await startApp(mode, {
+  test.beforeAll(async () => {
+    ({ port, stopApp, buildResult } = await startApp('PRD', {
       cmd: 'npx wrangler dev',
       portFlag: '--port',
     }));

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -494,22 +494,23 @@ test.describe(`create-pages`, () => {
     expect(await res.text()).toBe('');
   });
 
-  test('static api is served from build-time pre-generation', async ({
-    mode,
-  }) => {
-    test.skip(mode !== 'PRD', 'PRD only test');
-    // `/api/cache-time` is a static API whose handler returns
-    // `Date.now()`. With build-time pre-generation it was emitted at
-    // build (before this test started), so the returned timestamp is
-    // older than `curr`. Without pre-generation the handler would run
-    // at request time, after `curr`. The route is dedicated so this
-    // test is the first request to it in the process.
-    const curr = Date.now();
-    const res = await fetch(`http://localhost:${port}/api/cache-time`);
-    expect(res.status).toBe(200);
-    const time = Number(await res.text());
-    expect(time).toBeLessThan(curr);
-  });
+  test(
+    'static api is served from build-time pre-generation',
+    { tag: '@prd' },
+    async () => {
+      // `/api/cache-time` is a static API whose handler returns
+      // `Date.now()`. With build-time pre-generation it was emitted at
+      // build (before this test started), so the returned timestamp is
+      // older than `curr`. Without pre-generation the handler would run
+      // at request time, after `curr`. The route is dedicated so this
+      // test is the first request to it in the process.
+      const curr = Date.now();
+      const res = await fetch(`http://localhost:${port}/api/cache-time`);
+      expect(res.status).toBe(200);
+      const time = Number(await res.text());
+      expect(time).toBeLessThan(curr);
+    },
+  );
 
   test('api hi with POST', async () => {
     const res = await fetch(`http://localhost:${port}/api/hi`, {
@@ -786,35 +787,35 @@ test.describe(`create-pages`, () => {
     ).toHaveText('docs');
   });
 
-  test('static layout under dynamic layout is pre-cached at build time', async ({
-    browser,
-    mode,
-  }) => {
-    test.skip(mode !== 'PRD', 'Only relevant in production mode');
-    const getStaticTime = async (port: number) => {
-      const context = await browser.newContext();
-      const page = await context.newPage();
-      await page.goto(`http://localhost:${port}/nested-layouts`);
-      const text = await page
-        .getByRole('heading', { name: 'Static Layout' })
-        .textContent();
-      await context.close();
-      return text!.replace('Static Layout ', '');
-    };
-    // Stop the shared server, start two fresh instances and compare.
-    // If the static layout is pre-cached at build time, both runs see
-    // the same timestamp. If rendered at runtime, they differ.
-    await stopApp();
-    const run1 = await startApp(mode);
-    const time1 = await getStaticTime(run1.port);
-    await run1.stopApp();
-    const run2 = await startApp(mode);
-    const time2 = await getStaticTime(run2.port);
-    await run2.stopApp();
-    // Restart the shared server for remaining tests
-    ({ port, stopApp } = await startApp(mode));
-    expect(time1).toBe(time2);
-  });
+  test(
+    'static layout under dynamic layout is pre-cached at build time',
+    { tag: '@prd' },
+    async ({ browser }) => {
+      const getStaticTime = async (port: number) => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        await page.goto(`http://localhost:${port}/nested-layouts`);
+        const text = await page
+          .getByRole('heading', { name: 'Static Layout' })
+          .textContent();
+        await context.close();
+        return text!.replace('Static Layout ', '');
+      };
+      // Stop the shared server, start two fresh instances and compare.
+      // If the static layout is pre-cached at build time, both runs see
+      // the same timestamp. If rendered at runtime, they differ.
+      await stopApp();
+      const run1 = await startApp('PRD');
+      const time1 = await getStaticTime(run1.port);
+      await run1.stopApp();
+      const run2 = await startApp('PRD');
+      const time2 = await getStaticTime(run2.port);
+      await run2.stopApp();
+      // Restart the shared server for remaining tests
+      ({ port, stopApp } = await startApp('PRD'));
+      expect(time1).toBe(time2);
+    },
+  );
 
   test('no ssr', async ({ page }) => {
     await page.goto(`http://localhost:${port}/no-ssr`);
@@ -886,26 +887,15 @@ test.describe(`create-pages`, () => {
   });
 });
 
-test.describe(`create-pages STATIC`, () => {
-  test.skip(
-    ({ mode }) => mode !== 'PRD',
-    'static tests are only relevant in production mode',
-  );
-
+test.describe(`create-pages STATIC`, { tag: '@prd' }, () => {
   let port: number;
   let stopApp: () => Promise<void>;
 
-  test.beforeAll(async ({ mode }) => {
-    if (mode !== 'PRD') {
-      return;
-    }
+  test.beforeAll(async () => {
     ({ port, stopApp } = await startApp('STATIC'));
   });
 
-  test.afterAll(async ({ mode }) => {
-    if (mode !== 'PRD') {
-      return;
-    }
+  test.afterAll(async () => {
     await stopApp();
   });
 

--- a/e2e/custom-library-adapter.prd.spec.ts
+++ b/e2e/custom-library-adapter.prd.spec.ts
@@ -10,23 +10,15 @@ test.describe('custom-library-adapter', () => {
   let stopApp: () => Promise<void>;
   let standaloneDir: string;
 
-  test.beforeAll(async ({ mode }) => {
-    if (mode === 'DEV') {
-      return;
-    }
-    ({ port, stopApp, standaloneDir } = await startApp(mode, 'pnpm'));
+  test.beforeAll(async () => {
+    ({ port, stopApp, standaloneDir } = await startApp('PRD', 'pnpm'));
   });
 
-  test.afterAll(async ({ mode }) => {
-    if (mode === 'DEV') {
-      return;
-    }
+  test.afterAll(async () => {
     await stopApp();
   });
 
-  test('runs post build from dependency adapter', async ({ page, mode }) => {
-    test.skip(mode !== 'PRD', 'postBuild runs only in build mode');
-
+  test('runs post build from dependency adapter', async ({ page }) => {
     await page.goto(`http://localhost:${port}/`);
     await expect(page.getByTestId('custom-adapter-heading')).toHaveText(
       'Hello from custom adapter',

--- a/e2e/custom-user-adapter.prd.spec.ts
+++ b/e2e/custom-user-adapter.prd.spec.ts
@@ -10,23 +10,15 @@ test.describe('custom-user-adapter', () => {
   let stopApp: () => Promise<void>;
   let fixtureDir: string;
 
-  test.beforeAll(async ({ mode }) => {
-    if (mode === 'DEV') {
-      return;
-    }
-    ({ port, stopApp, fixtureDir } = await startApp(mode));
+  test.beforeAll(async () => {
+    ({ port, stopApp, fixtureDir } = await startApp('PRD'));
   });
 
-  test.afterAll(async ({ mode }) => {
-    if (mode === 'DEV') {
-      return;
-    }
+  test.afterAll(async () => {
     await stopApp();
   });
 
-  test('runs post build from in-project adapter', async ({ page, mode }) => {
-    test.skip(mode !== 'PRD', 'postBuild runs only in build mode');
-
+  test('runs post build from in-project adapter', async ({ page }) => {
     await page.goto(`http://localhost:${port}/`);
     await expect(page.getByTestId('custom-user-adapter-heading')).toHaveText(
       'Hello from custom user adapter',

--- a/e2e/fs-router-build-split.prd.spec.ts
+++ b/e2e/fs-router-build-split.prd.spec.ts
@@ -32,8 +32,8 @@ test.describe('fs-router build split', () => {
   let standaloneDir: string;
   let stopApp: (() => Promise<void>) | undefined;
 
-  test.beforeAll(async ({ mode }) => {
-    ({ port, stopApp, standaloneDir } = await startApp(mode));
+  test.beforeAll(async () => {
+    ({ port, stopApp, standaloneDir } = await startApp('PRD'));
   });
 
   test.afterAll(async () => {
@@ -43,11 +43,8 @@ test.describe('fs-router build split', () => {
   });
 
   test('runtime bundle excludes fully static routes while SSG still emits them', async ({
-    mode,
     page,
   }) => {
-    test.skip(mode !== 'PRD');
-
     const distDir = join(standaloneDir, 'dist');
 
     expect(existsSync(distDir)).toBe(true);

--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -386,26 +386,26 @@ test.describe('fs-router', () => {
     );
   });
 
-  test('static slug slice is served from build-time cache', async ({
-    page,
-    mode,
-  }) => {
-    test.skip(mode !== 'PRD');
-    // `_slices/cache-time/[id].tsx` is a static slug slice with
-    // `staticPaths: ['foo']`. With build-time pre-rendering its
-    // `Date.now()` is baked at build (before this test started), so
-    // it must be older than `curr`. Without it, the slice would
-    // render on the first PRD request — after `curr`. The route is
-    // dedicated so this test is the first request to that slice.
-    const curr = Date.now();
-    await page.goto(`http://localhost:${port}/cache-time`);
-    await waitForHydration(page);
-    const text = (await page
-      .getByTestId('cache-time-foo')
-      .textContent()) as string;
-    const time = Number(text.split(':')[1]);
-    expect(time).toBeLessThan(curr);
-  });
+  test(
+    'static slug slice is served from build-time cache',
+    { tag: '@prd' },
+    async ({ page }) => {
+      // `_slices/cache-time/[id].tsx` is a static slug slice with
+      // `staticPaths: ['foo']`. With build-time pre-rendering its
+      // `Date.now()` is baked at build (before this test started), so
+      // it must be older than `curr`. Without it, the slice would
+      // render on the first PRD request — after `curr`. The route is
+      // dedicated so this test is the first request to that slice.
+      const curr = Date.now();
+      await page.goto(`http://localhost:${port}/cache-time`);
+      await waitForHydration(page);
+      const text = (await page
+        .getByTestId('cache-time-foo')
+        .textContent()) as string;
+      const time = Number(text.split(':')[1]);
+      expect(time).toBeLessThan(curr);
+    },
+  );
 
   test('static slug slice renders on the page', async ({ page }) => {
     await page.goto(`http://localhost:${port}/page-with-slices`);
@@ -415,23 +415,23 @@ test.describe('fs-router', () => {
     );
   });
 
-  test('static layout inside a dynamic-path route is served from build-time cache', async ({
-    page,
-    mode,
-  }) => {
-    test.skip(mode !== 'PRD');
-    // `/cache-check/[name]` is a dynamic-path route whose layout is
-    // static and renders `Date.now()`. With build-time caching the
-    // value was baked at build (before this test even started), so
-    // it must be older than `curr`. Without it, the layout would
-    // render at runtime on this first request, after `curr`.
-    const curr = Date.now();
-    await page.goto(`http://localhost:${port}/cache-check/foo`);
-    const rendered = Number(
-      (await page.getByTestId('cache-check-time').textContent()) ?? '',
-    );
-    expect(rendered).toBeLessThan(curr);
-  });
+  test(
+    'static layout inside a dynamic-path route is served from build-time cache',
+    { tag: '@prd' },
+    async ({ page }) => {
+      // `/cache-check/[name]` is a dynamic-path route whose layout is
+      // static and renders `Date.now()`. With build-time caching the
+      // value was baked at build (before this test even started), so
+      // it must be older than `curr`. Without it, the layout would
+      // render at runtime on this first request, after `curr`.
+      const curr = Date.now();
+      await page.goto(`http://localhost:${port}/cache-check/foo`);
+      const rendered = Number(
+        (await page.getByTestId('cache-check-time').textContent()) ?? '',
+      );
+      expect(rendered).toBeLessThan(curr);
+    },
+  );
 
   test('segment route in group route', async ({ page }) => {
     await page.goto(

--- a/e2e/hot-reload.dev.spec.ts
+++ b/e2e/hot-reload.dev.spec.ts
@@ -82,11 +82,6 @@ test.afterAll(() => {
   }
 });
 
-test.skip(
-  ({ mode }) => mode !== 'DEV',
-  'HMR is only available in development mode',
-);
-
 test.describe('hot reload', () => {
   let port: number;
   let stopApp: () => Promise<void>;

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -307,21 +307,16 @@ const startHmrApp = prepareNormalSetup('instant-nav', {
   fixtureDir: hmrFixtureDir,
 });
 
-test.describe('instant-nav hmr', () => {
-  test.skip(
-    ({ mode }) => mode !== 'DEV',
-    'HMR is only available in development mode',
-  );
-
+test.describe('instant-nav hmr', { tag: '@dev' }, () => {
   let port: number;
   let stopApp: (() => Promise<void>) | undefined;
 
-  test.beforeAll(async ({ mode }) => {
+  test.beforeAll(async () => {
     cpSync(fixtureSrc, hmrFixtureDir, {
       recursive: true,
       filter: (src) => src !== distDir && !src.startsWith(distDir + sep),
     });
-    ({ port, stopApp } = await startHmrApp(mode));
+    ({ port, stopApp } = await startHmrApp('DEV'));
   });
 
   test.afterAll(async () => {

--- a/e2e/javascript-template.spec.ts
+++ b/e2e/javascript-template.spec.ts
@@ -42,28 +42,26 @@ test.describe('javascript template', () => {
     ).toBeVisible();
   });
 
-  test('redirects trailing slashes via managed middleware in dev', async ({
-    mode,
-    request,
-  }) => {
-    test.skip(mode !== 'DEV', 'DEV only middleware redirect assertion');
+  test(
+    'redirects trailing slashes via managed middleware in dev',
+    { tag: '@dev' },
+    async ({ request }) => {
+      const response = await request.get(`http://localhost:${port}/about/`, {
+        maxRedirects: 0,
+      });
+      expect(response.status()).toBe(301);
+      expect(response.headers().location).toMatch(/\/about$/);
+    },
+  );
 
-    const response = await request.get(`http://localhost:${port}/about/`, {
-      maxRedirects: 0,
-    });
-    expect(response.status()).toBe(301);
-    expect(response.headers().location).toMatch(/\/about$/);
-  });
-
-  test('serves the static trailing-slash page in production', async ({
-    mode,
-    request,
-  }) => {
-    test.skip(mode !== 'PRD', 'PRD only static output assertion');
-
-    const response = await request.get(`http://localhost:${port}/about/`, {
-      maxRedirects: 0,
-    });
-    expect(response.status()).toBe(200);
-  });
+  test(
+    'serves the static trailing-slash page in production',
+    { tag: '@prd' },
+    async ({ request }) => {
+      const response = await request.get(`http://localhost:${port}/about/`, {
+        maxRedirects: 0,
+      });
+      expect(response.status()).toBe(200);
+    },
+  );
 });

--- a/e2e/monorepo.spec.ts
+++ b/e2e/monorepo.spec.ts
@@ -3,9 +3,6 @@ import { prepareStandaloneSetup, test } from './utils.js';
 
 const startApp = prepareStandaloneSetup('monorepo');
 
-// TODO: skip since ecosystem ci overrides setup tends to break package managers
-test.skip(!!process.env.ECOSYSTEM_CI);
-
 for (const packageManager of ['npm', 'pnpm', 'yarn'] as const) {
   test.describe(`${packageManager} monorepo`, () => {
     let port: number;

--- a/e2e/multi-platform.prd.spec.ts
+++ b/e2e/multi-platform.prd.spec.ts
@@ -136,11 +136,6 @@ const ensureServerEntryWithAdapter = (file: string, adapter: string) => {
 
 test.describe.configure({ mode: 'parallel' });
 
-test.skip(
-  ({ mode }) => mode !== 'PRD',
-  'Build tests are only relevant in production mode.',
-);
-
 test.describe(`multi platform builds`, () => {
   for (const { cwd, project } of dryRunList) {
     for (const {

--- a/e2e/partial-build.prd.spec.ts
+++ b/e2e/partial-build.prd.spec.ts
@@ -21,15 +21,6 @@ const waku = fileURLToPath(
   new URL('../packages/waku/dist/cli.js', import.meta.url),
 );
 
-test.skip(
-  ({ browserName }) => browserName !== 'chromium',
-  'Browsers are not relevant for this test. One is enough.',
-);
-test.skip(
-  ({ mode }) => mode !== 'PRD',
-  'Partial builds are only relevant in production mode.',
-);
-
 test.describe(`partial builds`, () => {
   let port: number;
   let cp: ChildProcess;

--- a/e2e/performance-track.dev.spec.ts
+++ b/e2e/performance-track.dev.spec.ts
@@ -11,8 +11,6 @@ test.describe('performance-track', () => {
   // assert the markers are present. They only appear because patch-rsdw
   // recovers React's debug info for Waku's plain-object RSC payload, so this
   // exercises that patch end to end.
-  test.skip(({ browserName }) => browserName !== 'chromium', 'Chromium only');
-  test.skip(({ mode }) => mode !== 'DEV', 'Dev only');
   // The track entries land after React's deferred performance flush, whose
   // timing varies on loaded CI runners, so retry rather than flake.
   test.describe.configure({ retries: process.env.CI ? 2 : 0 });

--- a/e2e/render-type.prd.spec.ts
+++ b/e2e/render-type.prd.spec.ts
@@ -3,15 +3,6 @@ import { prepareNormalSetup, test, waitForHydration } from './utils.js';
 
 const startApp = prepareNormalSetup('render-type');
 
-test.skip(
-  ({ browserName }) => browserName !== 'chromium',
-  'Browsers are not relevant for this test. One is enough.',
-);
-test.skip(
-  ({ mode }) => mode !== 'PRD',
-  'This test is only relevant in production mode.',
-);
-
 test.describe('render type', () => {
   test.describe('static', () => {
     let port: number;

--- a/e2e/router-client.spec.ts
+++ b/e2e/router-client.spec.ts
@@ -554,35 +554,35 @@ test.describe('router-client', () => {
   // The prefetch also warms the route's client chunk: decoding the prefetched
   // RSC pulls /view-target's client component, so clicking loads no new JS.
   // Regression test for https://github.com/wakujs/waku/issues/2099.
-  test('unstable_prefetchOnView warms the route client chunk', async ({
-    page,
-    mode,
-  }) => {
-    test.skip(mode === 'DEV', 'production chunking');
-    const jsUrls: string[] = [];
-    page.on('request', (request) => {
-      const url = request.url();
-      if (request.method() === 'GET' && url.endsWith('.js')) {
-        jsUrls.push(url);
-      }
-    });
+  test(
+    'unstable_prefetchOnView warms the route client chunk',
+    { tag: '@prd' },
+    async ({ page }) => {
+      const jsUrls: string[] = [];
+      page.on('request', (request) => {
+        const url = request.url();
+        if (request.method() === 'GET' && url.endsWith('.js')) {
+          jsUrls.push(url);
+        }
+      });
 
-    await page.goto(`http://localhost:${port}/start`);
-    await waitForHydration(page);
-    // /view-target's chunk is not used on /start, so it is not loaded yet.
-    const initialJs = new Set(jsUrls);
+      await page.goto(`http://localhost:${port}/start`);
+      await waitForHydration(page);
+      // /view-target's chunk is not used on /start, so it is not loaded yet.
+      const initialJs = new Set(jsUrls);
 
-    await page.getByTestId('prefetch-on-view-link').scrollIntoViewIfNeeded();
-    // The prefetch fetches and decodes the route, pulling its client chunk.
-    await expect.poll(() => jsUrls.some((u) => !initialJs.has(u))).toBe(true);
+      await page.getByTestId('prefetch-on-view-link').scrollIntoViewIfNeeded();
+      // The prefetch fetches and decodes the route, pulling its client chunk.
+      await expect.poll(() => jsUrls.some((u) => !initialJs.has(u))).toBe(true);
 
-    const beforeClick = new Set(jsUrls);
-    await page.getByTestId('prefetch-on-view-link').click();
-    await expect(page.getByTestId('view-target-marker')).toBeVisible();
+      const beforeClick = new Set(jsUrls);
+      await page.getByTestId('prefetch-on-view-link').click();
+      await expect(page.getByTestId('view-target-marker')).toBeVisible();
 
-    const newJsOnClick = jsUrls.filter((u) => !beforeClick.has(u));
-    expect(newJsOnClick).toEqual([]);
-  });
+      const newJsOnClick = jsUrls.filter((u) => !beforeClick.has(u));
+      expect(newJsOnClick).toEqual([]);
+    },
+  );
 
   test('unstable_prefetchOnEnter triggers prefetch on hover', async ({
     page,

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -174,8 +174,7 @@ test.describe(`rsc-basic`, () => {
     await expect(page.getByTestId('some-config-foo')).toHaveText('value-1234');
   });
 
-  test('build metadata', async ({ page, mode }) => {
-    test.skip(mode !== 'PRD', 'Build metadata is only available in build mode');
+  test('build metadata', { tag: '@prd' }, async ({ page }) => {
     await page.goto(`http://localhost:${port}/`);
     await expect(page.getByTestId('build-metadata')).toHaveText(
       'metadata-value',

--- a/e2e/ssg-performance.prd.spec.ts
+++ b/e2e/ssg-performance.prd.spec.ts
@@ -3,15 +3,6 @@ import { prepareNormalSetup, test } from './utils.js';
 
 const startApp = prepareNormalSetup('ssg-performance');
 
-test.skip(
-  ({ browserName }) => browserName !== 'chromium',
-  'Browsers are not relevant for this test. One is enough.',
-);
-test.skip(
-  ({ mode }) => mode !== 'PRD',
-  'This test is only relevant in production mode.',
-);
-
 test.describe(`high volume static site generation`, () => {
   test('build and verify', async ({ page }) => {
     test.setTimeout(60000);

--- a/e2e/ssr-target-bundle.spec.ts
+++ b/e2e/ssr-target-bundle.spec.ts
@@ -18,9 +18,7 @@ test.describe(`ssr-target-bundle`, () => {
     await stopApp();
   });
 
-  test.describe('PRD only tests', () => {
-    test.skip(({ mode }) => mode !== 'PRD', 'PRD only tests');
-
+  test.describe('PRD only tests', { tag: '@prd' }, () => {
     test('image exists in folder public/assets', async () => {
       const imagePath = path.join(fixtureDir, 'dist', 'public', 'assets');
       const files = readdirSync(imagePath);

--- a/e2e/styled-components.spec.ts
+++ b/e2e/styled-components.spec.ts
@@ -37,26 +37,15 @@ test.describe('styled-components', () => {
   defineTests(() => port);
 });
 
-test.describe('styled-components: static build', () => {
-  test.skip(
-    ({ mode }) => mode !== 'PRD',
-    'Static build is only relevant in production mode.',
-  );
-
+test.describe('styled-components: static build', { tag: '@prd' }, () => {
   let port: number;
   let stopApp: () => Promise<void>;
 
-  test.beforeAll(async ({ mode }) => {
-    if (mode !== 'PRD') {
-      return;
-    }
+  test.beforeAll(async () => {
     ({ port, stopApp } = await startApp('STATIC'));
   });
 
-  test.afterAll(async ({ mode }) => {
-    if (mode !== 'PRD') {
-      return;
-    }
+  test.afterAll(async () => {
     await stopApp();
   });
 

--- a/e2e/suites.ts
+++ b/e2e/suites.ts
@@ -1,0 +1,95 @@
+// Specs run in the full OS, Node, browser, and mode matrix by default.
+// These lists only declare intentional restrictions.
+export const UBUNTU_LTS_ONLY_SPECS = [
+  'base-path.spec.ts',
+  'broken-links.spec.ts',
+  'cache-tag.spec.ts',
+  'cloudflare-adapter.prd.spec.ts',
+  'css-plugin-integrations.spec.ts',
+  'custom-library-adapter.prd.spec.ts',
+  'custom-user-adapter.prd.spec.ts',
+  'fs-router-build-split.prd.spec.ts',
+  'instant-nav.spec.ts',
+  'minimal-examples.spec.ts',
+  'multi-platform.prd.spec.ts',
+  'partial-build.prd.spec.ts',
+  'performance-track.dev.spec.ts',
+  'react-compiler.spec.ts',
+  'react-tweet.spec.ts',
+  'render-type.prd.spec.ts',
+  'router-client-no-404.spec.ts',
+  'router-client.spec.ts',
+  'rsc-asset.spec.ts',
+  'rsc-css-modules.spec.ts',
+  'spa-example.spec.ts',
+  'ssg-performance.prd.spec.ts',
+  'ssg-wildcard.spec.ts',
+  'ssr-catch-error.spec.ts',
+  'ssr-context-provider.spec.ts',
+  'ssr-nonce-middleware.spec.ts',
+  'ssr-nonce.spec.ts',
+  'ssr-redirect.spec.ts',
+  'ssr-swr.spec.ts',
+  'ssr-target-bundle.spec.ts',
+  'styled-components.spec.ts',
+  'tailwindcss.spec.ts',
+  'tanstack-router.spec.ts',
+  'use-router.spec.ts',
+  'waku-jotai-integration.spec.ts',
+  'website-smoke.spec.ts',
+  'wildcard-api-routes.spec.ts',
+] as const;
+
+export const CHROMIUM_ONLY_SPECS = [
+  'cache-tag.spec.ts',
+  'cloudflare-adapter.prd.spec.ts',
+  'css-plugin-integrations.spec.ts',
+  'custom-library-adapter.prd.spec.ts',
+  'custom-user-adapter.prd.spec.ts',
+  'define-router.spec.ts',
+  'fs-router-build-split.prd.spec.ts',
+  'hot-reload.dev.spec.ts',
+  'javascript-template.spec.ts',
+  'minimal-examples.spec.ts',
+  'monorepo.spec.ts',
+  'multi-platform.prd.spec.ts',
+  'partial-build.prd.spec.ts',
+  'performance-track.dev.spec.ts',
+  'react-compiler.spec.ts',
+  'react-tweet.spec.ts',
+  'render-type.prd.spec.ts',
+  'rsc-asset.spec.ts',
+  'rsc-css-modules.spec.ts',
+  'spa-example.spec.ts',
+  'ssg-performance.prd.spec.ts',
+  'ssg-wildcard.spec.ts',
+  'ssr-context-provider.spec.ts',
+  'ssr-target-bundle.spec.ts',
+  'styled-components.spec.ts',
+  'tailwindcss.spec.ts',
+  'tanstack-router.spec.ts',
+  'waku-jotai-integration.spec.ts',
+  'website-smoke.spec.ts',
+  'wildcard-api-routes.spec.ts',
+] as const;
+
+export const PRD_ONLY_SPECS = [
+  'cloudflare-adapter.prd.spec.ts',
+  'custom-library-adapter.prd.spec.ts',
+  'custom-user-adapter.prd.spec.ts',
+  'fs-router-build-split.prd.spec.ts',
+  'multi-platform.prd.spec.ts',
+  'partial-build.prd.spec.ts',
+  'render-type.prd.spec.ts',
+  'ssg-performance.prd.spec.ts',
+] as const;
+
+export const DEV_ONLY_SPECS = [
+  'hot-reload.dev.spec.ts',
+  'performance-track.dev.spec.ts',
+] as const;
+
+export const ECOSYSTEM_CI_IGNORED_SPECS = ['monorepo.spec.ts'] as const;
+
+export const DEV_ONLY_TAG = /@dev/;
+export const PRD_ONLY_TAG = /@prd/;

--- a/e2e/typescript-template.spec.ts
+++ b/e2e/typescript-template.spec.ts
@@ -40,28 +40,26 @@ test.describe('typescript template', () => {
     ).toBeVisible();
   });
 
-  test('redirects trailing slashes via managed middleware in dev', async ({
-    mode,
-    request,
-  }) => {
-    test.skip(mode !== 'DEV', 'DEV only middleware redirect assertion');
+  test(
+    'redirects trailing slashes via managed middleware in dev',
+    { tag: '@dev' },
+    async ({ request }) => {
+      const response = await request.get(`http://localhost:${port}/about/`, {
+        maxRedirects: 0,
+      });
+      expect(response.status()).toBe(301);
+      expect(response.headers().location).toMatch(/\/about$/);
+    },
+  );
 
-    const response = await request.get(`http://localhost:${port}/about/`, {
-      maxRedirects: 0,
-    });
-    expect(response.status()).toBe(301);
-    expect(response.headers().location).toMatch(/\/about$/);
-  });
-
-  test('serves the static trailing-slash page in production', async ({
-    mode,
-    request,
-  }) => {
-    test.skip(mode !== 'PRD', 'PRD only static output assertion');
-
-    const response = await request.get(`http://localhost:${port}/about/`, {
-      maxRedirects: 0,
-    });
-    expect(response.status()).toBe(200);
-  });
+  test(
+    'serves the static trailing-slash page in production',
+    { tag: '@prd' },
+    async ({ request }) => {
+      const response = await request.get(`http://localhost:${port}/about/`, {
+        maxRedirects: 0,
+      });
+      expect(response.status()).toBe(200);
+    },
+  );
 });

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -103,17 +103,6 @@ export default defineConfig(
     files: ['e2e/**'],
   },
   {
-    files: ['e2e/**'],
-    rules: {
-      'playwright/no-skipped-test': [
-        'error',
-        {
-          allowConditional: true,
-        },
-      ],
-    },
-  },
-  {
     files: [
       'packages/waku/cli.js',
       'packages/waku/src/lib/vite-entries/*',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,28 @@
 import type { PlaywrightTestProject } from '@playwright/test';
 import { defineConfig, devices } from '@playwright/test';
+import {
+  CHROMIUM_ONLY_SPECS,
+  DEV_ONLY_SPECS,
+  DEV_ONLY_TAG,
+  ECOSYSTEM_CI_IGNORED_SPECS,
+  PRD_ONLY_SPECS,
+  PRD_ONLY_TAG,
+  UBUNTU_LTS_ONLY_SPECS,
+} from './e2e/suites.js';
 import type { TestOptions } from './e2e/utils.js';
+
+const e2eSuite = process.env.E2E_SUITE;
+if (e2eSuite && e2eSuite !== 'full-matrix' && e2eSuite !== 'ubuntu-lts') {
+  throw new Error(`Unknown E2E_SUITE: ${e2eSuite}`);
+}
+
+const toGlobs = (specs: readonly string[]) => specs.map((spec) => `**/${spec}`);
+
+const ubuntuLtsOnlySpecs = toGlobs(UBUNTU_LTS_ONLY_SPECS);
+const chromiumOnlySpecs = toGlobs(CHROMIUM_ONLY_SPECS);
+const prdOnlySpecs = toGlobs(PRD_ONLY_SPECS);
+const devOnlySpecs = toGlobs(DEV_ONLY_SPECS);
+const ecosystemCiIgnoredSpecs = toGlobs(ECOSYSTEM_CI_IGNORED_SPECS);
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -40,6 +62,16 @@ const config = defineConfig<TestOptions>({
     {
       ...item,
       name: `${item.name}-dev`,
+      ...(e2eSuite === 'ubuntu-lts' && {
+        testMatch: ubuntuLtsOnlySpecs,
+      }),
+      testIgnore: [
+        ...(e2eSuite === 'full-matrix' ? ubuntuLtsOnlySpecs : []),
+        ...(item.name === 'chromium' ? [] : chromiumOnlySpecs),
+        ...prdOnlySpecs,
+        ...(process.env.ECOSYSTEM_CI ? ecosystemCiIgnoredSpecs : []),
+      ],
+      grepInvert: PRD_ONLY_TAG,
       use: {
         ...item.use,
         mode: 'DEV',
@@ -48,6 +80,16 @@ const config = defineConfig<TestOptions>({
     {
       ...item,
       name: `${item.name}-prd`,
+      ...(e2eSuite === 'ubuntu-lts' && {
+        testMatch: ubuntuLtsOnlySpecs,
+      }),
+      testIgnore: [
+        ...(e2eSuite === 'full-matrix' ? ubuntuLtsOnlySpecs : []),
+        ...(item.name === 'chromium' ? [] : chromiumOnlySpecs),
+        ...devOnlySpecs,
+        ...(process.env.ECOSYSTEM_CI ? ecosystemCiIgnoredSpecs : []),
+      ],
+      grepInvert: DEV_ONLY_TAG,
       use: {
         ...item.use,
         mode: 'PRD',


### PR DESCRIPTION
Run core specs across the full compatibility matrix and run edge-case specs on Ubuntu with Node LTS. Centralize browser and mode restrictions so new specs still run everywhere by default.