### PR TITLE
refactor(router): derive the route from elements

### DIFF
--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -229,8 +229,6 @@ test.describe('instant-nav', () => {
     expect(bodies[0]).toContain('hover-body');
   });
 
-  // The optimistic commit happens before the response, so it reconciles a
-  // server redirect once the response lands.
   test('a redirected instant navigation reconciles to the target', async ({
     page,
   }) => {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -124,6 +124,7 @@ const swrElementsPromise = (
   b: Promise<Elements>,
   pin: (key: string) => boolean,
   base?: Elements,
+  overlay?: Elements,
 ): Promise<Elements> => {
   const getResult = () => {
     const result: Promise<Elements> = Promise.resolve(a).then((aRes) => {
@@ -153,6 +154,9 @@ const swrElementsPromise = (
           }
         }
       }
+      if (overlay) {
+        Object.assign(nextElements, overlay);
+      }
       resolvedMergeResults.set(result, nextElements);
       return nextElements;
     });
@@ -169,13 +173,18 @@ const swrNewKeysElementsPromise = (
   prev: Promise<Elements>,
   b: Promise<Elements>,
   bRes: Elements,
+  overlay?: Elements,
 ): Promise<Elements> => {
   if (swrMergeSources.get(prev) !== b) {
     return prev;
   }
+  const overlayKeys = overlay
+    ? Object.keys(overlay).filter((key) => key in bRes)
+    : [];
   const prevRes = resolvedMergeResults.get(prev);
   if (
     prevRes &&
+    !overlayKeys.length &&
     !Object.keys(bRes).some((key) => key !== '_value' && !(key in prevRes))
   ) {
     return prev;
@@ -185,11 +194,14 @@ const swrNewKeysElementsPromise = (
       const newKeys = Object.keys(bRes).filter(
         (key) => key !== '_value' && !(key in prevRes),
       );
-      if (!newKeys.length) {
+      if (!newKeys.length && !overlayKeys.length) {
         return prevRes;
       }
       const nextElements = { ...prevRes };
       for (const key of newKeys) {
+        nextElements[key] = bRes[key];
+      }
+      for (const key of overlayKeys) {
         nextElements[key] = bRes[key];
       }
       return nextElements;
@@ -211,6 +223,7 @@ type Refetch = (
     unstable_swr?: {
       pin: (key: string) => boolean;
       base?: Elements;
+      overlay?: Elements;
     };
   },
 ) => Promise<Elements>;
@@ -507,6 +520,10 @@ export const unstable_prefetchRsc = (
 const RefetchContext = createContext<Refetch>(() => {
   throw new Error('Missing Root component');
 });
+type MergeElements = (partial: Elements) => void;
+const MergeElementsContext = createContext<MergeElements>(() => {
+  throw new Error('Missing Root component');
+});
 const ElementsContext = createContext<Promise<Elements> | null>(null);
 
 /**
@@ -554,11 +571,22 @@ export const Root = ({
     const dataWithoutErrors = Promise.resolve(data).catch(() => ({}));
     if (swr) {
       setElements((prev) =>
-        swrElementsPromise(prev, dataWithoutErrors, swr.pin, swr.base),
+        swrElementsPromise(
+          prev,
+          dataWithoutErrors,
+          swr.pin,
+          swr.base,
+          swr.overlay,
+        ),
       );
       return Promise.resolve(data).then((resolved) => {
         setElements((prev) =>
-          swrNewKeysElementsPromise(prev, dataWithoutErrors, resolved),
+          swrNewKeysElementsPromise(
+            prev,
+            dataWithoutErrors,
+            resolved,
+            swr.overlay,
+          ),
         );
         return resolved;
       });
@@ -566,12 +594,17 @@ export const Root = ({
     setElements((prev) => mergeElementsPromise(prev, dataWithoutErrors));
     return data;
   }, []);
+  const mergeElements = useCallback<MergeElements>((partial) => {
+    setElements((prev) => mergeElementsPromise(prev, partial));
+  }, []);
   return (
     <RefetchContext value={refetch}>
-      <ElementsContext value={elements}>
-        {DEFAULT_HTML_HEAD}
-        {children}
-      </ElementsContext>
+      <MergeElementsContext value={mergeElements}>
+        <ElementsContext value={elements}>
+          {DEFAULT_HTML_HEAD}
+          {children}
+        </ElementsContext>
+      </MergeElementsContext>
     </RefetchContext>
   );
 };
@@ -581,6 +614,8 @@ export const Root = ({
  * even though it does not carry the `unstable_` prefix.
  */
 export const useRefetch = () => use(RefetchContext);
+
+export const useMergeElements_UNSTABLE = () => use(MergeElementsContext);
 
 const ChildrenContext = createContext<ReactNode>(undefined);
 const ChildrenContextProvider = memo(ChildrenContext);
@@ -652,10 +687,12 @@ export const INTERNAL_ServerRoot = ({
   children: ReactNode;
 }) => (
   <RefetchContext value={async () => ({})}>
-    <ElementsContext value={elementsPromise}>
-      {DEFAULT_HTML_HEAD}
-      {children}
-    </ElementsContext>
+    <MergeElementsContext value={() => {}}>
+      <ElementsContext value={elementsPromise}>
+        {DEFAULT_HTML_HEAD}
+        {children}
+      </ElementsContext>
+    </MergeElementsContext>
   </RefetchContext>
 );
 

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -125,15 +125,17 @@ export const writeUrlToHistory = (mode: 'push' | 'replace', url: URL) => {
   }
 };
 
-// --- the committed value ---
+// --- client-only navigation state ---
 
-export type Committed = {
-  route: RouteProps;
+// The route is derived from the elements' ROUTE_ID; only the client-only intent
+// the server does not know is stored here.
+export type Nav = {
+  hash: string;
   history: { mode: 'push' | 'replace'; url: URL | undefined } | null;
   scroll: { pathChanged: boolean } | null;
 };
 
-export const deriveCommitted = (outcome: {
+export const deriveNav = (outcome: {
   destination: Destination;
   attempted: RouteProps;
   routeBefore: RouteProps;
@@ -144,7 +146,7 @@ export const deriveCommitted = (outcome: {
     elements: Record<string, unknown>,
     route: RouteProps,
   ) => RouteProps | undefined;
-}): Committed => {
+}): { route: RouteProps; nav: Nav } => {
   const { destination, attempted, routeBefore } = outcome;
   const followed = !isSameRoute(destination.route, attempted);
   const redirect =
@@ -163,19 +165,19 @@ export const deriveCommitted = (outcome: {
       : outcome.historyUrl;
   return {
     route,
-    history: mode ? { mode, url } : null,
-    scroll: outcome.shouldScroll
-      ? { pathChanged: route.path !== routeBefore.path }
-      : null,
+    nav: {
+      hash: route.hash,
+      history: mode ? { mode, url } : null,
+      scroll: outcome.shouldScroll
+        ? { pathChanged: route.path !== routeBefore.path }
+        : null,
+    },
   };
 };
 
-export const applyServerRedirect = (
-  prev: Committed,
-  redirect: RouteProps,
-): Committed => ({
+export const applyServerRedirect = (prev: Nav, redirect: RouteProps): Nav => ({
   ...prev,
-  route: redirect,
+  hash: redirect.hash,
   history:
     redirect.path === '/404'
       ? null

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -127,9 +127,11 @@ export const writeUrlToHistory = (mode: 'push' | 'replace', url: URL) => {
 
 // --- client-only navigation state ---
 
-// The route is derived from the elements' ROUTE_ID; only the client-only intent
-// the server does not know is stored here.
+// The route path is derived from the elements' ROUTE_ID. The query and hash are
+// kept here because they are client-owned: a static route does not echo the URL
+// query, and the server never sees the hash.
 export type Nav = {
+  query: string;
   hash: string;
   history: { mode: 'push' | 'replace'; url: URL | undefined } | null;
   scroll: { pathChanged: boolean } | null;
@@ -166,6 +168,7 @@ export const deriveNav = (outcome: {
   return {
     route,
     nav: {
+      query: route.query,
       hash: route.hash,
       history: mode ? { mode, url } : null,
       scroll: outcome.shouldScroll
@@ -177,6 +180,7 @@ export const deriveNav = (outcome: {
 
 export const applyServerRedirect = (prev: Nav, redirect: RouteProps): Nav => ({
   ...prev,
+  query: redirect.query,
   hash: redirect.hash,
   history:
     redirect.path === '/404'

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -1,4 +1,5 @@
 import {
+  unstable_addBase as addBase,
   unstable_getErrorInfo as getErrorInfo,
   unstable_isImmutableElement as isImmutableElement,
   unstable_removeBase as removeBase,
@@ -25,7 +26,7 @@ export const parseRoute = (url: URL): RouteProps => {
 
 export const getRouteUrl = (route: RouteProps): URL => {
   const nextUrl = new URL(window.location.href);
-  nextUrl.pathname = route.path;
+  nextUrl.pathname = addBase(route.path, import.meta.env.WAKU_CONFIG_BASE_PATH);
   nextUrl.search = route.query;
   nextUrl.hash = route.hash;
   return nextUrl;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -752,9 +752,7 @@ const FollowError = ({
       : true;
     followPromiseMap.set(
       error as object,
-      // `following` makes the commit write history imperatively (the follow's
-      // render churns, so a layout-effect write is unreliable) and reconcile the
-      // URL to the final destination even when the target itself redirects.
+      // following: the commit writes the url, even if the target redirects again
       changeRoute(parseRoute(url), {
         shouldScroll,
         following: true,
@@ -969,8 +967,7 @@ const InnerRouter = ({
   const mergeElements = useMergeElements();
   const [nav, setNav] = useState<Nav>(() => ({
     query: initialRouteRef.current.query,
-    // The first render ignores the hash, which the server does not know, to
-    // avoid a hydration error; the effect below restores it.
+    // hydrate without the hash the server does not know; an effect restores it
     hash: '',
     history: null,
     scroll: null,
@@ -1094,10 +1091,8 @@ const InnerRouter = ({
           }
           routeRef.current = route;
           if (options.following && nextNav.history) {
-            // Reconcile the URL to the final destination now; the follow's
-            // render churns, so the layout-effect history write is unreliable.
-            // Always replace: a follow corrects the current entry, and pushing
-            // would leave the redirecting route reachable with Back.
+            // A follow's render churns, so write the url now, and always
+            // replace so Back skips the redirecting route.
             writeUrlToHistory(
               'replace',
               nextNav.history.url || getRouteUrl(route),
@@ -1156,8 +1151,7 @@ const InnerRouter = ({
             },
           );
           routeRef.current = nextRoute;
-          // Instant nav paints the target right away, so its URL is written
-          // now (imperatively); a later error follow can supersede it.
+          // instant nav paints the target right away, so write its url now
           const optimisticNav = deriveNav({
             destination: { route: nextRoute, routeUrl: targetUrl },
             attempted: nextRoute,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -994,7 +994,10 @@ const InnerRouter = ({
   useLayoutEffect(() => {
     const route = routeRef.current;
     if (nav.history) {
-      writeUrlToHistory(nav.history.mode, nav.history.url || getRouteUrl(route));
+      writeUrlToHistory(
+        nav.history.mode,
+        nav.history.url || getRouteUrl(route),
+      );
     }
     if (nav.scroll) {
       scrollToRoute(

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -34,6 +34,7 @@ import {
   unstable_removeBase as removeBase,
   unstable_upsertRscReloadListener as upsertRscReloadListener,
   useElementsPromise_UNSTABLE as useElementsPromise,
+  useMergeElements_UNSTABLE as useMergeElements,
   useRefetch,
 } from '../minimal/client.js';
 import {
@@ -45,7 +46,7 @@ import {
 import {
   applyServerRedirect,
   canCommitInstantly,
-  deriveCommitted,
+  deriveNav,
   getRouteUrl,
   isSameRoute,
   parseRedirectUrl,
@@ -55,7 +56,7 @@ import {
   resolveFollowingErrors,
   writeUrlToHistory,
 } from './client-utils/navigate.js';
-import type { Committed, Destination } from './client-utils/navigate.js';
+import type { Destination, Nav } from './client-utils/navigate.js';
 import type {
   RouteParams,
   RouteSearch,
@@ -719,27 +720,15 @@ const FollowError = ({
   error,
   has404,
   reset,
-  handledErrorSet,
+  followPromiseMap,
 }: {
   error: unknown;
   has404: boolean;
   reset: () => void;
-  handledErrorSet: WeakSet<object>;
+  followPromiseMap: WeakMap<object, Promise<unknown>>;
 }) => {
-  const { route, changeRoute } = useRouterOrThrow();
-  const targetRef = useRef<RouteProps>(undefined);
+  const { changeRoute } = useRouterOrThrow();
   useEffect(() => {
-    if (targetRef.current && isSameRoute(route, targetRef.current)) {
-      targetRef.current = undefined;
-      reset();
-    }
-  }, [route, reset]);
-  useEffect(() => {
-    // ensure a single re-fetch per error on StrictMode
-    // https://github.com/wakujs/waku/pull/1512
-    if (handledErrorSet.has(error as object)) {
-      return;
-    }
     const info = getErrorInfo(error);
     const url = info?.location
       ? parseRedirectUrl(info.location, window.location.href)
@@ -749,32 +738,36 @@ const FollowError = ({
     if (!url) {
       return;
     }
-    handledErrorSet.add(error as object);
+    if (followPromiseMap.has(error as object)) {
+      return;
+    }
     if (url.origin !== window.location.origin) {
+      followPromiseMap.set(error as object, Promise.resolve());
       window.location.replace(url.href);
       return;
     }
-    const target = parseRoute(url);
-    targetRef.current = target;
-    changeRoute(
-      target,
-      info?.location
-        ? {
-            shouldScroll: url.pathname !== window.location.pathname,
-            mode: 'replace',
-            url,
-          }
-        : { shouldScroll: true },
-    )
-      .then(() => {
-        handledErrorSet.delete(error as object);
-      })
-      .catch((err) => {
-        targetRef.current = undefined;
-        handledErrorSet.delete(error as object);
-        console.log('Error while following the error:', err);
-      });
-  }, [error, has404, reset, changeRoute, handledErrorSet]);
+    followPromiseMap.set(
+      error as object,
+      changeRoute(
+        parseRoute(url),
+        info?.location
+          ? {
+              shouldScroll: url.pathname !== window.location.pathname,
+              mode: 'replace',
+              url,
+            }
+          : { shouldScroll: true },
+      )
+        .then(() => {
+          followPromiseMap.delete(error as object);
+          reset();
+        })
+        .catch((err) => {
+          followPromiseMap.delete(error as object);
+          console.log('Error while following the error:', err);
+        }),
+    );
+  }, [error, has404, reset, changeRoute, followPromiseMap]);
   const info = getErrorInfo(error);
   return info?.status === 404 && !has404 ? <h1>Not Found</h1> : null;
 };
@@ -783,7 +776,7 @@ class CustomErrorHandler extends Component<
   { has404: boolean; children?: ReactNode },
   { error: unknown | null }
 > {
-  private handledErrorSet = new WeakSet();
+  private followPromiseMap = new WeakMap<object, Promise<unknown>>();
   constructor(props: { has404: boolean; children?: ReactNode }) {
     super(props);
     this.state = { error: null };
@@ -805,7 +798,7 @@ class CustomErrorHandler extends Component<
             error={error}
             has404={this.props.has404}
             reset={this.reset}
-            handledErrorSet={this.handledErrorSet}
+            followPromiseMap={this.followPromiseMap}
           />
         );
       }
@@ -971,43 +964,43 @@ const InnerRouter = ({
   const prefetchCacheRef = useRef<PrefetchCache>(new Map());
 
   const refetch = useRefetch();
-  const [committed, setCommitted] = useState<Committed>(() => ({
-    // The first route ignores the hash, which the server does not know,
-    // to avoid a hydration error; the effect below restores it.
-    route: { ...initialRouteRef.current, hash: '' },
+  const mergeElements = useMergeElements();
+  const [nav, setNav] = useState<Nav>(() => ({
+    // The first render ignores the hash, which the server does not know, to
+    // avoid a hydration error; the effect below restores it.
+    hash: '',
     history: null,
     scroll: null,
   }));
   const [err, setErr] = useState<unknown>(null);
-  const routeRef = useRef(committed.route);
+  const currentRoute: RouteProps = routeFromElements
+    ? {
+        path: routeFromElements.path,
+        query: routeFromElements.query,
+        hash: nav.hash,
+      }
+    : { ...initialRouteRef.current, hash: nav.hash };
+  const routeRef = useRef(currentRoute);
   useEffect(() => {
-    const route = {
-      ...initialRouteRef.current,
-      hash: window.location.hash || initialRouteRef.current.hash,
-    };
-    routeRef.current = route;
-    setCommitted((prev) =>
-      isSameRoute(prev.route, route) && !prev.history && !prev.scroll
+    const hash = window.location.hash || initialRouteRef.current.hash;
+    routeRef.current = { ...routeRef.current, hash };
+    setNav((prev) =>
+      prev.hash === hash && !prev.history && !prev.scroll
         ? prev
-        : { route, history: null, scroll: null },
+        : { hash, history: null, scroll: null },
     );
     setErr(null);
   }, []);
   useLayoutEffect(() => {
-    if (committed.history) {
-      writeUrlToHistory(
-        committed.history.mode,
-        committed.history.url || getRouteUrl(committed.route),
-      );
-    }
-    if (committed.scroll) {
+    if (nav.scroll) {
+      const route = routeRef.current;
       scrollToRoute(
-        committed.route,
-        committed.scroll.pathChanged ? 'instant' : 'auto',
-        committed.scroll.pathChanged,
+        route,
+        nav.scroll.pathChanged ? 'instant' : 'auto',
+        nav.scroll.pathChanged,
       );
     }
-  }, [committed]);
+  }, [nav]);
 
   if (import.meta.hot) {
     // The etag cache is cleared by minimal's own reload listener, which Root
@@ -1068,7 +1061,7 @@ const InnerRouter = ({
         leaveApp: (url: URL) => {
           if (mode && window.location.href !== targetUrl.href) {
             writeUrlToHistory(mode, targetUrl);
-            setCommitted((prev) => ({ ...prev, history: null }));
+            setNav((prev) => ({ ...prev, history: null }));
           }
           window.location.replace(url.href);
         },
@@ -1077,7 +1070,7 @@ const InnerRouter = ({
         if (isAborted()) {
           return;
         }
-        const value = deriveCommitted({
+        const { route, nav: nextNav } = deriveNav({
           destination,
           attempted: nextRoute,
           routeBefore,
@@ -1087,11 +1080,20 @@ const InnerRouter = ({
           getServerRedirect,
         });
         const commit = () => {
-          routeRef.current = value.route;
-          setCommitted(value);
+          if (!destination.elements) {
+            mergeElements({ [ROUTE_ID]: [route.path, route.query] });
+          }
+          routeRef.current = route;
+          if (nextNav.history) {
+            writeUrlToHistory(
+              nextNav.history.mode,
+              nextNav.history.url || getRouteUrl(route),
+            );
+          }
+          setNav(nextNav);
           setErr(null);
           abortRef.current = null;
-          emitRouteChangeEvent('complete', value.route);
+          emitRouteChangeEvent('complete', route);
         };
         if (isSameRoute(destination.route, nextRoute)) {
           void startTransitionFn(commit);
@@ -1129,6 +1131,7 @@ const InnerRouter = ({
               unstable_swr: {
                 pin,
                 ...(prefetchedElements ? { base: prefetchedElements } : {}),
+                overlay: { [ROUTE_ID]: [nextRoute.path, nextRoute.query] },
               },
               onBuildIdMismatch: () => {
                 window.history.pushState(window.history.state, '', targetUrl);
@@ -1138,17 +1141,22 @@ const InnerRouter = ({
             },
           );
           routeRef.current = nextRoute;
-          setCommitted(
-            deriveCommitted({
-              destination: { route: nextRoute, routeUrl: targetUrl },
-              attempted: nextRoute,
-              routeBefore,
-              history: mode,
-              historyUrl: options.url,
-              shouldScroll: options.shouldScroll,
-              getServerRedirect,
-            }),
-          );
+          const optimisticNav = deriveNav({
+            destination: { route: nextRoute, routeUrl: targetUrl },
+            attempted: nextRoute,
+            routeBefore,
+            history: mode,
+            historyUrl: options.url,
+            shouldScroll: options.shouldScroll,
+            getServerRedirect,
+          }).nav;
+          if (optimisticNav.history) {
+            writeUrlToHistory(
+              optimisticNav.history.mode,
+              optimisticNav.history.url || getRouteUrl(nextRoute),
+            );
+          }
+          setNav(optimisticNav);
           setErr(null);
           try {
             const elements = await dataPromise;
@@ -1158,7 +1166,10 @@ const InnerRouter = ({
             const redirect = getServerRedirect(elements, nextRoute);
             if (redirect) {
               routeRef.current = redirect;
-              setCommitted((prev) => applyServerRedirect(prev, redirect));
+              if (redirect.path !== '/404') {
+                writeUrlToHistory('replace', getRouteUrl(redirect));
+              }
+              setNav((prev) => applyServerRedirect(prev, redirect));
             }
             abortRef.current = null;
             emitRouteChangeEvent('complete', redirect ?? nextRoute);
@@ -1168,7 +1179,7 @@ const InnerRouter = ({
             }
             if (mode && window.location.href !== targetUrl.href) {
               writeUrlToHistory(mode, targetUrl);
-              setCommitted((prev) => ({
+              setNav((prev) => ({
                 ...prev,
                 history: null,
                 scroll: null,
@@ -1225,6 +1236,7 @@ const InnerRouter = ({
     },
     [
       refetch,
+      mergeElements,
       has404,
       emitRouteChangeEvent,
       staticPathSetRef,
@@ -1312,13 +1324,12 @@ const InnerRouter = ({
     };
   }, [changeRoute, routeInterceptor]);
 
-  const routeSlotId = getRouteSlotId(committed.route.path);
   const routeElement =
     err !== null ? (
       <ThrowError error={err} />
-    ) : routeSlotId in elements ? (
-      <Slot id={routeSlotId} />
-    ) : null;
+    ) : (
+      <Slot id={getRouteSlotId(currentRoute.path)} />
+    );
   const rootElement = (
     <Slot id="root">
       <CustomErrorHandler has404={has404}>{routeElement}</CustomErrorHandler>
@@ -1327,7 +1338,7 @@ const InnerRouter = ({
   return (
     <RouterContext
       value={{
-        route: committed.route,
+        route: currentRoute,
         changeRoute,
         prefetchRoute,
         routeChangeEvents,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -163,6 +163,7 @@ type ChangeRouteOptions = {
   url?: URL | undefined;
   startTransition?: ((fn: TransitionFunction) => void) | undefined;
   instant?: boolean | undefined;
+  following?: boolean | undefined; // this navigation follows a render-time error
 };
 
 type ChangeRoute = (
@@ -749,14 +750,16 @@ const FollowError = ({
     const shouldScroll = info?.location
       ? url.pathname !== window.location.pathname
       : true;
-    if (info?.location) {
-      // The redirect target's URL should show; write it now rather than through
-      // the committed nav, whose render can churn while the follow resolves.
-      writeUrlToHistory('replace', url);
-    }
     followPromiseMap.set(
       error as object,
-      changeRoute(parseRoute(url), { shouldScroll })
+      // `following` makes the commit write history imperatively (the follow's
+      // render churns, so a layout-effect write is unreliable) and reconcile the
+      // URL to the final destination even when the target itself redirects.
+      changeRoute(parseRoute(url), {
+        shouldScroll,
+        following: true,
+        ...(info?.location ? { mode: 'replace' as const } : {}),
+      })
         .then(() => {
           followPromiseMap.delete(error as object);
           reset();
@@ -1090,7 +1093,17 @@ const InnerRouter = ({
             mergeElements({ [ROUTE_ID]: [route.path, route.query] });
           }
           routeRef.current = route;
-          setNav(nextNav);
+          if (options.following && nextNav.history) {
+            // Reconcile the URL to the final destination now; the follow's
+            // render churns, so the layout-effect history write is unreliable.
+            writeUrlToHistory(
+              nextNav.history.mode,
+              nextNav.history.url || getRouteUrl(route),
+            );
+            setNav({ ...nextNav, history: null });
+          } else {
+            setNav(nextNav);
+          }
           setErr(null);
           abortRef.current = null;
           emitRouteChangeEvent('complete', route);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -746,18 +746,17 @@ const FollowError = ({
       window.location.replace(url.href);
       return;
     }
+    const shouldScroll = info?.location
+      ? url.pathname !== window.location.pathname
+      : true;
+    if (info?.location) {
+      // The redirect target's URL should show; write it now rather than through
+      // the committed nav, whose render can churn while the follow resolves.
+      writeUrlToHistory('replace', url);
+    }
     followPromiseMap.set(
       error as object,
-      changeRoute(
-        parseRoute(url),
-        info?.location
-          ? {
-              shouldScroll: url.pathname !== window.location.pathname,
-              mode: 'replace',
-              url,
-            }
-          : { shouldScroll: true },
-      )
+      changeRoute(parseRoute(url), { shouldScroll })
         .then(() => {
           followPromiseMap.delete(error as object);
           reset();
@@ -966,6 +965,7 @@ const InnerRouter = ({
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
   const [nav, setNav] = useState<Nav>(() => ({
+    query: initialRouteRef.current.query,
     // The first render ignores the hash, which the server does not know, to
     // avoid a hydration error; the effect below restores it.
     hash: '',
@@ -973,13 +973,13 @@ const InnerRouter = ({
     scroll: null,
   }));
   const [err, setErr] = useState<unknown>(null);
-  const currentRoute: RouteProps = routeFromElements
-    ? {
-        path: routeFromElements.path,
-        query: routeFromElements.query,
-        hash: nav.hash,
-      }
-    : { ...initialRouteRef.current, hash: nav.hash };
+  const currentRoute: RouteProps = {
+    path: routeFromElements
+      ? routeFromElements.path
+      : initialRouteRef.current.path,
+    query: nav.query,
+    hash: nav.hash,
+  };
   const routeRef = useRef(currentRoute);
   useEffect(() => {
     const hash = window.location.hash || initialRouteRef.current.hash;
@@ -987,13 +987,16 @@ const InnerRouter = ({
     setNav((prev) =>
       prev.hash === hash && !prev.history && !prev.scroll
         ? prev
-        : { hash, history: null, scroll: null },
+        : { ...prev, hash, history: null, scroll: null },
     );
     setErr(null);
   }, []);
   useLayoutEffect(() => {
+    const route = routeRef.current;
+    if (nav.history) {
+      writeUrlToHistory(nav.history.mode, nav.history.url || getRouteUrl(route));
+    }
     if (nav.scroll) {
-      const route = routeRef.current;
       scrollToRoute(
         route,
         nav.scroll.pathChanged ? 'instant' : 'auto',
@@ -1084,12 +1087,6 @@ const InnerRouter = ({
             mergeElements({ [ROUTE_ID]: [route.path, route.query] });
           }
           routeRef.current = route;
-          if (nextNav.history) {
-            writeUrlToHistory(
-              nextNav.history.mode,
-              nextNav.history.url || getRouteUrl(route),
-            );
-          }
           setNav(nextNav);
           setErr(null);
           abortRef.current = null;
@@ -1141,6 +1138,8 @@ const InnerRouter = ({
             },
           );
           routeRef.current = nextRoute;
+          // Instant nav paints the target right away, so its URL is written
+          // now (imperatively); a later error follow can supersede it.
           const optimisticNav = deriveNav({
             destination: { route: nextRoute, routeUrl: targetUrl },
             attempted: nextRoute,
@@ -1156,7 +1155,7 @@ const InnerRouter = ({
               optimisticNav.history.url || getRouteUrl(nextRoute),
             );
           }
-          setNav(optimisticNav);
+          setNav({ ...optimisticNav, history: null });
           setErr(null);
           try {
             const elements = await dataPromise;
@@ -1169,7 +1168,10 @@ const InnerRouter = ({
               if (redirect.path !== '/404') {
                 writeUrlToHistory('replace', getRouteUrl(redirect));
               }
-              setNav((prev) => applyServerRedirect(prev, redirect));
+              setNav((prev) => ({
+                ...applyServerRedirect(prev, redirect),
+                history: null,
+              }));
             }
             abortRef.current = null;
             emitRouteChangeEvent('complete', redirect ?? nextRoute);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -758,7 +758,7 @@ const FollowError = ({
       changeRoute(parseRoute(url), {
         shouldScroll,
         following: true,
-        ...(info?.location ? { mode: 'replace' as const } : {}),
+        ...(info?.location ? { mode: 'replace' as const, url } : {}),
       })
         .then(() => {
           followPromiseMap.delete(error as object);
@@ -1096,8 +1096,10 @@ const InnerRouter = ({
           if (options.following && nextNav.history) {
             // Reconcile the URL to the final destination now; the follow's
             // render churns, so the layout-effect history write is unreliable.
+            // Always replace: a follow corrects the current entry, and pushing
+            // would leave the redirecting route reachable with Back.
             writeUrlToHistory(
-              nextNav.history.mode,
+              'replace',
               nextNav.history.url || getRouteUrl(route),
             );
             setNav({ ...nextNav, history: null });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4417,6 +4417,54 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a followed redirect that redirects again keeps the base path', async () => {
+    vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/docs/');
+    try {
+      window.history.replaceState({}, '', '/docs/start');
+      const capture = { router: null as RouterApi | null };
+      const Probe = makeProbe(capture);
+      const ThrowRedirect = () => {
+        throw createCustomError('redirect', {
+          status: 307,
+          location: '/docs/login',
+        });
+      };
+
+      const pushStateSpy = vi.spyOn(window.history, 'pushState');
+
+      getRefetchMock().mockImplementation(((rscPath: string) =>
+        Promise.resolve(
+          rscPath === unstable_encodeRoutePath('/login')
+            ? { [ROUTE_ID]: ['/dashboard', ''] }
+            : {},
+        )) as never);
+
+      const elements = {
+        [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+        [unstable_getRouteSlotId('/dashboard')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      };
+
+      const view = await renderRouter(
+        {
+          initialRoute: { path: '/start', query: '', hash: '' },
+        },
+        elements,
+      );
+      await flush();
+      await flush();
+
+      expect(capture.router?.path).toBe('/dashboard');
+      expect(window.location.pathname).toBe('/docs/dashboard');
+      expect(pushStateSpy).not.toHaveBeenCalled();
+
+      view.unmount();
+    } finally {
+      vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
+    }
+  });
+
   test('redirect error with cross-origin location uses window.location.replace', async () => {
     const ThrowRedirect = () => {
       throw createCustomError('redirect', {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4294,6 +4294,50 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a render-time redirect whose target also redirects reconciles the url to the final route', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const ThrowRedirect = () => {
+      throw createCustomError('redirect', { status: 307, location: '/login' });
+    };
+
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+    getRefetchMock().mockImplementation(((rscPath: string) =>
+      rscPath === unstable_encodeRoutePath('/login')
+        ? Promise.reject(
+            createCustomError('redirect', {
+              status: 307,
+              location: '/dashboard',
+            }),
+          )
+        : Promise.resolve({})) as never);
+
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+      [unstable_getRouteSlotId('/dashboard')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      {
+        initialRoute: { path: '/start', query: '', hash: '' },
+      },
+      elements,
+    );
+    // the first follow redirects again, so let both follows settle
+    await flush();
+    await flush();
+    await flush();
+
+    expect(capture.router?.path).toBe('/dashboard');
+    expect(window.location.pathname).toBe('/dashboard');
+    expect(replaceStateSpy).toHaveBeenCalled();
+
+    view.unmount();
+  });
+
   test('redirect error with cross-origin location uses window.location.replace', async () => {
     const ThrowRedirect = () => {
       throw createCustomError('redirect', {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4338,6 +4338,85 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a followed redirect keeps the base path in the url', async () => {
+    vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/docs/');
+    try {
+      window.history.replaceState({}, '', '/docs/start');
+      const capture = { router: null as RouterApi | null };
+      const Probe = makeProbe(capture);
+      const ThrowRedirect = () => {
+        throw createCustomError('redirect', {
+          status: 307,
+          location: '/docs/login',
+        });
+      };
+
+      const elements = {
+        [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+        [unstable_getRouteSlotId('/login')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      };
+
+      const view = await renderRouter(
+        {
+          initialRoute: { path: '/start', query: '', hash: '' },
+        },
+        elements,
+      );
+      await flush();
+      await flush();
+
+      expect(capture.router?.path).toBe('/login');
+      expect(window.location.pathname).toBe('/docs/login');
+
+      view.unmount();
+    } finally {
+      vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
+    }
+  });
+
+  test('a followed redirect whose response redirects again replaces instead of pushing', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const ThrowRedirect = () => {
+      throw createCustomError('redirect', { status: 307, location: '/login' });
+    };
+
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+    getRefetchMock().mockImplementation(((rscPath: string) =>
+      Promise.resolve(
+        rscPath === unstable_encodeRoutePath('/login')
+          ? { [ROUTE_ID]: ['/dashboard', ''] }
+          : {},
+      )) as never);
+
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+      [unstable_getRouteSlotId('/dashboard')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      {
+        initialRoute: { path: '/start', query: '', hash: '' },
+      },
+      elements,
+    );
+    await flush();
+    await flush();
+
+    expect(capture.router?.path).toBe('/dashboard');
+    expect(window.location.pathname).toBe('/dashboard');
+    expect(pushStateSpy).not.toHaveBeenCalled();
+    expect(replaceStateSpy).toHaveBeenCalled();
+
+    view.unmount();
+  });
+
   test('redirect error with cross-origin location uses window.location.replace', async () => {
     const ThrowRedirect = () => {
       throw createCustomError('redirect', {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { StrictMode, act, use, useState } from 'react';
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { preloadModule } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { expectType } from 'ts-expect';
@@ -47,6 +47,7 @@ import {
   HAS404_ID,
   IS_STATIC_ID,
   ROUTE_ID,
+  decodeRoutePath,
 } from '../src/router/isomorphic-utils/route-path.js';
 import { PREFETCH_LIMIT } from '../src/router/prefetch-cache.js';
 
@@ -76,9 +77,18 @@ type IntersectionObserverMockInstance = IntersectionObserver & {
 };
 
 // Elements the mocked `Root` provides for the current render. Hoisted so the
-// `vi.mock` factory can read it.
+// `vi.mock` factory can read it. The mocked Root keeps them in state and
+// `setElements` (set once mounted) merges a fetched response in, so the derived
+// route follows a navigation the way it does with the real minimal client.
 const testHoisted = vi.hoisted(() => ({
   elements: {} as Record<string, unknown>,
+  elementsValue: {} as Record<string, unknown>,
+  // synchronous merge of a value (used for route metadata with no fetch)
+  setElements: null as ((data: Record<string, unknown>) => void) | null,
+  // eager merge of a pending fetch: elements suspend until it resolves, like the
+  // real client, so a transition stays pending across the fetch
+  mergeElementsAsync: null as
+    ((data: Promise<Record<string, unknown>>) => void) | null,
 }));
 
 const createDeferred = <T,>() => {
@@ -97,15 +107,74 @@ const resolvedThenable = <T,>(value: T): Promise<T> =>
     value,
   });
 
-const createRefetchMock = () =>
-  vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+// A real route response carries its ROUTE_ID and route slot; tests that only
+// configure content (or nothing) get those defaulted from the request so the
+// derived route can follow the navigation.
+const withRouteMeta = (
+  result: unknown,
+  rscPath: string,
+  rscParams: unknown,
+): Record<string, unknown> => {
+  if (!result || typeof result !== 'object') {
+    return {};
+  }
+  const data = result as Record<string, unknown>;
+  if (ROUTE_ID in data || !rscPath.startsWith('R/')) {
+    return data;
+  }
+  const routePath = decodeRoutePath(rscPath);
+  const query =
+    rscParams instanceof URLSearchParams ? (rscParams.get('query') ?? '') : '';
+  // Inject only the route metadata; the route slot itself comes from the
+  // initial elements or the configured response.
+  return { ...data, [ROUTE_ID]: [routePath, query] };
+};
+
+// The refetch the router calls (`outer`) merges its response into the mocked
+// Root's elements so the derived route follows; tests configure and inspect the
+// underlying `inner` mock (getRefetchMock(), or the fn passed to installRefetch).
+type RefetchInner = ReturnType<typeof useRefetch>;
+type MockedRefetch = ReturnType<typeof vi.fn<RefetchInner>>;
+type RefetchMock = RefetchInner & { inner: MockedRefetch };
+
+const wrapRefetch = (inner: MockedRefetch): RefetchMock => {
+  const call = (
+    rscPath: string,
+    ...rest: [rscParams?: unknown, options?: unknown]
+  ) => {
+    // Merge synchronously (in the caller's transition) with a pending promise
+    // so the elements suspend until the response lands, like the real client;
+    // a failed fetch leaves the elements unchanged (the router follows it).
+    const dataPromise = Promise.resolve(
+      (inner as (...args: unknown[]) => Promise<Record<string, unknown>>)(
+        rscPath,
+        ...rest,
+      ),
+    ).then((result) => withRouteMeta(result, rscPath, rest[0]));
+    testHoisted.mergeElementsAsync?.(dataPromise.catch(() => ({})));
+    return dataPromise;
+  };
+  const outer = vi.fn(call) as unknown as RefetchMock;
+  outer.inner = inner;
+  return outer;
+};
+
+const createRefetchMock = (): RefetchMock =>
+  wrapRefetch(vi.fn<RefetchInner>(async () => ({})));
+
+// Install a test-provided refetch behind the merging wrapper. Returns the same
+// fn so the test keeps configuring/inspecting it.
+const installRefetch = (inner: MockedRefetch) => {
+  vi.mocked(useRefetch).mockReturnValue(wrapRefetch(inner));
+  return inner;
+};
 
 const getRefetchMock = () => {
   const results = vi.mocked(useRefetch).mock.results;
   for (let index = results.length - 1; index >= 0; index -= 1) {
     const result = results[index];
     if (result?.type === 'return') {
-      return result.value as ReturnType<typeof createRefetchMock>;
+      return (result.value as RefetchMock).inner;
     }
   }
   throw new Error('useRefetch was not called');
@@ -156,18 +225,62 @@ vi.mock('../src/minimal/client.js', async () => {
   const actual = await vi.importActual<
     typeof import('../src/minimal/client.js')
   >('../src/minimal/client.js');
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  const makeThenable = (value: Record<string, unknown>) =>
+    Object.assign(Promise.resolve(value), {
+      status: 'fulfilled' as const,
+      value,
+    });
+
+  const StatefulRoot = (props: { children?: ReactNode }) => {
+    const [elements, setElements] = React.useState<
+      Promise<Record<string, unknown>>
+    >(() => {
+      testHoisted.elementsValue = {
+        root: React.createElement(actual.Children),
+        ...testHoisted.elements,
+      };
+      return makeThenable(testHoisted.elementsValue);
+    });
+    // Assigned during render (not in an effect) so it is available before
+    // descendant effects run, e.g. a redirect follow triggered on first render.
+    testHoisted.setElements = (data) => {
+      testHoisted.elementsValue = { ...testHoisted.elementsValue, ...data };
+      setElements(makeThenable(testHoisted.elementsValue));
+    };
+    testHoisted.mergeElementsAsync = (dataPromise) => {
+      const pending = dataPromise.then((data) => {
+        testHoisted.elementsValue = { ...testHoisted.elementsValue, ...data };
+        return testHoisted.elementsValue;
+      });
+      setElements(pending);
+    };
+    // A boundary so a merge that suspends (pending fetch) shows a fallback
+    // instead of crashing on a non-transition update; the real app supplies its
+    // own boundaries.
+    return React.createElement(
+      React.Suspense,
+      { fallback: null },
+      actual.INTERNAL_ServerRoot({
+        elementsPromise: elements,
+        children: props.children,
+      }),
+    );
+  };
+
+  const mockMergeElements = (partial: Record<string, unknown>) => {
+    testHoisted.setElements?.(partial);
+  };
 
   return {
     ...actual,
     Root: vi.fn((props: Parameters<typeof actual.Root>[0]) =>
-      actual.INTERNAL_ServerRoot({
-        elementsPromise: resolvedThenable({
-          root: <Children />,
-          ...testHoisted.elements,
-        }),
-        children: props.children,
-      }),
+      React.createElement(StatefulRoot, props),
     ),
+    // The router uses this to write route metadata when no fetch carries it;
+    // route it to the mocked Root's elements state.
+    useMergeElements_UNSTABLE: () => mockMergeElements,
     unstable_prefetchRsc: vi.fn(),
     useRefetch: vi.fn(),
   };
@@ -245,6 +358,9 @@ beforeEach(() => {
 
   delete (globalThis as Record<string, unknown>).__WAKU_PREFETCHED__;
   testHoisted.elements = {};
+  testHoisted.elementsValue = {};
+  testHoisted.setElements = null;
+  testHoisted.mergeElementsAsync = null;
 
   vi.mocked(useRefetch).mockReset();
   vi.mocked(useRefetch).mockReturnValue(createRefetchMock());
@@ -1321,7 +1437,7 @@ describe('Slice', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
     refetch.mockRejectedValueOnce(new Error('slice failed'));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const view = await renderWithMinimalRoot(
       <RouterContext
@@ -1485,40 +1601,11 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('committing a route whose slot has not arrived renders nothing instead of crashing', async () => {
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-
-    // The target route slot is intentionally absent: the mocked refetch never
-    // updates the elements context, simulating a route commit that lands
-    // before the fetched elements do.
-    const elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-    };
-
-    const view = await renderRouter(
-      {
-        initialRoute: { path: '/start', query: '', hash: '' },
-      },
-      elements,
-    );
-
-    if (!capture.router) {
-      throw new Error('router not initialized');
-    }
-
-    await act(async () => {
-      await capture.router!.push('/next');
-    });
-
-    // Previously this threw 'Invalid element: route:/next' from Slot and
-    // poisoned the error boundaries.
-    expect(view.container.textContent).toBe('');
-
-    view.unmount();
-  });
+  // (Removed) The old test 'committing a route whose slot has not arrived
+  // renders nothing instead of crashing' covered the missing-slot guard. The
+  // route now derives from the elements' ROUTE_ID, which the server always ships
+  // with the matching route slot, so a route ahead of its slot is unrepresentable
+  // and the guard is gone.
 
   test('push accepts a structured target and builds the href', async () => {
     const capture = { router: null as RouterApi | null };
@@ -1574,7 +1661,7 @@ describe('Router integration', () => {
       .mockImplementationOnce(() => firstNavigation.promise)
       .mockImplementationOnce(() => secondNavigation.promise)
       .mockImplementationOnce(() => thirdNavigation.promise);
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
     window.history.replaceState({}, '', '/one');
 
     const view = await renderRouterInStrictMode(
@@ -2180,7 +2267,7 @@ describe('Router integration', () => {
     const Probe = makeProbe(capture);
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
     refetch.mockRejectedValueOnce(new Error('refetch failed'));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
     const historyPushSpy = vi.spyOn(window.history, 'pushState');
 
     const elements = {
@@ -2343,7 +2430,7 @@ describe('Router integration', () => {
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
     }));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const shell = {
       [unstable_getRouteSlotId('/next')]: <div>next-shell</div>,
@@ -2383,7 +2470,11 @@ describe('Router integration', () => {
       expect.any(URLSearchParams),
       expect.objectContaining({
         unstable_prefetched: shellPromise,
-        unstable_swr: { pin: expect.any(Function), base: shell },
+        unstable_swr: {
+          pin: expect.any(Function),
+          base: shell,
+          overlay: { [ROUTE_ID]: ['/next', ''] },
+        },
       }),
     );
 
@@ -2395,7 +2486,7 @@ describe('Router integration', () => {
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
     }));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     // Still in flight at navigation time: it started earlier than a fresh
     // request could, so the navigation adopts it instead of duplicating it.
@@ -2442,7 +2533,7 @@ describe('Router integration', () => {
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
     }));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const shell = {
       [unstable_getRouteSlotId('/next')]: <div>next-shell</div>,
@@ -2492,7 +2583,7 @@ describe('Router integration', () => {
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
     }));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const pending = createDeferred<Record<string, unknown>>();
     vi.mocked(prefetchRsc).mockReturnValue(pending.promise);
@@ -2771,7 +2862,7 @@ describe('Router integration', () => {
       [ROUTE_ID]: ['/fresh', ''],
       [IS_STATIC_ID]: false,
     }));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const freshSlotId = unstable_getRouteSlotId('/fresh');
     const shell = {
@@ -3057,7 +3148,7 @@ describe('Router integration', () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const elements = {
       [unstable_getRouteSlotId('/start')]: <Probe />,
@@ -3125,9 +3216,7 @@ describe('Router integration', () => {
         return {};
       },
     );
-    vi.mocked(useRefetch).mockReturnValue(
-      refetch as ReturnType<typeof useRefetch>,
-    );
+    installRefetch(refetch as unknown as MockedRefetch);
 
     const elements = {
       [unstable_getRouteSlotId('/start')]: <Probe />,
@@ -3170,7 +3259,7 @@ describe('Router integration', () => {
       [ROUTE_ID]: ['/streamed', 'x=1'],
       [IS_STATIC_ID]: false,
     }));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3239,7 +3328,7 @@ describe('Router integration', () => {
         refetch.mockResolvedValueOnce(response.resolve);
       }
     }
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const elements = {
@@ -3293,7 +3382,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/account/login', ''],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3357,7 +3446,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/account/login', ''],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3405,7 +3494,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/404', ''],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3462,7 +3551,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/account/profile', 'login=1'],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3507,7 +3596,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/login', ''],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3556,7 +3645,7 @@ describe('Router integration', () => {
             resolveSecond = resolve;
           }),
       );
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3642,7 +3731,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/products', 'page=3'],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3688,7 +3777,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/next', ''],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3764,7 +3853,7 @@ describe('Router integration', () => {
         createCustomError('moved', { status: 307, location: '/a' }),
       ),
     );
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3822,7 +3911,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/account/profile', 'login=1'],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3898,7 +3987,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/other', ''],
         [IS_STATIC_ID]: false,
       });
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -4046,7 +4135,11 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('two routers recover from the same revived 404 error', async () => {
+  // fixme: the harness serves one shared elements store (a single mocked Root
+  // setter), so two <Router>s cannot each recover independently here. The
+  // recovery itself is covered by the single-router 404/redirect follow tests
+  // and by e2e; this only pins the two-router strict-mode dedup.
+  test.skip('two routers recover from the same revived 404 error', async () => {
     const captureA = { router: null as RouterApi | null };
     const ProbeA = makeProbe(captureA);
     const sharedError = createCustomError('not-found', { status: 404 });
@@ -4076,6 +4169,7 @@ describe('Router integration', () => {
         </Unstable_SearchCodecsProvider>
       </StrictMode>,
     );
+    await flush();
     await flush();
 
     // each boundary follows independently and both recover
@@ -4187,6 +4281,8 @@ describe('Router integration', () => {
       },
       elements,
     );
+    // the follow fetches and its elements suspend, so let them settle
+    await flush();
     await flush();
 
     expect(getRefetchMock()).toHaveBeenCalledWith(
@@ -4350,7 +4446,7 @@ describe('Router integration', () => {
       [ROUTE_ID]: ['/two', ''],
       [IS_STATIC_ID]: false,
     }));
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
     window.history.replaceState({}, '', '/one');
 
     const view = await renderRouter(
@@ -4423,7 +4519,7 @@ describe('Router integration', () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(
       () => navigation.promise,
     );
-    vi.mocked(useRefetch).mockReturnValue(refetch);
+    installRefetch(refetch);
     window.history.replaceState({}, '', '/one');
 
     const PendingProbe = () => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -76,19 +76,14 @@ type IntersectionObserverMockInstance = IntersectionObserver & {
   callback: IntersectionObserverCallback;
 };
 
-// Elements the mocked `Root` provides for the current render. Hoisted so the
-// `vi.mock` factory can read it. The mocked Root keeps them in state and
-// `setElements` (set once mounted) merges a fetched response in, so the derived
-// route follows a navigation the way it does with the real minimal client.
+// Hoisted so the `vi.mock` factory can read it. `elements` is the initial
+// elements a mocked Root seeds; `inner` is the shared, configurable refetch
+// mock tests observe. Each mocked Root keeps its OWN elements state (see the
+// factory), so independent Roots behave independently like the real client.
 const testHoisted = vi.hoisted(() => ({
   elements: {} as Record<string, unknown>,
-  elementsValue: {} as Record<string, unknown>,
-  // synchronous merge of a value (used for route metadata with no fetch)
-  setElements: null as ((data: Record<string, unknown>) => void) | null,
-  // eager merge of a pending fetch: elements suspend until it resolves, like the
-  // real client, so a transition stays pending across the fetch
-  mergeElementsAsync: null as
-    ((data: Promise<Record<string, unknown>>) => void) | null,
+  inner: null as
+    ((...args: unknown[]) => Promise<Record<string, unknown>>) | null,
 }));
 
 const createDeferred = <T,>() => {
@@ -130,54 +125,27 @@ const withRouteMeta = (
   return { ...data, [ROUTE_ID]: [routePath, query] };
 };
 
-// The refetch the router calls (`outer`) merges its response into the mocked
-// Root's elements so the derived route follows; tests configure and inspect the
-// underlying `inner` mock (getRefetchMock(), or the fn passed to installRefetch).
+// Per-root elements state, wired to each mocked Root through context so a
+// refetch or merge targets the Root that made it (see the factory).
+type RootStore = {
+  applySync: (data: Record<string, unknown>) => void;
+  applyAsync: (data: Promise<Record<string, unknown>>) => void;
+};
 type RefetchInner = ReturnType<typeof useRefetch>;
 type MockedRefetch = ReturnType<typeof vi.fn<RefetchInner>>;
-type RefetchMock = RefetchInner & { inner: MockedRefetch };
 
-const wrapRefetch = (inner: MockedRefetch): RefetchMock => {
-  const call = (
-    rscPath: string,
-    ...rest: [rscParams?: unknown, options?: unknown]
-  ) => {
-    // Merge synchronously (in the caller's transition) with a pending promise
-    // so the elements suspend until the response lands, like the real client;
-    // a failed fetch leaves the elements unchanged (the router follows it).
-    const dataPromise = Promise.resolve(
-      (inner as (...args: unknown[]) => Promise<Record<string, unknown>>)(
-        rscPath,
-        ...rest,
-      ),
-    ).then((result) => withRouteMeta(result, rscPath, rest[0]));
-    testHoisted.mergeElementsAsync?.(dataPromise.catch(() => ({})));
-    return dataPromise;
-  };
-  const outer = vi.fn(call) as unknown as RefetchMock;
-  outer.inner = inner;
-  return outer;
-};
-
-const createRefetchMock = (): RefetchMock =>
-  wrapRefetch(vi.fn<RefetchInner>(async () => ({})));
-
-// Install a test-provided refetch behind the merging wrapper. Returns the same
-// fn so the test keeps configuring/inspecting it.
+// Install a test-provided refetch as the shared inner mock the mocked Roots
+// wrap. Returns it so the test keeps configuring/inspecting it.
 const installRefetch = (inner: MockedRefetch) => {
-  vi.mocked(useRefetch).mockReturnValue(wrapRefetch(inner));
+  testHoisted.inner = inner as unknown as typeof testHoisted.inner;
   return inner;
 };
 
-const getRefetchMock = () => {
-  const results = vi.mocked(useRefetch).mock.results;
-  for (let index = results.length - 1; index >= 0; index -= 1) {
-    const result = results[index];
-    if (result?.type === 'return') {
-      return (result.value as RefetchMock).inner;
-    }
+const getRefetchMock = (): MockedRefetch => {
+  if (!testHoisted.inner) {
+    throw new Error('refetch mock not initialized');
   }
-  throw new Error('useRefetch was not called');
+  return testHoisted.inner as unknown as MockedRefetch;
 };
 
 const getIntersectionObserverMockInstance = () => {
@@ -233,44 +201,76 @@ vi.mock('../src/minimal/client.js', async () => {
       value,
     });
 
+  // Each mocked Root provides its own store through this context, so a refetch
+  // or merge from within a Root targets that Root's elements state.
+  const StoreContext = React.createContext<RootStore | null>(null);
+
   const StatefulRoot = (props: { children?: ReactNode }) => {
-    const [elements, setElements] = React.useState<
-      Promise<Record<string, unknown>>
-    >(() => {
-      testHoisted.elementsValue = {
+    const valueRef = React.useRef<Record<string, unknown>>(undefined);
+    if (!valueRef.current) {
+      valueRef.current = {
         root: React.createElement(actual.Children),
         ...testHoisted.elements,
       };
-      return makeThenable(testHoisted.elementsValue);
-    });
-    // Assigned during render (not in an effect) so it is available before
-    // descendant effects run, e.g. a redirect follow triggered on first render.
-    testHoisted.setElements = (data) => {
-      testHoisted.elementsValue = { ...testHoisted.elementsValue, ...data };
-      setElements(makeThenable(testHoisted.elementsValue));
-    };
-    testHoisted.mergeElementsAsync = (dataPromise) => {
-      const pending = dataPromise.then((data) => {
-        testHoisted.elementsValue = { ...testHoisted.elementsValue, ...data };
-        return testHoisted.elementsValue;
-      });
-      setElements(pending);
-    };
+    }
+    const [elements, setElements] = React.useState<
+      Promise<Record<string, unknown>>
+    >(() => makeThenable(valueRef.current!));
+    const storeRef = React.useRef<RootStore>(undefined);
+    if (!storeRef.current) {
+      storeRef.current = {
+        // synchronous merge of a value (route metadata with no fetch)
+        applySync: (data) => {
+          valueRef.current = { ...valueRef.current, ...data };
+          setElements(makeThenable(valueRef.current));
+        },
+        // eager merge of a pending fetch: elements suspend until it resolves,
+        // like the real client, so a transition stays pending across the fetch
+        applyAsync: (dataPromise) => {
+          setElements(
+            dataPromise.then((data) => {
+              valueRef.current = { ...valueRef.current, ...data };
+              return valueRef.current!;
+            }),
+          );
+        },
+      };
+    }
     // A boundary so a merge that suspends (pending fetch) shows a fallback
     // instead of crashing on a non-transition update; the real app supplies its
     // own boundaries.
     return React.createElement(
-      React.Suspense,
-      { fallback: null },
-      actual.INTERNAL_ServerRoot({
-        elementsPromise: elements,
-        children: props.children,
-      }),
+      StoreContext.Provider,
+      { value: storeRef.current },
+      React.createElement(
+        React.Suspense,
+        { fallback: null },
+        actual.INTERNAL_ServerRoot({
+          elementsPromise: elements,
+          children: props.children,
+        }),
+      ),
     );
   };
 
-  const mockMergeElements = (partial: Record<string, unknown>) => {
-    testHoisted.setElements?.(partial);
+  // Per-root refetch: calls the shared inner mock, then merges the response into
+  // this Root's own store.
+  const useMockRefetch = () => {
+    const store = React.use(StoreContext);
+    return React.useMemo(
+      () =>
+        (
+          rscPath: string,
+          ...rest: [rscParams?: unknown, options?: unknown]
+        ) => {
+          const dataPromise = Promise.resolve(
+            testHoisted.inner!(rscPath, ...rest),
+          ).then((result) => withRouteMeta(result, rscPath, rest[0]));
+          store?.applyAsync(dataPromise.catch(() => ({})));
+          return dataPromise;
+        },
+      [store],
+    );
   };
 
   return {
@@ -278,11 +278,14 @@ vi.mock('../src/minimal/client.js', async () => {
     Root: vi.fn((props: Parameters<typeof actual.Root>[0]) =>
       React.createElement(StatefulRoot, props),
     ),
-    // The router uses this to write route metadata when no fetch carries it;
-    // route it to the mocked Root's elements state.
-    useMergeElements_UNSTABLE: () => mockMergeElements,
+    // The router writes route metadata here when no fetch carries it; route it
+    // to the calling Root's own store.
+    useMergeElements_UNSTABLE: () => {
+      const store = React.use(StoreContext);
+      return store ? store.applySync : () => {};
+    },
     unstable_prefetchRsc: vi.fn(),
-    useRefetch: vi.fn(),
+    useRefetch: vi.fn(useMockRefetch),
   };
 });
 
@@ -358,12 +361,10 @@ beforeEach(() => {
 
   delete (globalThis as Record<string, unknown>).__WAKU_PREFETCHED__;
   testHoisted.elements = {};
-  testHoisted.elementsValue = {};
-  testHoisted.setElements = null;
-  testHoisted.mergeElementsAsync = null;
-
-  vi.mocked(useRefetch).mockReset();
-  vi.mocked(useRefetch).mockReturnValue(createRefetchMock());
+  // Fresh shared refetch mock per test; the mocked useRefetch (a per-root hook)
+  // wraps it, so its implementation must stay intact (do not mockReset it).
+  testHoisted.inner = vi.fn(async () => ({}));
+  vi.mocked(useRefetch).mockClear();
   vi.mocked(preloadModule).mockClear();
   vi.mocked(prefetchRsc).mockReset();
   // prefetchRsc returns the decoded Promise<Elements>; default to an empty
@@ -4135,11 +4136,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  // fixme: the harness serves one shared elements store (a single mocked Root
-  // setter), so two <Router>s cannot each recover independently here. The
-  // recovery itself is covered by the single-router 404/redirect follow tests
-  // and by e2e; this only pins the two-router strict-mode dedup.
-  test.skip('two routers recover from the same revived 404 error', async () => {
+  test('two routers recover from the same revived 404 error', async () => {
     const captureA = { router: null as RouterApi | null };
     const ProbeA = makeProbe(captureA);
     const sharedError = createCustomError('not-found', { status: 404 });

--- a/packages/waku/tests/router-navigator.test.ts
+++ b/packages/waku/tests/router-navigator.test.ts
@@ -5,7 +5,7 @@ import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import {
   applyServerRedirect,
   canCommitInstantly,
-  deriveCommitted,
+  deriveNav,
   pinForSwr,
   resolveFollowingErrors,
 } from '../src/router/client-utils/navigate.js';
@@ -139,11 +139,11 @@ describe('navigator', () => {
   });
 });
 
-describe('deriveCommitted', () => {
+describe('deriveNav', () => {
   const getServerRedirect = () => undefined;
 
   test('a plain navigation keeps its history and scroll intent', () => {
-    const committed = deriveCommitted({
+    const { route: derived, nav } = deriveNav({
       destination: {
         route: route('/next'),
         routeUrl: urlOf('/next'),
@@ -155,16 +155,16 @@ describe('deriveCommitted', () => {
       shouldScroll: true,
       getServerRedirect,
     });
-    expect(committed.route.path).toBe('/next');
-    expect(committed.history).toEqual({
+    expect(derived.path).toBe('/next');
+    expect(nav.history).toEqual({
       mode: 'push',
       url: urlOf('/next'),
     });
-    expect(committed.scroll).toEqual({ pathChanged: true });
+    expect(nav.scroll).toEqual({ pathChanged: true });
   });
 
   test('a followed navigation replaces the history url', () => {
-    const committed = deriveCommitted({
+    const { nav } = deriveNav({
       destination: {
         route: route('/login'),
         routeUrl: urlOf('/login'),
@@ -176,11 +176,11 @@ describe('deriveCommitted', () => {
       shouldScroll: true,
       getServerRedirect,
     });
-    expect(committed.history?.url?.pathname).toBe('/login');
+    expect(nav.history?.url?.pathname).toBe('/login');
   });
 
   test('a server side redirect to the 404 route drops the history write', () => {
-    const committed = deriveCommitted({
+    const { route: derived, nav } = deriveNav({
       destination: {
         route: route('/somewhere'),
         routeUrl: urlOf('/somewhere'),
@@ -193,9 +193,9 @@ describe('deriveCommitted', () => {
       shouldScroll: false,
       getServerRedirect: () => route('/404'),
     });
-    expect(committed.route.path).toBe('/404');
-    expect(committed.history).toBeNull();
-    expect(committed.scroll).toBeNull();
+    expect(derived.path).toBe('/404');
+    expect(nav.history).toBeNull();
+    expect(nav.scroll).toBeNull();
   });
 });
 
@@ -250,14 +250,13 @@ describe('pinForSwr', () => {
 
 describe('applyServerRedirect', () => {
   const prev = {
-    route: route('/a'),
+    hash: '',
     history: { mode: 'push', url: undefined },
     scroll: { pathChanged: true },
   } as const;
 
-  test('patches the route and replaces history with the redirect url', () => {
+  test('replaces history with the redirect url and keeps the scroll intent', () => {
     const next = applyServerRedirect(prev, route('/b'));
-    expect(next.route.path).toBe('/b');
     expect(next.history?.mode).toBe('replace');
     expect(next.history?.url?.pathname).toBe('/b');
     expect(next.scroll).toEqual({ pathChanged: true });
@@ -265,7 +264,6 @@ describe('applyServerRedirect', () => {
 
   test('drops the history write for the 404 route', () => {
     const next = applyServerRedirect(prev, route('/404'));
-    expect(next.route.path).toBe('/404');
     expect(next.history).toBeNull();
   });
 });

--- a/packages/waku/tests/router-navigator.test.ts
+++ b/packages/waku/tests/router-navigator.test.ts
@@ -250,13 +250,15 @@ describe('pinForSwr', () => {
 
 describe('applyServerRedirect', () => {
   const prev = {
+    query: '',
     hash: '',
     history: { mode: 'push', url: undefined },
     scroll: { pathChanged: true },
   } as const;
 
   test('replaces history with the redirect url and keeps the scroll intent', () => {
-    const next = applyServerRedirect(prev, route('/b'));
+    const next = applyServerRedirect(prev, route('/b', 'x=1'));
+    expect(next.query).toBe('x=1');
     expect(next.history?.mode).toBe('replace');
     expect(next.history?.url?.pathname).toBe('/b');
     expect(next.scroll).toEqual({ pathChanged: true });


### PR DESCRIPTION
The rendered route came from the router's own committed.route, kept separate from the ROUTE_ID the server ships with the route slot. Keeping the two in sync is what the missing-slot guard (#2204) and the atomic commit work were for.

Now the route is derived from the elements. The route and its slot come from one place and cannot drift, so the guard and the atomic commit mechanism are dropped, and the ssr-redirect flake is gone by construction.

Main changes:

- The router reads the current path from the elements' ROUTE_ID. Only the query and hash stay in client state, because they are client owned: a static route does not echo the URL query, and the server never sees the hash.
- The minimal API `unstable_mergeElements` is replaced with a React context hook, `useMergeElements_UNSTABLE`, so the router can write route metadata to its own Root.
- Error following (redirects and 404) is reworked around a promise map. This removes the old limitation where an instant navigation with a server redirect did not reconcile the URL, and also fixes the URL when a followed redirect redirects again.
- The previously skipped two-router recovery test and the instant navigation redirect e2e test are enabled.
