### PR TITLE
refactor(router): single source of truth in the elements record

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -163,6 +163,8 @@ export const PostButton = () => {
 };
 ```
 
+Both return a promise that resolves once the response for the route you asked for has been handled. They do not wait for a redirect or a 404 page that the response leads to, and they do not wait for React to finish rendering the destination.
+
 When the shell is cached, the layout and the `Loading...` fallback appear with no round trip, and the post's content streams into the fallback once the server responds. When the shell is **not** cached, the navigation falls back to normal behavior: the current page stays put until the response arrives, so there is no blank flash.
 
 The `<Suspense>` boundary decides how localized the loading state is. Wrapping the whole page area (as above) swaps the page for a skeleton; wrapping only a dynamic slice inside an otherwise-static page leaves the rest in place and shows the skeleton for just that slice.

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -163,7 +163,7 @@ export const PostButton = () => {
 };
 ```
 
-Both return a promise that resolves once the response for the route you asked for has been handled. They do not wait for a redirect or a 404 page that the response leads to, and they do not wait for React to finish rendering the destination.
+Both return a promise that resolves once the navigation you asked for has been handled: after the response when the route needs one, and right away when it does not, such as a static route or the route you are already on. They do not wait for a redirect or a 404 page that the response leads to, and they do not wait for React to finish rendering the destination.
 
 When the shell is cached, the layout and the `Loading...` fallback appear with no round trip, and the post's content streams into the fallback once the server responds. When the shell is **not** cached, the navigation falls back to normal behavior: the current page stays put until the response arrives, so there is no blank flash.
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -163,7 +163,9 @@ export const PostButton = () => {
 };
 ```
 
-Both return a promise that resolves once the navigation you asked for has been handled: after the response when the route needs one, and right away when it does not, such as a static route or the route you are already on. They do not wait for a redirect or a 404 page that the response leads to, and they do not wait for React to finish rendering the destination.
+Both return a promise that resolves once the navigation you asked for has been handled: after the response when the route needs one, right away when it does not, such as a static route already loaded once or the route you are already on, and also when a newer navigation supersedes it.
+
+It does not wait for a redirect or a 404 page that the response leads to, and it does not wait for React to finish rendering the destination, so the address bar may still show the previous URL when it resolves.
 
 When the shell is cached, the layout and the `Loading...` fallback appear with no round trip, and the post's content streams into the fallback once the server responds. When the shell is **not** cached, the navigation falls back to normal behavior: the current page stays put until the response arrives, so there is no blank flash.
 

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -250,8 +250,8 @@ test.describe('instant-nav', () => {
     await expect(page.getByTestId('complete-count')).toHaveText('3');
   });
 
-  // ...and surfaces a fetch error instead of getting stuck on the skeleton.
-  test('a failed instant navigation surfaces the error instead of sticking', async ({
+  // ...and retries as a browser navigation instead of sticking on the skeleton.
+  test('a failed instant navigation retries as a browser navigation', async ({
     page,
   }) => {
     await page.goto(`http://localhost:${port}/post/1`);
@@ -264,11 +264,11 @@ test.describe('instant-nav', () => {
     // Fail the RSC fetch, then instant-revisit /post/1 (its shell is cached).
     await page.route('**/RSC/**', (route) => route.abort());
     await page.getByTestId('link-post-1').click();
-    await expect(page.locator('body')).toContainText(/error/i);
-    await expect(page.getByTestId('page-skeleton')).toBeHidden();
-    // The optimistic commit already moved to the target URL, the same place a
-    // non-instant navigation that errors lands, and the error shows there.
+    // The router falls back to a document request for the attempted url,
+    // which does not go through the blocked RSC endpoint.
     await expect(page).toHaveURL(/\/post\/1$/);
+    await expect(page.getByTestId('post-body')).toHaveText('Post 1');
+    await expect(page.getByTestId('page-skeleton')).toBeHidden();
   });
 
   // With a dynamic etag (unstable_getEtag), an instant revisit must not let a

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -250,9 +250,8 @@ test.describe('instant-nav', () => {
     await expect(page.getByTestId('complete-count')).toHaveText('3');
   });
 
-  // ...and hands a redirected instant navigation to the browser instead of
-  // sticking on the skeleton.
-  test('an instant navigation redirected off the rsc endpoint leaves the app', async ({
+  // ...and surfaces a fetch error instead of getting stuck on the skeleton.
+  test('a failed instant navigation surfaces the error instead of sticking', async ({
     page,
   }) => {
     await page.goto(`http://localhost:${port}/post/1`);
@@ -262,17 +261,14 @@ test.describe('instant-nav', () => {
     await page.getByTestId('link-post-2').click();
     await expect(page.getByTestId('post-body')).toHaveText('Post 2');
 
-    // An auth proxy in front of the app answers the RSC request with a
-    // redirect to a page, then instant-revisit /post/1 (its shell is cached).
-    await page.route('**/RSC/**', (route) =>
-      route.fulfill({ status: 302, headers: { location: '/post/1' } }),
-    );
+    // Fail the RSC fetch, then instant-revisit /post/1 (its shell is cached).
+    await page.route('**/RSC/**', (route) => route.abort());
     await page.getByTestId('link-post-1').click();
-    // The browser follows the redirect as a document request, which is the
-    // only way to land on a page that has no rsc payload.
-    await expect(page).toHaveURL(/\/post\/1$/);
-    await expect(page.getByTestId('post-body')).toHaveText('Post 1');
+    await expect(page.locator('body')).toContainText(/error/i);
     await expect(page.getByTestId('page-skeleton')).toBeHidden();
+    // The optimistic commit already moved to the target URL, the same place a
+    // non-instant navigation that errors lands, and the error shows there.
+    await expect(page).toHaveURL(/\/post\/1$/);
   });
 
   // With a dynamic etag (unstable_getEtag), an instant revisit must not let a

--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -250,8 +250,9 @@ test.describe('instant-nav', () => {
     await expect(page.getByTestId('complete-count')).toHaveText('3');
   });
 
-  // ...and retries as a browser navigation instead of sticking on the skeleton.
-  test('a failed instant navigation retries as a browser navigation', async ({
+  // ...and hands a redirected instant navigation to the browser instead of
+  // sticking on the skeleton.
+  test('an instant navigation redirected off the rsc endpoint leaves the app', async ({
     page,
   }) => {
     await page.goto(`http://localhost:${port}/post/1`);
@@ -261,11 +262,14 @@ test.describe('instant-nav', () => {
     await page.getByTestId('link-post-2').click();
     await expect(page.getByTestId('post-body')).toHaveText('Post 2');
 
-    // Fail the RSC fetch, then instant-revisit /post/1 (its shell is cached).
-    await page.route('**/RSC/**', (route) => route.abort());
+    // An auth proxy in front of the app answers the RSC request with a
+    // redirect to a page, then instant-revisit /post/1 (its shell is cached).
+    await page.route('**/RSC/**', (route) =>
+      route.fulfill({ status: 302, headers: { location: '/post/1' } }),
+    );
     await page.getByTestId('link-post-1').click();
-    // The router falls back to a document request for the attempted url,
-    // which does not go through the blocked RSC endpoint.
+    // The browser follows the redirect as a document request, which is the
+    // only way to land on a page that has no rsc payload.
     await expect(page).toHaveURL(/\/post\/1$/);
     await expect(page.getByTestId('post-body')).toHaveText('Post 1');
     await expect(page.getByTestId('page-skeleton')).toBeHidden();

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -24,18 +24,11 @@ const isErrorInfo = (x: unknown): x is ErrorInfo => {
 const prefix = '__WAKU_CUSTOM_ERROR__;';
 
 // This is an internal API and not for public use
-export const createCustomError = (message: string, errorInfo: ErrorInfo) =>
-  markCustomError(new Error(message), errorInfo);
-
-// Adds the info to an error as it is, so its type and stack survive.
-// This is an internal API and not for public use
-export function markCustomError<T>(err: T, errorInfo: ErrorInfo): T | Error {
-  if (typeof err !== 'object' || err === null) {
-    return createCustomError(String(err), errorInfo);
-  }
+export const createCustomError = (message: string, errorInfo: ErrorInfo) => {
+  const err = new Error(message);
   (err as { digest?: string }).digest = prefix + JSON.stringify(errorInfo);
   return err;
-}
+};
 
 export const getErrorInfo = (err: unknown) => {
   const digest = (err as { digest?: string } | undefined)?.digest;

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -1,7 +1,8 @@
 type ErrorInfo = {
   status?: number;
   location?: string;
-  // set by the client when the fetch failed with a network error
+  // set by the client when the fetch failed with a network error; nothing in
+  // waku reads it, it is there for an app to decide its own recovery
   unstable_networkError?: boolean;
 };
 

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -1,6 +1,8 @@
 type ErrorInfo = {
   status?: number;
   location?: string;
+  // set by the client when the request produced no response at all
+  noResponse?: boolean;
 };
 
 const isErrorInfo = (x: unknown): x is ErrorInfo => {
@@ -11,6 +13,9 @@ const isErrorInfo = (x: unknown): x is ErrorInfo => {
     return false;
   }
   if ('location' in x && typeof (x as ErrorInfo).location !== 'string') {
+    return false;
+  }
+  if ('noResponse' in x && typeof (x as ErrorInfo).noResponse !== 'boolean') {
     return false;
   }
   return true;

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -1,8 +1,8 @@
 type ErrorInfo = {
   status?: number;
   location?: string;
-  // set by the client when the request produced no response at all
-  noResponse?: boolean;
+  // set by the client when the fetch failed with a network error
+  unstable_networkError?: boolean;
 };
 
 const isErrorInfo = (x: unknown): x is ErrorInfo => {
@@ -15,7 +15,10 @@ const isErrorInfo = (x: unknown): x is ErrorInfo => {
   if ('location' in x && typeof (x as ErrorInfo).location !== 'string') {
     return false;
   }
-  if ('noResponse' in x && typeof (x as ErrorInfo).noResponse !== 'boolean') {
+  if (
+    'unstable_networkError' in x &&
+    typeof (x as ErrorInfo).unstable_networkError !== 'boolean'
+  ) {
     return false;
   }
   return true;

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -24,11 +24,18 @@ const isErrorInfo = (x: unknown): x is ErrorInfo => {
 const prefix = '__WAKU_CUSTOM_ERROR__;';
 
 // This is an internal API and not for public use
-export const createCustomError = (message: string, errorInfo: ErrorInfo) => {
-  const err = new Error(message);
+export const createCustomError = (message: string, errorInfo: ErrorInfo) =>
+  markCustomError(new Error(message), errorInfo);
+
+// Adds the info to an error as it is, so its type and stack survive.
+// This is an internal API and not for public use
+export function markCustomError<T>(err: T, errorInfo: ErrorInfo): T | Error {
+  if (typeof err !== 'object' || err === null) {
+    return createCustomError(String(err), errorInfo);
+  }
   (err as { digest?: string }).digest = prefix + JSON.stringify(errorInfo);
   return err;
-};
+}
 
 export const getErrorInfo = (err: unknown) => {
   const digest = (err as { digest?: string } | undefined)?.digest;

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -1,8 +1,7 @@
 type ErrorInfo = {
   status?: number;
   location?: string;
-  // set by the client when the fetch failed with a network error; nothing in
-  // waku reads it, it is there for an app to decide its own recovery
+  // set by the client, read by no one in waku: an app decides its own recovery
   unstable_networkError?: boolean;
 };
 

--- a/packages/waku/src/minimal/client-utils/fetch-store.ts
+++ b/packages/waku/src/minimal/client-utils/fetch-store.ts
@@ -9,8 +9,8 @@ export const CACHED_ETAGS = 'c';
 
 export type SetElements = (
   updater: (
-    prev: Promise<Record<string, unknown>>,
-  ) => Promise<Record<string, unknown>>,
+    prev: Promise<Record<string | symbol, unknown>>,
+  ) => Promise<Record<string | symbol, unknown>>,
 ) => void;
 
 export type FetchEnhancer = (fetchFn: typeof fetch) => typeof fetch;

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -59,10 +59,16 @@ const checkStatus = async (
   responsePromise: Promise<Response>,
 ): Promise<Response> => {
   const response = await responsePromise;
-  if (response.redirected && typeof window !== 'undefined') {
-    // a redirected rsc request becomes a browser navigation
-    window.location.assign(response.url);
-    return new Promise<never>(() => {}); // stay pending until unload
+  if (
+    response.redirected &&
+    typeof window !== 'undefined' &&
+    !new URL(response.url).pathname.startsWith(BASE_RSC_PATH)
+  ) {
+    // redirected off the rsc endpoint; the navigation layer follows it
+    throw createCustomError('redirected rsc request', {
+      status: 307,
+      location: response.url,
+    });
   }
   if (!response.ok) {
     const location = response.headers.get('location');

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -154,6 +154,12 @@ const swrElementsPromise = (
           }
         }
       }
+      // symbol keys are client owned; they are carried, never fetched
+      for (const sym of Object.getOwnPropertySymbols(aRes)) {
+        (nextElements as Record<symbol, unknown>)[sym] = (
+          aRes as Record<symbol, unknown>
+        )[sym];
+      }
       if (overlay) {
         Object.assign(nextElements, overlay);
       }
@@ -220,10 +226,10 @@ type Refetch = (
   rscParams?: unknown,
   options?: FetchRscOptions & {
     unstable_prefetched?: Elements | Promise<Elements>;
+    unstable_overlay?: Elements;
     unstable_swr?: {
       pin: (key: string) => boolean;
       base?: Elements;
-      overlay?: Elements;
     };
   },
 ) => Promise<Elements>;
@@ -552,8 +558,11 @@ export const Root = ({
     elements.then(updateCachedEtags, () => {});
   }, [elements]);
   const refetch = useCallback<Refetch>(async (rscPath, rscParams, options) => {
-    const { unstable_prefetched: prefetched, unstable_swr: swr } =
-      options ?? {};
+    const {
+      unstable_prefetched: prefetched,
+      unstable_overlay: overlay,
+      unstable_swr: swr,
+    } = options ?? {};
     delete fetchRscStore[ENTRY];
     let data: Promise<Elements>;
     if (prefetched) {
@@ -571,27 +580,23 @@ export const Root = ({
     const dataWithoutErrors = Promise.resolve(data).catch(() => ({}));
     if (swr) {
       setElements((prev) =>
-        swrElementsPromise(
-          prev,
-          dataWithoutErrors,
-          swr.pin,
-          swr.base,
-          swr.overlay,
-        ),
+        swrElementsPromise(prev, dataWithoutErrors, swr.pin, swr.base, overlay),
       );
       return Promise.resolve(data).then((resolved) => {
         setElements((prev) =>
-          swrNewKeysElementsPromise(
-            prev,
-            dataWithoutErrors,
-            resolved,
-            swr.overlay,
-          ),
+          swrNewKeysElementsPromise(prev, dataWithoutErrors, resolved, overlay),
         );
         return resolved;
       });
     }
-    setElements((prev) => mergeElementsPromise(prev, dataWithoutErrors));
+    setElements((prev) =>
+      mergeElementsPromise(
+        prev,
+        overlay
+          ? dataWithoutErrors.then((data) => ({ ...data, ...overlay }))
+          : dataWithoutErrors,
+      ),
+    );
     return data;
   }, []);
   const mergeElements = useCallback<MergeElements>((partial) => {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -70,15 +70,9 @@ const checkStatus = async (
     });
   }
   if (!response.ok) {
-    const location = response.headers.get('location');
-    const err = createCustomError(
-      (await response.text()) || response.statusText,
-      {
-        status: response.status,
-        ...(location && { location }),
-      },
-    );
-    throw err;
+    throw createCustomError((await response.text()) || response.statusText, {
+      status: response.status,
+    });
   }
   return response;
 };

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -126,6 +126,27 @@ const mergeElementsPromise = (
   return getCached(getResult, cache2, b);
 };
 
+const replaceCache = new WeakMap();
+const replaceElementsPromise = (
+  a: Promise<Elements>,
+  b: Promise<Elements>,
+): Promise<Elements> => {
+  const getResult = () =>
+    Promise.all([a, b]).then(([aRes, bRes]) => {
+      const nextElements = { ...bRes };
+      delete nextElements._value;
+      // symbol keys are client owned; they are carried, never fetched
+      for (const sym of Object.getOwnPropertySymbols(aRes)) {
+        (nextElements as Record<symbol, unknown>)[sym] = (
+          aRes as Record<symbol, unknown>
+        )[sym];
+      }
+      return nextElements;
+    });
+  const cache2 = getCached(() => new WeakMap(), replaceCache, a);
+  return getCached(getResult, cache2, b);
+};
+
 const slotIdOf = (key: string) =>
   key.startsWith(ETAG_ID_PREFIX) ? key.slice(ETAG_ID_PREFIX.length) : key;
 
@@ -487,7 +508,7 @@ export const unstable_fetchRsc = (
     registerHmrRefetch(() => {
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
-      getSetElements()(() => data);
+      getSetElements()((prev) => replaceElementsPromise(prev, data));
     });
   }
   const entry = fetchRscStore[ENTRY];

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -59,6 +59,11 @@ const checkStatus = async (
   responsePromise: Promise<Response>,
 ): Promise<Response> => {
   const response = await responsePromise;
+  if (response.redirected && typeof window !== 'undefined') {
+    // the server redirected the rsc request itself; leave it to the browser
+    window.location.assign(response.url);
+    return new Promise<never>(() => {}); // stay pending until unload
+  }
   if (!response.ok) {
     const location = response.headers.get('location');
     const err = createCustomError(

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -60,7 +60,7 @@ const checkStatus = async (
 ): Promise<Response> => {
   const response = await responsePromise;
   if (response.redirected && typeof window !== 'undefined') {
-    // the server redirected the rsc request itself; leave it to the browser
+    // a redirected rsc request becomes a browser navigation
     window.location.assign(response.url);
     return new Promise<never>(() => {}); // stay pending until unload
   }
@@ -594,8 +594,7 @@ export const Root = ({
         return resolved;
       });
     }
-    // built outside the updater so a replayed updater reuses the identity;
-    // the overlay only applies when the fetch succeeds
+    // created once so a replayed updater stays pure; overlay on success only
     const dataToMerge = overlay
       ? Promise.resolve(data).then(
           (resolved) => ({ ...resolved, ...overlay }),

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -589,14 +589,15 @@ export const Root = ({
         return resolved;
       });
     }
-    setElements((prev) =>
-      mergeElementsPromise(
-        prev,
-        overlay
-          ? dataWithoutErrors.then((data) => ({ ...data, ...overlay }))
-          : dataWithoutErrors,
-      ),
-    );
+    // built outside the updater so a replayed updater reuses the identity;
+    // the overlay only applies when the fetch succeeds
+    const dataToMerge = overlay
+      ? Promise.resolve(data).then(
+          (resolved) => ({ ...resolved, ...overlay }),
+          () => ({}),
+        )
+      : dataWithoutErrors;
+    setElements((prev) => mergeElementsPromise(prev, dataToMerge));
     return data;
   }, []);
   const mergeElements = useCallback<MergeElements>((partial) => {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -589,12 +589,9 @@ export const Root = ({
         return resolved;
       });
     }
-    // created once so a replayed updater stays pure; overlay on success only
+    // the overlay lands only when the fetch succeeds
     const dataToMerge = overlay
-      ? Promise.resolve(data).then(
-          (resolved) => ({ ...resolved, ...overlay }),
-          () => ({}),
-        )
+      ? mergeElementsPromise(data, overlay).catch(() => ({}))
       : dataWithoutErrors;
     setElements((prev) => mergeElementsPromise(prev, dataToMerge));
     return data;

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -119,6 +119,27 @@ const mergeElementsPromise = (
   return getCached(getResult, cache2, b);
 };
 
+// an hmr refresh replaces server keys and carries the client's symbol keys
+const refreshCache = new WeakMap();
+const refreshElementsPromise = (
+  a: Promise<Elements>,
+  b: Promise<Elements>,
+): Promise<Elements> => {
+  const getResult = () =>
+    Promise.all([a, b]).then(([aRes, bRes]) => {
+      const nextElements = { ...bRes };
+      delete nextElements._value;
+      for (const key of Reflect.ownKeys(aRes)) {
+        if (typeof key === 'symbol') {
+          nextElements[key] = aRes[key];
+        }
+      }
+      return nextElements;
+    });
+  const cache2 = getCached(() => new WeakMap(), refreshCache, a);
+  return getCached(getResult, cache2, b);
+};
+
 const slotIdOf = <K extends string | symbol>(key: K): K =>
   typeof key === 'string' && key.startsWith(ETAG_ID_PREFIX)
     ? (key.slice(ETAG_ID_PREFIX.length) as K)
@@ -476,7 +497,7 @@ export const unstable_fetchRsc = (
     registerHmrRefetch(() => {
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
-      getSetElements()((prev) => mergeElementsPromise(prev, data));
+      getSetElements()((prev) => refreshElementsPromise(prev, data));
     });
   }
   const entry = fetchRscStore[ENTRY];

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -83,7 +83,7 @@ const checkStatus = async (
   return response;
 };
 
-type Elements = Record<string, unknown>;
+type Elements = Record<string | symbol, unknown>;
 
 const collectCachedEtags = (elements: Elements): Etags => {
   const etags: Etags = {};
@@ -125,46 +125,27 @@ const mergeElementsPromise = (
   return getCached(getResult, cache2, b);
 };
 
-const replaceCache = new WeakMap();
-const replaceElementsPromise = (
-  a: Promise<Elements>,
-  b: Promise<Elements>,
-): Promise<Elements> => {
-  const getResult = () =>
-    Promise.all([a, b]).then(([aRes, bRes]) => {
-      const nextElements = { ...bRes };
-      delete nextElements._value;
-      // symbol keys are client owned; they are carried, never fetched
-      for (const sym of Object.getOwnPropertySymbols(aRes)) {
-        (nextElements as Record<symbol, unknown>)[sym] = (
-          aRes as Record<symbol, unknown>
-        )[sym];
-      }
-      return nextElements;
-    });
-  const cache2 = getCached(() => new WeakMap(), replaceCache, a);
-  return getCached(getResult, cache2, b);
-};
-
-const slotIdOf = (key: string) =>
-  key.startsWith(ETAG_ID_PREFIX) ? key.slice(ETAG_ID_PREFIX.length) : key;
+const slotIdOf = <K extends string | symbol>(key: K): K =>
+  typeof key === 'string' && key.startsWith(ETAG_ID_PREFIX)
+    ? (key.slice(ETAG_ID_PREFIX.length) as K)
+    : key;
 
 const swrCache = new WeakMap();
 const swrElementsPromise = (
   a: Promise<Elements>,
   b: Promise<Elements>,
-  pin: (key: string) => boolean,
+  pin: (key: string | symbol) => boolean,
   base?: Elements,
   overlay?: Elements,
 ): Promise<Elements> => {
   const getResult = () => {
     const result: Promise<Elements> = Promise.resolve(a).then((aRes) => {
-      const holeFor = (key: string) =>
+      const holeFor = (key: string | symbol) =>
         b.then((bRes) =>
           key in bRes ? bRes[key] : base && key in base ? base[key] : aRes[key],
         );
       const nextElements: Elements = {};
-      for (const key of Object.keys(aRes)) {
+      for (const key of Reflect.ownKeys(aRes)) {
         if (key === '_value') {
           continue;
         }
@@ -184,12 +165,6 @@ const swrElementsPromise = (
             nextElements[key] = holeFor(key);
           }
         }
-      }
-      // symbol keys are client owned; they are carried, never fetched
-      for (const sym of Object.getOwnPropertySymbols(aRes)) {
-        (nextElements as Record<symbol, unknown>)[sym] = (
-          aRes as Record<symbol, unknown>
-        )[sym];
       }
       if (overlay) {
         Object.assign(nextElements, overlay);
@@ -259,7 +234,7 @@ type Refetch = (
     unstable_prefetched?: Elements | Promise<Elements>;
     unstable_overlay?: Elements;
     unstable_swr?: {
-      pin: (key: string) => boolean;
+      pin: (key: string | symbol) => boolean;
       base?: Elements;
     };
   },
@@ -507,7 +482,7 @@ export const unstable_fetchRsc = (
     registerHmrRefetch(() => {
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
-      getSetElements()((prev) => replaceElementsPromise(prev, data));
+      getSetElements()((prev) => mergeElementsPromise(prev, data));
     });
   }
   const entry = fetchRscStore[ENTRY];

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -61,7 +61,6 @@ const checkStatus = async (
   const response = await responsePromise;
   if (
     response.redirected &&
-    typeof window !== 'undefined' &&
     !new URL(response.url).pathname.startsWith(BASE_RSC_PATH)
   ) {
     // redirected off the rsc endpoint; the navigation layer follows it

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -131,9 +131,8 @@ const mergeElementsPromise = (
   return getCached(getResult, cache2, b);
 };
 
-// an hmr refresh replaces server keys and carries the client's symbol keys.
-// the cache keeps a replayed updater returning the same promise; without it
-// the tree never settles on the refreshed record (hot-reload.dev.spec.ts).
+// a replayed updater has to return the same promise, or the tree never
+// settles on the refreshed record (hot-reload.dev.spec.ts)
 const refreshCache = new WeakMap();
 const refreshElementsPromise = (
   a: Promise<Elements>,

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -86,6 +86,7 @@ const checkStatus = async (
   return response;
 };
 
+// only the client adds symbol keys; a decoded server payload has string keys
 type Elements = Record<string | symbol, unknown>;
 
 const collectCachedEtags = (elements: Elements): Etags => {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -129,6 +129,27 @@ const mergeElementsPromise = (
   return getCached(getResult, cache2, b);
 };
 
+// an hmr refresh replaces server keys and carries the client's symbol keys.
+// the cache keeps a replayed updater returning the same promise; without it
+// the tree never settles on the refreshed record (hot-reload.dev.spec.ts).
+const refreshCache = new WeakMap();
+const refreshElementsPromise = (
+  a: Promise<Elements>,
+  b: Promise<Elements>,
+): Promise<Elements> => {
+  const getResult = () =>
+    Promise.all([a, b]).then(([aRes, bRes]) => {
+      const nextElements = { ...bRes };
+      delete nextElements._value;
+      for (const key of Object.getOwnPropertySymbols(aRes)) {
+        nextElements[key] = aRes[key];
+      }
+      return nextElements;
+    });
+  const cache2 = getCached(() => new WeakMap(), refreshCache, a);
+  return getCached(getResult, cache2, b);
+};
+
 const slotIdOf = <K extends string | symbol>(key: K): K =>
   typeof key === 'string' && key.startsWith(ETAG_ID_PREFIX)
     ? (key.slice(ETAG_ID_PREFIX.length) as K)
@@ -479,17 +500,7 @@ export const unstable_fetchRsc = (
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
       const setElements = getSetElements();
-      // a refresh replaces the server keys and carries the client's symbols
-      setElements((prev) =>
-        Promise.all([prev, data]).then(([prevRes, dataRes]) => {
-          const nextElements: Elements = { ...dataRes };
-          delete nextElements._value;
-          for (const key of Object.getOwnPropertySymbols(prevRes)) {
-            nextElements[key] = prevRes[key];
-          }
-          return nextElements;
-        }),
-      );
+      setElements((prev) => refreshElementsPromise(prev, data));
     };
     unstable_upsertRscReloadListener(
       globalThis.__WAKU_REFETCH_RSC__,

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -474,7 +474,7 @@ export const unstable_fetchRsc = (
   options?: FetchRscOptions,
 ): Promise<Elements> => {
   if (import.meta.hot) {
-    const refetchRsc = () => {
+    const refetchRscOnHmr = () => {
       fetchRscStore[CACHED_ETAGS] = {};
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
@@ -483,10 +483,8 @@ export const unstable_fetchRsc = (
         Promise.all([prev, data]).then(([prevRes, dataRes]) => {
           const nextElements: Elements = { ...dataRes };
           delete nextElements._value;
-          for (const key of Reflect.ownKeys(prevRes)) {
-            if (typeof key === 'symbol') {
-              nextElements[key] = prevRes[key];
-            }
+          for (const key of Object.getOwnPropertySymbols(prevRes)) {
+            nextElements[key] = prevRes[key];
           }
           return nextElements;
         }),
@@ -494,9 +492,9 @@ export const unstable_fetchRsc = (
     };
     unstable_upsertRscReloadListener(
       globalThis.__WAKU_REFETCH_RSC__,
-      refetchRsc,
+      refetchRscOnHmr,
     );
-    globalThis.__WAKU_REFETCH_RSC__ = refetchRsc;
+    globalThis.__WAKU_REFETCH_RSC__ = refetchRscOnHmr;
   }
   const entry = fetchRscStore[ENTRY];
   if (entry && entry[0] === rscPath && entry[1] === rscParams) {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -120,25 +120,20 @@ const mergeElementsPromise = (
 };
 
 // an hmr refresh replaces server keys and carries the client's symbol keys
-const refreshCache = new WeakMap();
 const refreshElementsPromise = (
   a: Promise<Elements>,
   b: Promise<Elements>,
-): Promise<Elements> => {
-  const getResult = () =>
-    Promise.all([a, b]).then(([aRes, bRes]) => {
-      const nextElements = { ...bRes };
-      delete nextElements._value;
-      for (const key of Reflect.ownKeys(aRes)) {
-        if (typeof key === 'symbol') {
-          nextElements[key] = aRes[key];
-        }
+): Promise<Elements> =>
+  Promise.all([a, b]).then(([aRes, bRes]) => {
+    const nextElements = { ...bRes };
+    delete nextElements._value;
+    for (const key of Reflect.ownKeys(aRes)) {
+      if (typeof key === 'symbol') {
+        nextElements[key] = aRes[key];
       }
-      return nextElements;
-    });
-  const cache2 = getCached(() => new WeakMap(), refreshCache, a);
-  return getCached(getResult, cache2, b);
-};
+    }
+    return nextElements;
+  });
 
 const slotIdOf = <K extends string | symbol>(key: K): K =>
   typeof key === 'string' && key.startsWith(ETAG_ID_PREFIX)

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -11,7 +11,10 @@ import {
 } from 'react';
 import type { ReactNode } from 'react';
 import RSDWClient from 'react-server-dom-webpack/client';
-import { createCustomError } from '../lib/utils/custom-errors.js';
+import {
+  createCustomError,
+  markCustomError,
+} from '../lib/utils/custom-errors.js';
 import {
   ETAGS_HEADER,
   ETAG_ID_PREFIX,
@@ -66,9 +69,7 @@ const checkStatus = async (
       throw e;
     }
     // the transport failed, so nothing can be told about the server
-    throw createCustomError(String((e as Error | undefined)?.message ?? e), {
-      noResponse: true,
-    });
+    throw markCustomError(e, { noResponse: true });
   }
   if (
     response.redirected &&

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -58,7 +58,18 @@ const BASE_RSC_PATH = `${import.meta.env?.WAKU_CONFIG_BASE_PATH ?? '/'}${
 const checkStatus = async (
   responsePromise: Promise<Response>,
 ): Promise<Response> => {
-  const response = await responsePromise;
+  let response: Response;
+  try {
+    response = await responsePromise;
+  } catch (e) {
+    if ((e as Error | undefined)?.name === 'AbortError') {
+      throw e;
+    }
+    // the transport failed, so nothing can be told about the server
+    throw createCustomError(String((e as Error | undefined)?.message ?? e), {
+      noResponse: true,
+    });
+  }
   if (
     response.redirected &&
     !new URL(response.url).pathname.startsWith(BASE_RSC_PATH)

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -474,7 +474,7 @@ export const unstable_fetchRsc = (
   options?: FetchRscOptions,
 ): Promise<Elements> => {
   if (import.meta.hot) {
-    const reload = () => {
+    const refetchRsc = () => {
       fetchRscStore[CACHED_ETAGS] = {};
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
@@ -492,8 +492,11 @@ export const unstable_fetchRsc = (
         }),
       );
     };
-    unstable_upsertRscReloadListener(globalThis.__WAKU_REFETCH_RSC__, reload);
-    globalThis.__WAKU_REFETCH_RSC__ = reload;
+    unstable_upsertRscReloadListener(
+      globalThis.__WAKU_REFETCH_RSC__,
+      refetchRsc,
+    );
+    globalThis.__WAKU_REFETCH_RSC__ = refetchRsc;
   }
   const entry = fetchRscStore[ENTRY];
   if (entry && entry[0] === rscPath && entry[1] === rscParams) {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -62,13 +62,11 @@ const checkStatus = async (
   try {
     response = await responsePromise;
   } catch (e) {
-    if ((e as Error | undefined)?.name === 'AbortError') {
-      throw e;
+    if (e instanceof TypeError) {
+      // fetch reports a network error as a TypeError, so no response arrived
+      throw createCustomError(e.message, { unstable_networkError: true });
     }
-    // the transport failed, so nothing can be told about the server
-    throw createCustomError(String((e as Error | undefined)?.message ?? e), {
-      noResponse: true,
-    });
+    throw e;
   }
   if (
     response.redirected &&

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -480,7 +480,7 @@ export const unstable_fetchRsc = (
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
       // a refresh replaces the server keys and carries the client's symbols
-      getSetElements()((prev: Promise<Elements>) =>
+      getSetElements()((prev) =>
         Promise.all([prev, data]).then(([prevRes, dataRes]) => {
           const nextElements: Elements = { ...dataRes };
           delete nextElements._value;

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -131,22 +131,6 @@ const mergeElementsPromise = (
   return getCached(getResult, cache2, b);
 };
 
-// an hmr refresh replaces server keys and carries the client's symbol keys
-const refreshElementsPromise = (
-  a: Promise<Elements>,
-  b: Promise<Elements>,
-): Promise<Elements> =>
-  Promise.all([a, b]).then(([aRes, bRes]) => {
-    const nextElements = { ...bRes };
-    delete nextElements._value;
-    for (const key of Reflect.ownKeys(aRes)) {
-      if (typeof key === 'symbol') {
-        nextElements[key] = aRes[key];
-      }
-    }
-    return nextElements;
-  });
-
 const slotIdOf = <K extends string | symbol>(key: K): K =>
   typeof key === 'string' && key.startsWith(ETAG_ID_PREFIX)
     ? (key.slice(ETAG_ID_PREFIX.length) as K)
@@ -485,15 +469,6 @@ export const unstable_upsertRscReloadListener = (
   }
 };
 
-const registerHmrRefetch = (refetch: () => void) => {
-  const reload = () => {
-    fetchRscStore[CACHED_ETAGS] = {};
-    refetch();
-  };
-  unstable_upsertRscReloadListener(globalThis.__WAKU_REFETCH_RSC__, reload);
-  globalThis.__WAKU_REFETCH_RSC__ = reload;
-};
-
 /** Fetch elements for an RSC path, reusing a cached or prefetched result. */
 export const unstable_fetchRsc = (
   rscPath: string,
@@ -501,11 +476,26 @@ export const unstable_fetchRsc = (
   options?: FetchRscOptions,
 ): Promise<Elements> => {
   if (import.meta.hot) {
-    registerHmrRefetch(() => {
+    const reload = () => {
+      fetchRscStore[CACHED_ETAGS] = {};
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
-      getSetElements()((prev) => refreshElementsPromise(prev, data));
-    });
+      // a refresh replaces the server keys and carries the client's symbols
+      getSetElements()((prev: Promise<Elements>) =>
+        Promise.all([prev, data]).then(([prevRes, dataRes]) => {
+          const nextElements: Elements = { ...dataRes };
+          delete nextElements._value;
+          for (const key of Reflect.ownKeys(prevRes)) {
+            if (typeof key === 'symbol') {
+              nextElements[key] = prevRes[key];
+            }
+          }
+          return nextElements;
+        }),
+      );
+    };
+    unstable_upsertRscReloadListener(globalThis.__WAKU_REFETCH_RSC__, reload);
+    globalThis.__WAKU_REFETCH_RSC__ = reload;
   }
   const entry = fetchRscStore[ENTRY];
   if (entry && entry[0] === rscPath && entry[1] === rscParams) {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -11,10 +11,7 @@ import {
 } from 'react';
 import type { ReactNode } from 'react';
 import RSDWClient from 'react-server-dom-webpack/client';
-import {
-  createCustomError,
-  markCustomError,
-} from '../lib/utils/custom-errors.js';
+import { createCustomError } from '../lib/utils/custom-errors.js';
 import {
   ETAGS_HEADER,
   ETAG_ID_PREFIX,
@@ -69,7 +66,9 @@ const checkStatus = async (
       throw e;
     }
     // the transport failed, so nothing can be told about the server
-    throw markCustomError(e, { noResponse: true });
+    throw createCustomError(String((e as Error | undefined)?.message ?? e), {
+      noResponse: true,
+    });
   }
   if (
     response.redirected &&

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -68,9 +68,11 @@ const checkStatus = async (
     }
     throw e;
   }
+  const redirectedTo = response.redirected ? new URL(response.url) : undefined;
   if (
-    response.redirected &&
-    !new URL(response.url).pathname.startsWith(BASE_RSC_PATH)
+    redirectedTo &&
+    (redirectedTo.origin !== window.location.origin ||
+      !redirectedTo.pathname.startsWith(BASE_RSC_PATH))
   ) {
     // redirected off the rsc endpoint; the navigation layer follows it
     throw createCustomError('redirected rsc request', {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -217,6 +217,7 @@ const swrNewKeysElementsPromise = (
   if (swrMergeSources.get(prev) !== b) {
     return prev;
   }
+  // Object.keys, so a client only symbol key keeps the value it was given
   const overlayKeys = overlay
     ? Object.keys(overlay).filter((key) => key in bRes)
     : [];

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -478,8 +478,9 @@ export const unstable_fetchRsc = (
       fetchRscStore[CACHED_ETAGS] = {};
       delete fetchRscStore[ENTRY];
       const data = unstable_fetchRsc(rscPath, rscParams, options);
+      const setElements = getSetElements();
       // a refresh replaces the server keys and carries the client's symbols
-      getSetElements()((prev) =>
+      setElements((prev) =>
         Promise.all([prev, data]).then(([prevRes, dataRes]) => {
           const nextElements: Elements = { ...dataRes };
           delete nextElements._value;

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -61,9 +61,8 @@ export type NavState = {
 };
 
 export const getNavState = (
-  elements: Record<string, unknown>,
-): NavState | undefined =>
-  (elements as Record<symbol, unknown>)[NAV_ID] as NavState | undefined;
+  elements: Record<string | symbol, unknown>,
+): NavState | undefined => elements[NAV_ID] as NavState | undefined;
 
 export const makeNavState = (
   route: RouteProps,
@@ -121,6 +120,10 @@ export const canCommitInstantly = (
   isImmutableElement(resolvedElements, routeSlotId) ||
   !!(prefetchedElements && isImmutableElement(prefetchedElements, routeSlotId));
 
+// symbol keys are client owned; they are carried, never fetched
 export const pinForSwr =
-  (getResolvedElements: () => Record<string, unknown>) => (key: string) =>
-    isMetaKey(key) || isImmutableElement(getResolvedElements(), key);
+  (getResolvedElements: () => Record<string, unknown>) =>
+  (key: string | symbol) =>
+    typeof key === 'symbol' ||
+    isMetaKey(key) ||
+    isImmutableElement(getResolvedElements(), key);

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -1,12 +1,15 @@
 import {
   unstable_addBase as addBase,
-  unstable_getErrorInfo as getErrorInfo,
   unstable_isImmutableElement as isImmutableElement,
   unstable_removeBase as removeBase,
 } from '../../minimal/client.js';
 import { pathnameToRoutePath } from '../isomorphic-utils/route-path.js';
 import type { RouteProps } from '../isomorphic-utils/route-path.js';
-import { isMetaKey } from './elements-meta.js';
+import {
+  getRouteFromElements,
+  getServerRedirect,
+  isMetaKey,
+} from './elements-meta.js';
 
 // --- pure route and url helpers ---
 
@@ -37,153 +40,79 @@ export const isSameRoute = (next: RouteProps, prev: RouteProps) =>
   next.query === prev.query &&
   next.hash === prev.hash;
 
-const parseRedirectUrl = (location: string, base: string | URL) => {
+export const parseRedirectUrl = (location: string, base: string | URL) => {
   const url = new URL(location, base);
   return url.protocol === 'http:' || url.protocol === 'https:'
     ? url
     : undefined;
 };
 
-const MAX_ERROR_HOPS = 20;
+// --- client-only navigation state, stored in the elements record ---
 
-// --- the resolver ---
+// The record's symbol key for the client-owned navigation state. The rendered
+// path comes from the server's ROUTE_ID; NAV_ID carries what the server cannot
+// know: the browser url, the pending history intent and the scroll intent.
+export const NAV_ID = Symbol('waku-router-nav');
 
-export type Destination = {
-  route: RouteProps;
-  routeUrl: URL;
-  elements?: Record<string, unknown> | undefined;
+export type NavState = {
+  url: string; // pathname + search + hash, with the base path
+  attempted: readonly [path: string, query: string];
+  push: boolean; // consumed by the reconciler on the first write
+  scroll: { pathChanged: boolean } | null; // consumed by the reconciler
+  scrollIntent?: boolean; // a failed attempt's intent, for a follow to inherit
 };
 
-export type ResolveDeps = {
-  fetchRoute: (
-    route: RouteProps,
-    routeUrl: URL,
-  ) => Promise<Record<string, unknown>>;
-  isKnownStatic: (path: string) => boolean;
-  has404: boolean;
-  isAborted: () => boolean;
-  leaveApp: (url: URL) => void;
-};
+export const getNavState = (
+  elements: Record<string, unknown>,
+): NavState | undefined =>
+  (elements as Record<symbol, unknown>)[NAV_ID] as NavState | undefined;
 
-export const resolveFollowingErrors = async (
-  deps: ResolveDeps,
+export const makeNavState = (
   route: RouteProps,
-  routeUrl: URL,
-  routeBefore: RouteProps,
-  errorToFollow: unknown,
-): Promise<Destination | undefined> => {
-  for (let hops = errorToFollow ? 1 : 0; hops <= MAX_ERROR_HOPS; hops++) {
-    if (errorToFollow) {
-      const info = getErrorInfo(errorToFollow);
-      const redirectUrl = info?.location
-        ? parseRedirectUrl(info.location, routeUrl)
-        : undefined;
-      if (redirectUrl) {
-        if (redirectUrl.origin !== window.location.origin) {
-          deps.leaveApp(redirectUrl);
-          return undefined;
-        }
-        route = parseRoute(redirectUrl);
-        routeUrl = redirectUrl;
-      } else if (info?.status === 404 && deps.has404 && route.path !== '/404') {
-        route = parseRoute(new URL('/404', window.location.href));
-      } else {
-        throw errorToFollow;
-      }
-      errorToFollow = undefined;
-    }
-    if (
-      hops > 0 &&
-      (deps.isKnownStatic(route.path) || isSameRoute(route, routeBefore))
-    ) {
-      return { route, routeUrl };
-    }
-    try {
-      return {
-        route,
-        routeUrl,
-        elements: await deps.fetchRoute(route, routeUrl),
-      };
-    } catch (e) {
-      if (deps.isAborted()) {
-        throw e;
-      }
-      errorToFollow = e;
-    }
+  url: URL,
+  options: { push: boolean; scroll: boolean; pathChanged: boolean },
+): NavState => ({
+  url: url.pathname + url.search + url.hash,
+  attempted: [route.path, route.query],
+  push: options.push,
+  scroll: options.scroll ? { pathChanged: options.pathChanged } : null,
+});
+
+// Derive the committed route and browser url from the record. A server
+// redirect (ROUTE_ID differing from the attempted route) moves both to the
+// committed route, except the 404 route, which keeps the attempted url.
+export const deriveCommitted = (
+  elements: Record<string, unknown>,
+  fallbackRoute: RouteProps,
+): { route: RouteProps; nav: NavState | undefined; url: URL | undefined } => {
+  const nav = getNavState(elements);
+  const routeFromElements = getRouteFromElements(elements);
+  if (!nav) {
+    return { route: fallbackRoute, nav: undefined, url: undefined };
   }
-  throw new Error('too many redirect or 404 follows', {
-    cause: errorToFollow,
+  const navUrl = new URL(nav.url, window.location.href);
+  const redirect = getServerRedirect(elements, {
+    path: nav.attempted[0],
+    query: nav.attempted[1],
+    hash: '',
   });
-};
-
-// --- history, scroll ---
-
-export const writeUrlToHistory = (mode: 'push' | 'replace', url: URL) => {
-  if (mode === 'push') {
-    window.history.pushState(window.history.state, '', url);
-  } else {
-    window.history.replaceState(window.history.state, '', url);
+  if (redirect && redirect.path !== '/404') {
+    return { route: redirect, nav, url: getRouteUrl(redirect) };
   }
-};
-
-// --- client-only navigation state ---
-
-// The route path is derived from the elements' ROUTE_ID. The query and hash are
-// kept here because they are client-owned: a static route does not echo the URL
-// query, and the server never sees the hash.
-export type Nav = {
-  query: string;
-  hash: string;
-  history: { mode: 'push' | 'replace'; url: URL | undefined } | null;
-  scroll: { pathChanged: boolean } | null;
-};
-
-export const deriveNav = (outcome: {
-  destination: Destination;
-  attempted: RouteProps;
-  routeBefore: RouteProps;
-  history: 'push' | 'replace' | undefined;
-  historyUrl: URL | undefined;
-  shouldScroll: boolean;
-  getServerRedirect: (
-    elements: Record<string, unknown>,
-    route: RouteProps,
-  ) => RouteProps | undefined;
-}): { route: RouteProps; nav: Nav } => {
-  const { destination, attempted, routeBefore } = outcome;
-  const followed = !isSameRoute(destination.route, attempted);
-  const redirect =
-    destination.elements &&
-    outcome.getServerRedirect(destination.elements, destination.route);
-  const route = redirect || destination.route;
-  const mode = redirect?.path === '/404' ? undefined : outcome.history;
-  const url = redirect
-    ? undefined
-    : followed
-      ? destination.routeUrl
-      : outcome.historyUrl;
   return {
-    route,
-    nav: {
-      query: route.query,
-      hash: route.hash,
-      history: mode ? { mode, url } : null,
-      scroll: outcome.shouldScroll
-        ? { pathChanged: route.path !== routeBefore.path }
-        : null,
+    route: {
+      path: redirect
+        ? redirect.path
+        : routeFromElements
+          ? routeFromElements.path
+          : fallbackRoute.path,
+      query: navUrl.searchParams.toString(),
+      hash: navUrl.hash,
     },
+    nav,
+    url: navUrl,
   };
 };
-
-export const applyServerRedirect = (prev: Nav, redirect: RouteProps): Nav => ({
-  ...prev,
-  query: redirect.query,
-  hash: redirect.hash,
-  history:
-    redirect.path === '/404'
-      ? null
-      : { mode: 'replace', url: getRouteUrl(redirect) },
-});
 
 // --- instant navigation ---
 

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -49,9 +49,7 @@ export const parseRedirectUrl = (location: string, base: string | URL) => {
 
 // --- client-only navigation state, stored in the elements record ---
 
-// The record's symbol key for the client-owned navigation state. The rendered
-// path comes from the server's ROUTE_ID; NAV_ID carries what the server cannot
-// know: the browser url, the pending history intent and the scroll intent.
+// the client owned navigation state; the server's ROUTE_ID owns the path
 export const NAV_ID = Symbol('waku-router-nav');
 
 export type NavState = {
@@ -78,9 +76,7 @@ export const makeNavState = (
   scroll: options.scroll ? { pathChanged: options.pathChanged } : null,
 });
 
-// Derive the committed route and browser url from the record. A server
-// redirect (ROUTE_ID differing from the attempted route) moves both to the
-// committed route, except the 404 route, which keeps the attempted url.
+// a server redirect moves route and url; the 404 route keeps the attempted url
 export const deriveCommitted = (
   elements: Record<string, unknown>,
   fallbackRoute: RouteProps,

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -57,7 +57,7 @@ export type NavState = {
   attempted: readonly [path: string, query: string];
   push: boolean; // consumed by the reconciler on the first write
   scroll: { pathChanged: boolean } | null; // consumed by the reconciler
-  scrollIntent?: boolean; // a failed attempt's intent, for a follow to inherit
+  scrollIntent: boolean; // the attempt's decision, for a follow to inherit
 };
 
 export const getNavState = (
@@ -74,6 +74,7 @@ export const makeNavState = (
   attempted: [route.path, route.query],
   push: options.push,
   scroll: options.scroll ? { pathChanged: options.pathChanged } : null,
+  scrollIntent: options.scroll,
 });
 
 // a server redirect moves route and url; the 404 route keeps the attempted url

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -52,6 +52,7 @@ export const parseRedirectUrl = (location: string, base: string | URL) => {
 // the client owned navigation state; the server's ROUTE_ID owns the path
 export const NAV_ID = Symbol('waku-router-nav');
 
+// merges carry this object by reference; the consumed flags rely on identity
 export type NavState = {
   url: string; // pathname + search + hash, with the base path
   attempted: readonly [path: string, query: string];
@@ -78,7 +79,7 @@ export const makeNavState = (
 
 // a server redirect moves route and url; the 404 route keeps the attempted url
 export const deriveCommitted = (
-  elements: Record<string, unknown>,
+  elements: Record<string | symbol, unknown>,
   fallbackRoute: RouteProps,
 ): { route: RouteProps; nav: NavState | undefined; url: URL | undefined } => {
   const nav = getNavState(elements);

--- a/packages/waku/src/router/client-utils/navigate.ts
+++ b/packages/waku/src/router/client-utils/navigate.ts
@@ -56,7 +56,9 @@ export const NAV_ID = Symbol('waku-router-nav');
 export type NavState = {
   url: string; // pathname + search + hash, with the base path
   attempted: readonly [path: string, query: string];
-  push: boolean; // consumed by the reconciler on the first write
+  // null leaves history alone (the browser already wrote it); a push turns into
+  // a replace once the reconciler has written
+  history: 'push' | 'replace' | null;
   scroll: { pathChanged: boolean } | null; // consumed by the reconciler
   scrollIntent: boolean; // the attempt's decision, for a follow to inherit
 };
@@ -68,11 +70,15 @@ export const getNavState = (
 export const makeNavState = (
   route: RouteProps,
   url: URL,
-  options: { push: boolean; scroll: boolean; pathChanged: boolean },
+  options: {
+    history: 'push' | 'replace' | null;
+    scroll: boolean;
+    pathChanged: boolean;
+  },
 ): NavState => ({
   url: url.pathname + url.search + url.hash,
   attempted: [route.path, route.query],
-  push: options.push,
+  history: options.history,
   scroll: options.scroll ? { pathChanged: options.pathChanged } : null,
   scrollIntent: options.scroll,
 });

--- a/packages/waku/src/router/client-utils/prefetch-cache.ts
+++ b/packages/waku/src/router/client-utils/prefetch-cache.ts
@@ -2,7 +2,7 @@
 // prefetch for one query is never reused for another, and bounded by a ttl and a
 // size limit so hover-prefetching in a long session cannot grow without bound.
 
-type Elements = Record<string, unknown>;
+type Elements = Record<string | symbol, unknown>;
 
 export type PrefetchMode = 'always' | 'once';
 

--- a/packages/waku/src/router/client-utils/route-url.ts
+++ b/packages/waku/src/router/client-utils/route-url.ts
@@ -1,0 +1,40 @@
+import {
+  unstable_addBase as addBase,
+  unstable_removeBase as removeBase,
+} from '../../minimal/client.js';
+import { pathnameToRoutePath } from '../isomorphic-utils/route-path.js';
+import type { RouteProps } from '../isomorphic-utils/route-path.js';
+
+export const pathnameToCurrentRoutePath = (pathname: string) =>
+  pathnameToRoutePath(
+    removeBase(pathname, import.meta.env.WAKU_CONFIG_BASE_PATH),
+  );
+
+export const parseRoute = (url: URL): RouteProps => {
+  const { pathname, searchParams, hash } = url;
+  return {
+    path: pathnameToCurrentRoutePath(pathname),
+    query: searchParams.toString(),
+    hash,
+  };
+};
+
+export const getRouteUrl = (route: RouteProps): URL => {
+  const nextUrl = new URL(window.location.href);
+  nextUrl.pathname = addBase(route.path, import.meta.env.WAKU_CONFIG_BASE_PATH);
+  nextUrl.search = route.query;
+  nextUrl.hash = route.hash;
+  return nextUrl;
+};
+
+export const isSameRoute = (next: RouteProps, prev: RouteProps) =>
+  next.path === prev.path &&
+  next.query === prev.query &&
+  next.hash === prev.hash;
+
+export const parseRedirectUrl = (location: string, base: string | URL) => {
+  const url = new URL(location, base);
+  return url.protocol === 'http:' || url.protocol === 'https:'
+    ? url
+    : undefined;
+};

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -80,19 +80,16 @@ export const makeRouterState = (
   scrollIntent: options.scroll,
 });
 
-// a server redirect moves route and url; the 404 route keeps the attempted url
-export const deriveCommitted = (
+// What the record commits to: the route to render and the url to show, or
+// undefined before the client has navigated. A server redirect moves both; the
+// 404 route keeps the attempted url.
+export const getCommittedRoute = (
   elements: Record<string | symbol, unknown>,
-  fallbackRoute: RouteProps,
-): {
-  route: RouteProps;
-  routerState: RouterState | undefined;
-  url: URL | undefined;
-} => {
+  fallbackPath: string,
+): { routerState: RouterState; route: RouteProps; url: URL } | undefined => {
   const routerState = getRouterState(elements);
-  const routeFromElements = getRouteFromElements(elements);
   if (!routerState) {
-    return { route: fallbackRoute, routerState: undefined, url: undefined };
+    return undefined;
   }
   const stateUrl = new URL(routerState.url, window.location.href);
   const redirect = getServerRedirect(elements, {
@@ -101,19 +98,16 @@ export const deriveCommitted = (
     hash: '',
   });
   if (redirect && redirect.path !== '/404') {
-    return { route: redirect, routerState, url: getRouteUrl(redirect) };
+    return { routerState, route: redirect, url: getRouteUrl(redirect) };
   }
   return {
+    routerState,
     route: {
-      path: redirect
-        ? redirect.path
-        : routeFromElements
-          ? routeFromElements.path
-          : fallbackRoute.path,
+      path:
+        redirect?.path ?? getRouteFromElements(elements)?.path ?? fallbackPath,
       query: stateUrl.searchParams.toString(),
       hash: stateUrl.hash,
     },
-    routerState,
     url: stateUrl,
   };
 };

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -11,8 +11,6 @@ import {
   isMetaKey,
 } from './elements-meta.js';
 
-// --- pure route and url helpers ---
-
 export const pathnameToCurrentRoutePath = (pathname: string) =>
   pathnameToRoutePath(
     removeBase(pathname, import.meta.env.WAKU_CONFIG_BASE_PATH),
@@ -46,8 +44,6 @@ export const parseRedirectUrl = (location: string, base: string | URL) => {
     ? url
     : undefined;
 };
-
-// --- client-only router state, stored in the elements record ---
 
 // the client owned router state; the server's ROUTE_ID owns the path
 export const ROUTER_STATE_ID = Symbol('waku-router-state');
@@ -121,8 +117,6 @@ export const deriveCommitted = (
     url: stateUrl,
   };
 };
-
-// --- instant navigation ---
 
 export const canCommitInstantly = (
   routeSlotId: string,

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -81,7 +81,7 @@ export const makeRouterState = (
 });
 
 // a server redirect moves route and url; the 404 route keeps the attempted url
-export const getCommittedRoute = (
+export const getCommitted = (
   elements: Record<string | symbol, unknown>,
   fallbackPath: string,
 ): { routerState: RouterState; route: RouteProps; url: URL } | undefined => {

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -47,8 +47,7 @@ export const resolveServerRedirect = (
   fallbackPath: string,
 ): { route: RouteProps; url: URL } => {
   const stateUrl = new URL(routerState.url, window.location.href);
-  // a failed navigation reports the route the record still holds with the url
-  // it tried; nothing landed, so there is no redirect to read
+  // nothing landed on a failed navigation, so there is no redirect to read
   const redirect = routerState.failed
     ? undefined
     : getServerRedirect(elements, {

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -47,6 +47,8 @@ export const resolveServerRedirect = (
   fallbackPath: string,
 ): { route: RouteProps; url: URL } => {
   const stateUrl = new URL(routerState.url, window.location.href);
+  // a failed navigation reports the route the record still holds with the url
+  // it tried; nothing landed, so there is no redirect to read
   const redirect = routerState.failed
     ? undefined
     : getServerRedirect(elements, {

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -10,15 +10,13 @@ import { getRouteUrl } from './route-url.js';
 // the client owned router state; the server's ROUTE_ID owns the path
 export const ROUTER_STATE_ID = Symbol('waku-router-state');
 
-// merges carry this object by reference; the consumed flags rely on identity
+// merges carry this object by reference; the reconciler keys off its identity
 export type RouterState = {
-  url: string; // pathname + search + hash, with the base path
-  attempted: readonly [path: string, query: string];
-  // null leaves history alone (the browser already wrote it); a push turns into
-  // a replace once the reconciler has written
-  history: 'push' | 'replace' | null;
-  scroll: { pathChanged: boolean } | null; // consumed by the reconciler
-  scrollIntent: boolean; // the attempt's decision, for a follow to inherit
+  readonly url: string; // pathname + search + hash, with the base path
+  readonly attempted: readonly [path: string, query: string];
+  // null leaves history alone: the browser already wrote it
+  readonly history: 'push' | 'replace' | null;
+  readonly scroll: { readonly pathChanged: boolean } | null;
 };
 
 export const getRouterState = (
@@ -39,7 +37,6 @@ export const makeRouterState = (
   attempted: [route.path, route.query],
   history: options.history,
   scroll: options.scroll ? { pathChanged: options.pathChanged } : null,
-  scrollIntent: options.scroll,
 });
 
 // a redirect to the 404 route keeps the url that was attempted

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -1,49 +1,11 @@
-import {
-  unstable_addBase as addBase,
-  unstable_isImmutableElement as isImmutableElement,
-  unstable_removeBase as removeBase,
-} from '../../minimal/client.js';
-import { pathnameToRoutePath } from '../isomorphic-utils/route-path.js';
+import { unstable_isImmutableElement as isImmutableElement } from '../../minimal/client.js';
 import type { RouteProps } from '../isomorphic-utils/route-path.js';
 import {
   getRouteFromElements,
   getServerRedirect,
   isMetaKey,
 } from './elements-meta.js';
-
-export const pathnameToCurrentRoutePath = (pathname: string) =>
-  pathnameToRoutePath(
-    removeBase(pathname, import.meta.env.WAKU_CONFIG_BASE_PATH),
-  );
-
-export const parseRoute = (url: URL): RouteProps => {
-  const { pathname, searchParams, hash } = url;
-  return {
-    path: pathnameToCurrentRoutePath(pathname),
-    query: searchParams.toString(),
-    hash,
-  };
-};
-
-export const getRouteUrl = (route: RouteProps): URL => {
-  const nextUrl = new URL(window.location.href);
-  nextUrl.pathname = addBase(route.path, import.meta.env.WAKU_CONFIG_BASE_PATH);
-  nextUrl.search = route.query;
-  nextUrl.hash = route.hash;
-  return nextUrl;
-};
-
-export const isSameRoute = (next: RouteProps, prev: RouteProps) =>
-  next.path === prev.path &&
-  next.query === prev.query &&
-  next.hash === prev.hash;
-
-export const parseRedirectUrl = (location: string, base: string | URL) => {
-  const url = new URL(location, base);
-  return url.protocol === 'http:' || url.protocol === 'https:'
-    ? url
-    : undefined;
-};
+import { getRouteUrl } from './route-url.js';
 
 // the client owned router state; the server's ROUTE_ID owns the path
 export const ROUTER_STATE_ID = Symbol('waku-router-state');

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -17,6 +17,7 @@ export type RouterState = {
   // null leaves history alone: the browser already wrote it
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
+  readonly failed?: boolean; // the fetch never landed, so the route id is stale
 };
 
 export const getRouterState = (
@@ -46,11 +47,13 @@ export const resolveServerRedirect = (
   fallbackPath: string,
 ): { route: RouteProps; url: URL } => {
   const stateUrl = new URL(routerState.url, window.location.href);
-  const redirect = getServerRedirect(elements, {
-    path: routerState.attempted[0],
-    query: routerState.attempted[1],
-    hash: '',
-  });
+  const redirect = routerState.failed
+    ? undefined
+    : getServerRedirect(elements, {
+        path: routerState.attempted[0],
+        query: routerState.attempted[1],
+        hash: '',
+      });
   if (redirect && redirect.path !== '/404') {
     return { route: redirect, url: getRouteUrl(redirect) };
   }

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -80,9 +80,7 @@ export const makeRouterState = (
   scrollIntent: options.scroll,
 });
 
-// What the record commits to: the route to render and the url to show, or
-// undefined before the client has navigated. A server redirect moves both; the
-// 404 route keeps the attempted url.
+// a server redirect moves route and url; the 404 route keeps the attempted url
 export const getCommittedRoute = (
   elements: Record<string | symbol, unknown>,
   fallbackPath: string,

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -47,13 +47,13 @@ export const parseRedirectUrl = (location: string, base: string | URL) => {
     : undefined;
 };
 
-// --- client-only navigation state, stored in the elements record ---
+// --- client-only router state, stored in the elements record ---
 
-// the client owned navigation state; the server's ROUTE_ID owns the path
-export const NAV_ID = Symbol('waku-router-nav');
+// the client owned router state; the server's ROUTE_ID owns the path
+export const ROUTER_STATE_ID = Symbol('waku-router-state');
 
 // merges carry this object by reference; the consumed flags rely on identity
-export type NavState = {
+export type RouterState = {
   url: string; // pathname + search + hash, with the base path
   attempted: readonly [path: string, query: string];
   // null leaves history alone (the browser already wrote it); a push turns into
@@ -63,11 +63,12 @@ export type NavState = {
   scrollIntent: boolean; // the attempt's decision, for a follow to inherit
 };
 
-export const getNavState = (
+export const getRouterState = (
   elements: Record<string | symbol, unknown>,
-): NavState | undefined => elements[NAV_ID] as NavState | undefined;
+): RouterState | undefined =>
+  elements[ROUTER_STATE_ID] as RouterState | undefined;
 
-export const makeNavState = (
+export const makeRouterState = (
   route: RouteProps,
   url: URL,
   options: {
@@ -75,7 +76,7 @@ export const makeNavState = (
     scroll: boolean;
     pathChanged: boolean;
   },
-): NavState => ({
+): RouterState => ({
   url: url.pathname + url.search + url.hash,
   attempted: [route.path, route.query],
   history: options.history,
@@ -87,20 +88,24 @@ export const makeNavState = (
 export const deriveCommitted = (
   elements: Record<string | symbol, unknown>,
   fallbackRoute: RouteProps,
-): { route: RouteProps; nav: NavState | undefined; url: URL | undefined } => {
-  const nav = getNavState(elements);
+): {
+  route: RouteProps;
+  routerState: RouterState | undefined;
+  url: URL | undefined;
+} => {
+  const routerState = getRouterState(elements);
   const routeFromElements = getRouteFromElements(elements);
-  if (!nav) {
-    return { route: fallbackRoute, nav: undefined, url: undefined };
+  if (!routerState) {
+    return { route: fallbackRoute, routerState: undefined, url: undefined };
   }
-  const navUrl = new URL(nav.url, window.location.href);
+  const stateUrl = new URL(routerState.url, window.location.href);
   const redirect = getServerRedirect(elements, {
-    path: nav.attempted[0],
-    query: nav.attempted[1],
+    path: routerState.attempted[0],
+    query: routerState.attempted[1],
     hash: '',
   });
   if (redirect && redirect.path !== '/404') {
-    return { route: redirect, nav, url: getRouteUrl(redirect) };
+    return { route: redirect, routerState, url: getRouteUrl(redirect) };
   }
   return {
     route: {
@@ -109,11 +114,11 @@ export const deriveCommitted = (
         : routeFromElements
           ? routeFromElements.path
           : fallbackRoute.path,
-      query: navUrl.searchParams.toString(),
-      hash: navUrl.hash,
+      query: stateUrl.searchParams.toString(),
+      hash: stateUrl.hash,
     },
-    nav,
-    url: navUrl,
+    routerState,
+    url: stateUrl,
   };
 };
 

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -81,14 +81,11 @@ export const makeRouterState = (
 });
 
 // a server redirect moves route and url; the 404 route keeps the attempted url
-export const getCommitted = (
+export const resolveCommitted = (
   elements: Record<string | symbol, unknown>,
+  routerState: RouterState,
   fallbackPath: string,
-): { routerState: RouterState; route: RouteProps; url: URL } | undefined => {
-  const routerState = getRouterState(elements);
-  if (!routerState) {
-    return undefined;
-  }
+): { route: RouteProps; url: URL } => {
   const stateUrl = new URL(routerState.url, window.location.href);
   const redirect = getServerRedirect(elements, {
     path: routerState.attempted[0],
@@ -96,10 +93,9 @@ export const getCommitted = (
     hash: '',
   });
   if (redirect && redirect.path !== '/404') {
-    return { routerState, route: redirect, url: getRouteUrl(redirect) };
+    return { route: redirect, url: getRouteUrl(redirect) };
   }
   return {
-    routerState,
     route: {
       path:
         redirect?.path ?? getRouteFromElements(elements)?.path ?? fallbackPath,

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -42,8 +42,8 @@ export const makeRouterState = (
   scrollIntent: options.scroll,
 });
 
-// a server redirect moves route and url; the 404 route keeps the attempted url
-export const resolveCommitted = (
+// a redirect to the 404 route keeps the url that was attempted
+export const resolveServerRedirect = (
   elements: Record<string | symbol, unknown>,
   routerState: RouterState,
   fallbackPath: string,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -165,8 +165,7 @@ type ChangeRouteOptions = {
   instant?: boolean | undefined;
 };
 
-// Resolves with a followable error (redirect or 404) instead of rejecting,
-// so awaiting callers treat a follow as a handoff, not a failure.
+// resolves with a followable error instead of rejecting: a follow is a handoff
 type ChangeRoute = (
   route: RouteProps,
   options: ChangeRouteOptions,
@@ -240,8 +239,7 @@ const useResolveSearchCodec = () => {
   );
 };
 
-// Dispatch inside a transition so the eager elements merge suspends without
-// blanking the tree, while sync throws and rejections reach the caller.
+// a transition, so the eager elements merge suspends without blanking the tree
 const changeRouteInTransition = (
   changeRoute: ChangeRoute,
   route: RouteProps,
@@ -767,8 +765,7 @@ const FollowError = ({
   }, [nav]);
   useEffect(() => {
     const [caughtPath, caughtQuery] = caughtAtRef.current!;
-    // the route derives from the elements, so a change means the followed
-    // route slot is committed and the children render it after the reset
+    // a route change means the followed slot is committed; safe to reset
     if (routePath !== caughtPath || routeQuery !== caughtQuery) {
       reset();
       return;
@@ -790,8 +787,7 @@ const FollowError = ({
   }, [routePath, routeQuery, nav, reset, fail, error]);
   useEffect(() => {
     const info = getErrorInfo(error);
-    // relative redirects resolve against the attempted url, which may not
-    // have reached the address bar yet
+    // the attempted url may not have reached the address bar yet
     const attemptedUrl = navRef.current
       ? new URL(navRef.current.url, window.location.href)
       : new URL(window.location.href);
@@ -915,7 +911,7 @@ const preloadRouteModules = (path: string) => {
   });
 };
 
-// In flight slice fetches, deduped per Root through the refetch identity.
+// in flight slice fetches; the refetch identity scopes them per Root
 const fetchingSlicesMap = new WeakMap<object, Set<SliceId>>();
 const getFetchingSlices = (refetch: object): Set<SliceId> => {
   let set = fetchingSlicesMap.get(refetch);
@@ -1053,10 +1049,8 @@ const InnerRouter = ({
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
   const [err, setErr] = useState<unknown>(null);
-  // the server does not know the hash; it appears after hydration
-  // the server does not know the hash; restore it after hydration. The
-  // update bails out when there is no hash, so hydrating suspense
-  // boundaries are not disturbed on hash-less loads.
+  // the hash appears after hydration; an empty one bails out, leaving
+  // hydrating suspense boundaries undisturbed
   const [restoredHash, setRestoredHash] = useState('');
   useEffect(() => {
     setRestoredHash(window.location.hash || initialHash);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1190,6 +1190,18 @@ const InnerRouter = ({
         if (isAborted()) {
           return;
         }
+        abortRef.current = null;
+        const info = getErrorInfo(e);
+        if (info?.location) {
+          // a fetch level redirect may leave waku; the browser follows it
+          const url = new URL(info.location, targetUrl);
+          if (navState.push) {
+            window.location.assign(url.href);
+          } else {
+            window.location.replace(url.href);
+          }
+          return;
+        }
         // write the url now; an unrecoverable rethrow discards the commit
         if (window.location.href !== targetUrl.href) {
           if (navState.push) {
@@ -1208,9 +1220,7 @@ const InnerRouter = ({
           },
         } as unknown as Record<string, unknown>);
         setErr(e);
-        abortRef.current = null;
-        const info = getErrorInfo(e);
-        if (info?.location || (info?.status === 404 && has404)) {
+        if (info?.status === 404 && has404) {
           // a followable outcome; the boundary takes it from here
           return e;
         }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1143,7 +1143,7 @@ const InnerRouter = ({
         mergeElements({
           [ROUTE_ID]: [nextRoute.path, nextRoute.query],
           [NAV_ID]: navState,
-        } as unknown as Record<string, unknown>);
+        });
         abortRef.current = null;
         emitRouteChangeEvent('complete', nextRoute);
         return;
@@ -1164,7 +1164,7 @@ const InnerRouter = ({
           [NAV_ID]: navState,
           // instant nav paints from the cache, so route meta comes with it
           ...(instant ? { [ROUTE_ID]: [nextRoute.path, nextRoute.query] } : {}),
-        } as unknown as Record<string, unknown>,
+        },
         ...(instant
           ? {
               unstable_swr: {
@@ -1218,7 +1218,7 @@ const InnerRouter = ({
             scrollIntent: options.shouldScroll,
             attempted: [routeBefore.path, routeBefore.query],
           },
-        } as unknown as Record<string, unknown>);
+        });
         setErr(e);
         if (info?.status === 404 && has404) {
           // a followable outcome; the boundary takes it from here

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -3,6 +3,7 @@
 import {
   Component,
   createContext,
+  startTransition,
   use,
   useCallback,
   useContext,
@@ -44,18 +45,18 @@ import {
   isStaticFromElements,
 } from './client-utils/elements-meta.js';
 import {
-  applyServerRedirect,
+  NAV_ID,
   canCommitInstantly,
-  deriveNav,
+  deriveCommitted,
   getRouteUrl,
   isSameRoute,
+  makeNavState,
+  parseRedirectUrl,
   parseRoute,
   pathnameToCurrentRoutePath,
   pinForSwr,
-  resolveFollowingErrors,
-  writeUrlToHistory,
 } from './client-utils/navigate.js';
-import type { Destination, Nav } from './client-utils/navigate.js';
+import type { NavState } from './client-utils/navigate.js';
 import {
   type PrefetchOptions,
   createPrefetchManager,
@@ -159,17 +160,17 @@ const createRscParams = (query: string): URLSearchParams => {
 type ChangeRouteOptions = {
   shouldScroll: boolean;
   refetch?: boolean; // true: force refetch, false: don't refetch, undefined: auto-decide based on route change
-  mode?: undefined | 'push' | 'replace';
+  push?: boolean;
   url?: URL | undefined;
-  startTransition?: ((fn: TransitionFunction) => void) | undefined;
   instant?: boolean | undefined;
-  errorToFollow?: unknown;
 };
 
+// Resolves with a followable error (redirect or 404) instead of rejecting,
+// so awaiting callers treat a follow as a handoff, not a failure.
 type ChangeRoute = (
   route: RouteProps,
   options: ChangeRouteOptions,
-) => Promise<void>;
+) => Promise<unknown>;
 
 type ChangeRouteEvent = 'start' | 'complete';
 
@@ -215,6 +216,7 @@ const createRouteChangeListeners = (): [
 // This is an internal thing, not a public API
 const RouterContext = createContext<{
   route: RouteProps;
+  nav?: NavState | undefined;
   changeRoute: ChangeRoute;
   prefetchRoute: PrefetchRoute;
   routeChangeEvents: Record<
@@ -238,6 +240,23 @@ const useResolveSearchCodec = () => {
     [codecs],
   );
 };
+
+// Dispatch inside a transition so the eager elements merge suspends without
+// blanking the tree, while sync throws and rejections reach the caller.
+const changeRouteInTransition = (
+  changeRoute: ChangeRoute,
+  route: RouteProps,
+  options: ChangeRouteOptions,
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    startTransition(() => {
+      try {
+        changeRoute(route, options).then(() => resolve(), reject);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
 
 const useRouterOrThrow = () => {
   const router = useContext(RouterContext);
@@ -271,9 +290,9 @@ export function useRouter() {
       options?: NavigateOptions,
     ) => {
       const url = resolveRouteUrl(to, resolveCodec);
-      await changeRoute(parseRoute(url), {
+      await changeRouteInTransition(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
-        mode: 'push',
+        push: true,
         url,
         instant: options?.unstable_instant,
       });
@@ -286,9 +305,8 @@ export function useRouter() {
       options?: NavigateOptions,
     ) => {
       const url = resolveRouteUrl(to, resolveCodec);
-      await changeRoute(parseRoute(url), {
+      await changeRouteInTransition(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
-        mode: 'replace',
         url,
         instant: options?.unstable_instant,
       });
@@ -296,7 +314,7 @@ export function useRouter() {
     [changeRoute, resolveCodec],
   ) as Navigate;
   const reload = useCallback(async () => {
-    await changeRoute(parseRouteFromLocation(), {
+    await changeRouteInTransition(changeRoute, parseRouteFromLocation(), {
       shouldScroll: true,
       refetch: true,
     });
@@ -446,9 +464,9 @@ export function useSetSearch_UNSTABLE<Path extends RoutePath>({
       const nextQuery = codec.serialize({ ...prev, ...partial });
       const url = new URL(window.location.href);
       url.search = nextQuery;
-      await changeRoute(parseRoute(url), {
+      await changeRouteInTransition(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? false,
-        mode: options?.history ?? 'push',
+        push: (options?.history ?? 'push') === 'push',
         url,
       });
     },
@@ -609,7 +627,7 @@ export function Link<Path extends RoutePath>({
       if (unstable_instant) {
         changeRoute(route, {
           shouldScroll: scroll ?? shouldScrollByDefault(url),
-          mode: 'push',
+          push: true,
           url,
           instant: true,
         }).catch(() => {});
@@ -617,9 +635,8 @@ export function Link<Path extends RoutePath>({
         startTransitionFn(async () => {
           await changeRoute(route, {
             shouldScroll: scroll ?? shouldScrollByDefault(url),
-            mode: 'push',
+            push: true,
             url,
-            startTransition: startTransitionFn,
           });
         });
       }
@@ -719,51 +736,123 @@ export class ErrorBoundary extends Component<
   }
 }
 
+const MAX_FOLLOW_HOPS = 20;
+
 const FollowError = ({
   error,
   has404,
   reset,
   fail,
+  countHop,
   followPromiseMap,
 }: {
   error: unknown;
   has404: boolean;
   reset: () => void;
   fail: (original: unknown, error: unknown) => void;
+  countHop: () => number;
   followPromiseMap: WeakMap<object, Promise<unknown>>;
 }) => {
-  const { route, changeRoute } = useRouterOrThrow();
-  const routeAtCatchRef = useRef(route);
+  const { route, nav, changeRoute } = useRouterOrThrow();
+  const { path: routePath, query: routeQuery } = route;
+  const caughtAtRef = useRef<readonly [string, string] | undefined>(undefined);
+  if (caughtAtRef.current === undefined) {
+    caughtAtRef.current = [routePath, routeQuery];
+  }
+  const dispatchedRef = useRef<readonly [string, string] | undefined>(
+    undefined,
+  );
+  const navRef = useRef(nav);
   useEffect(() => {
-    // reset once the followed route commits; a revived error follows again
-    if (!isSameRoute(route, routeAtCatchRef.current)) {
-      followPromiseMap.delete(error as object);
+    navRef.current = nav;
+  }, [nav]);
+  useEffect(() => {
+    const [caughtPath, caughtQuery] = caughtAtRef.current!;
+    // the route derives from the elements, so a change means the followed
+    // route slot is committed and the children render it after the reset
+    if (routePath !== caughtPath || routeQuery !== caughtQuery) {
       reset();
+      return;
     }
-  }, [route, error, reset, followPromiseMap]);
+    const dispatched = dispatchedRef.current;
+    if (
+      dispatched &&
+      nav?.attempted[0] === dispatched[0] &&
+      nav?.attempted[1] === dispatched[1]
+    ) {
+      if (dispatched[0] === routePath && dispatched[1] === routeQuery) {
+        // the follow bounced back to the rendered route; it can render
+        reset();
+      } else {
+        // the followed navigation committed without moving the route: a loop
+        fail(error, new Error('detected a redirect loop', { cause: error }));
+      }
+    }
+  }, [routePath, routeQuery, nav, reset, fail, error]);
   useEffect(() => {
     const info = getErrorInfo(error);
-    if (!info?.location && !(info?.status === 404 && has404)) {
+    // relative redirects resolve against the attempted url, which may not
+    // have reached the address bar yet
+    const attemptedUrl = navRef.current
+      ? new URL(navRef.current.url, window.location.href)
+      : new URL(window.location.href);
+    let target: RouteProps;
+    let url: URL;
+    if (info?.location) {
+      const parsed = parseRedirectUrl(info.location, attemptedUrl);
+      if (!parsed) {
+        return;
+      }
+      if (parsed.origin !== window.location.origin) {
+        window.location.replace(parsed.href);
+        return;
+      }
+      target = parseRoute(parsed);
+      url = parsed;
+    } else if (info?.status === 404 && has404) {
+      target = { path: '/404', query: '', hash: '' };
+      // the 404 route renders while the url keeps the attempted location
+      url = attemptedUrl;
+    } else {
       return;
     }
-    if (
-      !isSameRoute(route, routeAtCatchRef.current) ||
-      followPromiseMap.has(error as object)
-    ) {
+    if (followPromiseMap.has(error as object)) {
       return;
     }
-    followPromiseMap.set(
-      error as object,
-      changeRoute(parseRouteFromLocation(), {
-        shouldScroll: true,
-        errorToFollow: error,
-        ...(info?.location ? { mode: 'replace' as const } : {}),
-      }).catch((err) => {
-        followPromiseMap.delete(error as object);
-        fail(error, err);
-      }),
-    );
-  }, [route, error, has404, changeRoute, fail, followPromiseMap]);
+    // redirecting back to the route the error came from cannot recover
+    const caught = parseRoute(attemptedUrl);
+    if (target.path === caught.path && target.query === caught.query) {
+      fail(error, new Error('detected a redirect loop', { cause: error }));
+      return;
+    }
+    if (countHop() > MAX_FOLLOW_HOPS) {
+      fail(
+        error,
+        new Error('too many redirect or 404 follows', { cause: error }),
+      );
+      return;
+    }
+    dispatchedRef.current = [target.path, target.query];
+    startTransition(() => {
+      followPromiseMap.set(
+        error as object,
+        changeRoute(target, {
+          shouldScroll:
+            navRef.current?.scrollIntent ?? target.path !== caught.path,
+          url,
+        }).then(
+          (followable) => {
+            if (followable !== undefined) {
+              fail(error, followable);
+            }
+          },
+          (err) => {
+            fail(error, err);
+          },
+        ),
+      );
+    });
+  }, [error, has404, fail, countHop, changeRoute, followPromiseMap]);
   const info = getErrorInfo(error);
   return info?.status === 404 && !has404 ? <h1>Not Found</h1> : null;
 };
@@ -773,17 +862,24 @@ class CustomErrorHandler extends Component<
   { error: unknown | null }
 > {
   private followPromiseMap = new WeakMap<object, Promise<unknown>>();
+  private followHops = 0;
   constructor(props: { has404: boolean; children?: ReactNode }) {
     super(props);
     this.state = { error: null };
     this.reset = this.reset.bind(this);
     this.fail = this.fail.bind(this);
+    this.countHop = this.countHop.bind(this);
   }
   static getDerivedStateFromError(error: unknown) {
     return { error };
   }
   reset() {
+    this.followHops = 0;
     this.setState({ error: null });
+  }
+  countHop() {
+    this.followHops += 1;
+    return this.followHops;
   }
   fail(original: unknown, error: unknown) {
     this.setState((state) => (state.error === original ? { error } : null));
@@ -799,6 +895,7 @@ class CustomErrorHandler extends Component<
             has404={this.props.has404}
             reset={this.reset}
             fail={this.fail}
+            countHop={this.countHop}
             followPromiseMap={this.followPromiseMap}
           />
         );
@@ -929,7 +1026,8 @@ const InnerRouter = ({
     routeFromElements && routeFromElements.path !== fallbackRoute.path
       ? { ...routeFromElements, hash: fallbackRoute.hash }
       : fallbackRoute;
-  const initialRoute = useRef(resolvedRoute).current;
+  const initialHash = useRef(resolvedRoute.hash).current;
+  const initialRoute = useRef({ ...resolvedRoute, hash: '' }).current;
 
   // meta keys persist across merges, so they read from the current elements
   const has404 = has404FromElements(elements);
@@ -948,46 +1046,51 @@ const InnerRouter = ({
 
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
-  const [nav, setNav] = useState<Nav>(() => ({
-    query: initialRoute.query,
-    // hydrate without the hash the server does not know; an effect restores it
-    hash: '',
-    history: null,
-    scroll: null,
-  }));
   const [err, setErr] = useState<unknown>(null);
-  const currentRoute: RouteProps = {
-    path: routeFromElements ? routeFromElements.path : initialRoute.path,
-    query: nav.query,
-    hash: nav.hash,
-  };
-  const routeRef = useRef(currentRoute);
+  // the server does not know the hash; it appears after hydration
+  // the server does not know the hash; restore it after hydration. The
+  // update bails out when there is no hash, so hydrating suspense
+  // boundaries are not disturbed on hash-less loads.
+  const [restoredHash, setRestoredHash] = useState('');
   useEffect(() => {
-    const hash = window.location.hash || initialRoute.hash;
-    routeRef.current = { ...routeRef.current, hash };
-    setNav((prev) =>
-      prev.hash === hash && !prev.history && !prev.scroll
-        ? prev
-        : { ...prev, hash, history: null, scroll: null },
-    );
-    setErr(null);
-  }, [initialRoute.hash]);
+    setRestoredHash(window.location.hash || initialHash);
+  }, [initialHash]);
+
+  const derived = deriveCommitted(elements, initialRoute);
+  const { nav, url: committedUrl } = derived;
+  const currentRoute = nav
+    ? derived.route
+    : { ...derived.route, hash: restoredHash };
+  const routeRef = useRef(currentRoute);
+  const reconciledRef = useRef<{ nav: NavState; href: string } | undefined>(
+    undefined,
+  );
   useLayoutEffect(() => {
-    const route = routeRef.current;
-    if (nav.history) {
-      writeUrlToHistory(
-        nav.history.mode,
-        nav.history.url || getRouteUrl(route),
-      );
+    routeRef.current = currentRoute;
+    if (!nav || !committedUrl) {
+      return;
+    }
+    const navChanged = nav !== reconciledRef.current?.nav;
+    if (!navChanged && committedUrl.href === reconciledRef.current?.href) {
+      return;
+    }
+    reconciledRef.current = { nav, href: committedUrl.href };
+    if (nav.push && window.location.href !== committedUrl.href) {
+      nav.push = false; // consumed, so a later commit does not push again
+      window.history.pushState(window.history.state, '', committedUrl);
+    } else {
+      window.history.replaceState(window.history.state, '', committedUrl);
     }
     if (nav.scroll) {
+      const scroll = nav.scroll;
+      nav.scroll = null; // consumed, so a later commit does not scroll again
       scrollToRoute(
-        route,
-        nav.scroll.pathChanged ? 'instant' : 'auto',
-        nav.scroll.pathChanged,
+        currentRoute,
+        scroll.pathChanged ? 'instant' : 'auto',
+        scroll.pathChanged,
       );
     }
-  }, [nav]);
+  });
 
   if (import.meta.hot) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -1016,207 +1119,91 @@ const InnerRouter = ({
       abortRef.current = abortController;
       const isAborted = () => abortController.signal.aborted;
       emitRouteChangeEvent('start', nextRoute);
-      const startTransitionFn =
-        options.startTransition || ((fn: TransitionFunction) => fn());
-      const prevPathname = window.location.pathname;
-      let mode = options.mode;
       const routeBefore = routeRef.current;
+      const targetUrl = options.url ?? getRouteUrl(nextRoute);
+      const navState = makeNavState(nextRoute, targetUrl, {
+        push: !!options.push,
+        scroll: options.shouldScroll,
+        pathChanged: nextRoute.path !== routeBefore.path,
+      });
       const shouldRefetch =
         options.refetch ?? !isSameRoute(nextRoute, routeBefore);
-      const targetUrl = options.url ?? getRouteUrl(nextRoute);
-      const resolveDeps = {
-        fetchRoute: (route: RouteProps, routeUrl: URL) => {
-          const rscPath = encodeRoutePath(route.path);
-          const cached = prefetchManager.get(rscPath, route.query);
-          return refetch(rscPath, createRscParams(route.query), {
-            signal: abortController.signal,
-            onBuildIdMismatch: () => reloadWithUrl(routeUrl),
-            ...(cached ? { unstable_prefetched: cached.promise } : {}),
-          });
-        },
-        isKnownStatic: (path: string) => staticPathSet.has(path),
-        has404,
-        isAborted,
-        leaveApp: (url: URL) => {
-          if (mode && window.location.href !== targetUrl.href) {
-            writeUrlToHistory(mode, targetUrl);
-            setNav((prev) => ({ ...prev, history: null }));
-          }
-          window.location.replace(url.href);
-        },
-      };
-      const finish = (destination: Destination) => {
+      setErr(null);
+      if (staticPathSet.has(nextRoute.path) || !shouldRefetch) {
+        mergeElements({
+          [ROUTE_ID]: [nextRoute.path, nextRoute.query],
+          [NAV_ID]: navState,
+        } as unknown as Record<string, unknown>);
+        abortRef.current = null;
+        emitRouteChangeEvent('complete', nextRoute);
+        return;
+      }
+      const rscPath = encodeRoutePath(nextRoute.path);
+      const cached = prefetchManager.get(rscPath, nextRoute.query);
+      const prefetchedElements = prefetchManager.getElements(rscPath);
+      const instant =
+        options.instant &&
+        canCommitInstantly(
+          getRouteSlotId(nextRoute.path),
+          resolvedElementsRef.current,
+          prefetchedElements,
+        );
+      const dataPromise = refetch(rscPath, createRscParams(nextRoute.query), {
+        signal: abortController.signal,
+        unstable_overlay: {
+          [NAV_ID]: navState,
+          // instant nav paints from the cache, so route meta comes with it
+          ...(instant ? { [ROUTE_ID]: [nextRoute.path, nextRoute.query] } : {}),
+        } as unknown as Record<string, unknown>,
+        ...(instant
+          ? {
+              unstable_swr: {
+                pin: pinForSwr(() => resolvedElementsRef.current),
+                ...(prefetchedElements ? { base: prefetchedElements } : {}),
+              },
+            }
+          : {}),
+        onBuildIdMismatch: () => reloadWithUrl(targetUrl),
+        ...(cached ? { unstable_prefetched: cached.promise } : {}),
+      });
+      try {
+        const resolved = await dataPromise;
         if (isAborted()) {
           return;
         }
-        const { route, nav: nextNav } = deriveNav({
-          destination,
-          attempted: nextRoute,
-          routeBefore,
-          history: mode,
-          historyUrl: options.url,
-          shouldScroll: options.errorToFollow
-            ? destination.route.path !== routeBefore.path
-            : options.shouldScroll,
-          getServerRedirect,
-        });
-        if (
-          options.errorToFollow !== undefined &&
-          isSameRoute(route, routeBefore)
-        ) {
-          throw new Error('detected a redirect loop', {
-            cause: options.errorToFollow,
-          });
-        }
-        const commit = () => {
-          if (!destination.elements) {
-            mergeElements({ [ROUTE_ID]: [route.path, route.query] });
-          }
-          routeRef.current = route;
-          if (options.errorToFollow && nextNav.history) {
-            writeUrlToHistory(
-              nextNav.history.mode,
-              nextNav.history.url || getRouteUrl(route),
-            );
-            setNav({ ...nextNav, history: null });
-          } else {
-            setNav(nextNav);
-          }
-          setErr(null);
-          abortRef.current = null;
-          emitRouteChangeEvent('complete', route);
-        };
-        if (isSameRoute(destination.route, nextRoute)) {
-          void startTransitionFn(commit);
-        } else {
-          commit();
-        }
-      };
-      if (
-        !options.errorToFollow &&
-        (staticPathSet.has(nextRoute.path) || !shouldRefetch)
-      ) {
-        finish({ route: nextRoute, routeUrl: targetUrl });
-        return;
-      }
-      if (!options.errorToFollow && options.instant) {
-        const rscPath = encodeRoutePath(nextRoute.path);
-        const prefetchedElements = prefetchManager.getElements(rscPath);
-        const routeSlotId = getRouteSlotId(nextRoute.path);
-        if (
-          canCommitInstantly(
-            routeSlotId,
-            resolvedElementsRef.current,
-            prefetchedElements,
-          )
-        ) {
-          const pin = pinForSwr(() => resolvedElementsRef.current);
-          const cached = prefetchManager.get(rscPath, nextRoute.query);
-          const dataPromise = refetch(
-            rscPath,
-            createRscParams(nextRoute.query),
-            {
-              signal: abortController.signal,
-              unstable_overlay: {
-                [ROUTE_ID]: [nextRoute.path, nextRoute.query],
-              },
-              unstable_swr: {
-                pin,
-                ...(prefetchedElements ? { base: prefetchedElements } : {}),
-              },
-              onBuildIdMismatch: () => reloadWithUrl(targetUrl),
-              ...(cached ? { unstable_prefetched: cached.promise } : {}),
-            },
-          );
-          routeRef.current = nextRoute;
-          // instant nav paints the target right away, so write its url now
-          const optimisticNav = deriveNav({
-            destination: { route: nextRoute, routeUrl: targetUrl },
-            attempted: nextRoute,
-            routeBefore,
-            history: mode,
-            historyUrl: options.url,
-            shouldScroll: options.shouldScroll,
-            getServerRedirect,
-          }).nav;
-          if (optimisticNav.history) {
-            writeUrlToHistory(
-              optimisticNav.history.mode,
-              optimisticNav.history.url || getRouteUrl(nextRoute),
-            );
-          }
-          setNav({ ...optimisticNav, history: null });
-          setErr(null);
-          try {
-            const elements = await dataPromise;
-            if (isAborted()) {
-              return;
-            }
-            const redirect = getServerRedirect(elements, nextRoute);
-            if (redirect) {
-              routeRef.current = redirect;
-              if (redirect.path !== '/404') {
-                writeUrlToHistory('replace', getRouteUrl(redirect));
-              }
-              setNav((prev) => ({
-                ...applyServerRedirect(prev, redirect),
-                history: null,
-              }));
-            }
-            abortRef.current = null;
-            emitRouteChangeEvent('complete', redirect ?? nextRoute);
-          } catch (e) {
-            if (isAborted()) {
-              return;
-            }
-            // the url was already written optimistically, so a follow replaces
-            mode = mode && 'replace';
-            try {
-              const destination = await resolveFollowingErrors(
-                resolveDeps,
-                nextRoute,
-                targetUrl,
-                routeBefore,
-                e,
-              );
-              if (destination) {
-                finish(destination);
-              }
-            } catch (e2) {
-              if (isAborted()) {
-                return;
-              }
-              setErr(e2);
-              abortRef.current = null;
-              throw e2;
-            }
-          }
-          return;
-        }
-      }
-      try {
-        const destination = await resolveFollowingErrors(
-          resolveDeps,
-          nextRoute,
-          targetUrl,
-          routeBefore,
-          options.errorToFollow,
+        abortRef.current = null;
+        emitRouteChangeEvent(
+          'complete',
+          getServerRedirect(resolved, nextRoute) ?? nextRoute,
         );
-        if (!destination) {
-          return;
-        }
-        finish(destination);
       } catch (e) {
         if (isAborted()) {
           return;
         }
-        // Write URL synchronously
-        // React may rollback transition state updates when the render throws
-        if (mode && window.location.pathname === prevPathname) {
-          writeUrlToHistory(mode, targetUrl);
+        // write the url now; an unrecoverable rethrow discards the commit
+        if (window.location.href !== targetUrl.href) {
+          if (navState.push) {
+            window.history.pushState(window.history.state, '', targetUrl);
+          } else {
+            window.history.replaceState(window.history.state, '', targetUrl);
+          }
         }
+        mergeElements({
+          [NAV_ID]: {
+            ...navState,
+            push: false,
+            scroll: null,
+            scrollIntent: options.shouldScroll,
+            attempted: [routeBefore.path, routeBefore.query],
+          },
+        } as unknown as Record<string, unknown>);
         setErr(e);
         abortRef.current = null;
+        const info = getErrorInfo(e);
+        if (info?.location || (info?.status === 404 && has404)) {
+          // a followable outcome; the boundary takes it from here
+          return e;
+        }
         throw e;
       }
     },
@@ -1245,10 +1232,10 @@ const InnerRouter = ({
         return;
       }
       const route = { path, query, hash: '' };
-      await changeRoute(route, {
+      await changeRouteInTransition(changeRoute, route, {
         refetch: false,
         shouldScroll: false,
-        mode: path === '/404' ? undefined : 'push',
+        push: path !== '/404',
         url: getRouteUrl(route),
       });
     },
@@ -1290,10 +1277,12 @@ const InnerRouter = ({
       if (!nextRoute) {
         return;
       }
-      changeRoute(nextRoute, {
-        shouldScroll: shouldScrollForRouteChange(nextRoute, routeRef.current),
-      }).catch((err) => {
-        console.log('Error while navigating back:', err);
+      startTransition(() => {
+        changeRoute(nextRoute, {
+          shouldScroll: shouldScrollForRouteChange(nextRoute, routeRef.current),
+        }).catch((err) => {
+          console.log('Error while navigating back:', err);
+        });
       });
     };
     window.addEventListener('popstate', callback);
@@ -1317,6 +1306,7 @@ const InnerRouter = ({
     <RouterContext
       value={{
         route: currentRoute,
+        nav,
         changeRoute,
         prefetchRoute,
         routeChangeEvents,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1099,7 +1099,12 @@ const InnerRouter = ({
         prefetchManager.clear();
         staticPathSet.clear();
         const route = routeRef.current;
-        void refetch(encodeRoutePath(route.path), createRscParams(route.query));
+        startTransition(() => {
+          void refetch(
+            encodeRoutePath(route.path),
+            createRscParams(route.query),
+          );
+        });
       };
       upsertRscReloadListener(globalThis.__WAKU_REFETCH_ROUTE__, refetchRoute);
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRoute;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -735,6 +735,8 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOW_HOPS = 20;
 
+const PROBE_TIMEOUT = 3000;
+
 const FollowError = ({
   error,
   has404,
@@ -1204,14 +1206,19 @@ const InnerRouter = ({
         }
         if (!info && e instanceof TypeError) {
           // a probe tells a dead server from a cors blocked redirect
-          const alive = await fetch(targetUrl, {
-            method: 'HEAD',
-            redirect: 'manual',
-            signal: abortController.signal,
-          }).then(
-            () => true,
-            () => false,
-          );
+          const alive = await Promise.race([
+            fetch(targetUrl, {
+              method: 'HEAD',
+              redirect: 'manual',
+              signal: abortController.signal,
+            }).then(
+              () => true,
+              () => false,
+            ),
+            new Promise<boolean>((resolve) => {
+              setTimeout(() => resolve(false), PROBE_TIMEOUT);
+            }),
+          ]);
           if (isAborted()) {
             return;
           }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -165,7 +165,7 @@ type ChangeRouteOptions = {
   instant?: boolean | undefined;
 };
 
-// resolves with a followable error instead of rejecting: a follow is a handoff
+/** Resolves with a followable error instead of rejecting: a follow is a handoff. */
 type ChangeRoute = (
   route: RouteProps,
   options: ChangeRouteOptions,
@@ -1247,7 +1247,8 @@ const InnerRouter = ({
             ...navState,
             push: false,
             scroll: null,
-            scrollIntent: options.shouldScroll,
+            // attempted mirrors routeBefore; the stale ROUTE_ID must not
+            // read as a server redirect
             attempted: [routeBefore.path, routeBefore.query],
           },
         });

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -869,12 +869,17 @@ class CustomErrorHandler extends Component<
     return { error };
   }
   reset() {
-    this.followHops = 0;
     this.setState({ error: null });
   }
   countHop() {
     this.followHops += 1;
     return this.followHops;
+  }
+  // a clean commit settles the chain; a rendering cycle would keep the count
+  componentDidUpdate() {
+    if (this.state.error === null) {
+      this.followHops = 0;
+    }
   }
   fail(original: unknown, error: unknown) {
     this.setState((state) => (state.error === original ? { error } : null));

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -816,7 +816,7 @@ const FollowError = ({
     }
     // redirecting back to the route the error came from cannot recover
     const caught = parseRoute(attemptedUrl);
-    if (target.path === caught.path && target.query === caught.query) {
+    if (isSameRoute(target, caught)) {
       fail(error, new Error('detected a redirect loop', { cause: error }));
       return;
     }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1202,6 +1202,15 @@ const InnerRouter = ({
           }
           return;
         }
+        if (!info && e instanceof TypeError) {
+          // a network error can hide a cors blocked redirect; the browser retries
+          if (navState.push) {
+            window.location.assign(targetUrl.href);
+          } else {
+            window.location.replace(targetUrl.href);
+          }
+          return;
+        }
         // write the url now; an unrecoverable rethrow discards the commit
         if (window.location.href !== targetUrl.href) {
           if (navState.push) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1117,10 +1117,12 @@ const InnerRouter = ({
             createRscParams(nextRoute.query),
             {
               signal: abortController.signal,
+              unstable_overlay: {
+                [ROUTE_ID]: [nextRoute.path, nextRoute.query],
+              },
               unstable_swr: {
                 pin,
                 ...(prefetchedElements ? { base: prefetchedElements } : {}),
-                overlay: { [ROUTE_ID]: [nextRoute.path, nextRoute.query] },
               },
               onBuildIdMismatch: () => reloadWithUrl(targetUrl),
               ...(cached ? { unstable_prefetched: cached.promise } : {}),

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1190,9 +1190,9 @@ const InnerRouter = ({
         if (isAborted()) {
           return;
         }
-        abortRef.current = null;
         const info = getErrorInfo(e);
         if (info?.location) {
+          abortRef.current = null;
           // a fetch level redirect may leave waku; the browser follows it
           const url = new URL(info.location, targetUrl);
           if (navState.push) {
@@ -1207,6 +1207,7 @@ const InnerRouter = ({
           const alive = await fetch(targetUrl, {
             method: 'HEAD',
             redirect: 'manual',
+            signal: abortController.signal,
           }).then(
             () => true,
             () => false,
@@ -1215,6 +1216,7 @@ const InnerRouter = ({
             return;
           }
           if (alive) {
+            abortRef.current = null;
             // the browser retries the url itself and follows any redirect
             if (navState.push) {
               window.location.assign(targetUrl.href);
@@ -1224,6 +1226,7 @@ const InnerRouter = ({
             return;
           }
         }
+        abortRef.current = null;
         // write the url now; an unrecoverable rethrow discards the commit
         if (window.location.href !== targetUrl.href) {
           if (navState.push) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -223,7 +223,6 @@ const RouterContext = createContext<{
     'on' | 'off',
     (event: ChangeRouteEvent, handler: ChangeRouteCallback) => void
   >;
-  fetchingSlices: Set<SliceId>;
 } | null>(null);
 
 const SearchCodecsContext = createContext<ReadonlyMap<string, AnyCodec>>(
@@ -916,6 +915,17 @@ const preloadRouteModules = (path: string) => {
   });
 };
 
+// In flight slice fetches, deduped per Root through the refetch identity.
+const fetchingSlicesMap = new WeakMap<object, Set<SliceId>>();
+const getFetchingSlices = (refetch: object): Set<SliceId> => {
+  let set = fetchingSlicesMap.get(refetch);
+  if (!set) {
+    set = new Set();
+    fetchingSlicesMap.set(refetch, set);
+  }
+  return set;
+};
+
 export function Slice({
   id,
   children,
@@ -932,8 +942,6 @@ export function Slice({
       fallback: ReactNode;
     }
 )) {
-  const router = useRouterOrThrow();
-  const { fetchingSlices } = router;
   const refetch = useRefetch();
   const slotId = getSliceSlotId(id);
   const elementsPromise = useElementsPromise();
@@ -942,7 +950,7 @@ export function Slice({
     props.lazy &&
     (!(slotId in elements) || !isImmutableElement(elements, slotId));
   useEffect(() => {
-    // FIXME this works because of subtle timing behavior.
+    const fetchingSlices = getFetchingSlices(refetch);
     if (needsToFetchSlice && !fetchingSlices.has(id)) {
       fetchingSlices.add(id);
       const rscPath = encodeSliceId(id);
@@ -954,7 +962,7 @@ export function Slice({
           fetchingSlices.delete(id);
         });
     }
-  }, [fetchingSlices, refetch, id, needsToFetchSlice]);
+  }, [refetch, id, needsToFetchSlice]);
   if (props.lazy && !(slotId in elements)) {
     // FIXME the fallback doesn't show on refetch after the first one.
     return props.fallback;
@@ -1040,8 +1048,6 @@ const InnerRouter = ({
       staticPathSet.add(route.path);
     }
   }, [elements, staticPathSet]);
-  // FIXME this "fetchingSlices" hack feels suboptimal.
-  const fetchingSlices = useRef(new Set<SliceId>()).current;
   const prefetchManager = useRef(createPrefetchManager()).current;
 
   const refetch = useRefetch();
@@ -1310,7 +1316,6 @@ const InnerRouter = ({
         changeRoute,
         prefetchRoute,
         routeChangeEvents,
-        fetchingSlices,
       }}
     >
       {rootElement}
@@ -1360,7 +1365,6 @@ export function INTERNAL_ServerRouter({ route }: { route: RouteProps }) {
           changeRoute: notAvailableInServer('changeRoute'),
           prefetchRoute: notAvailableInServer('prefetchRoute'),
           routeChangeEvents: MOCK_ROUTE_CHANGE_LISTENER,
-          fetchingSlices: new Set<SliceId>(),
         }}
       >
         {rootElement}

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1203,13 +1203,26 @@ const InnerRouter = ({
           return;
         }
         if (!info && e instanceof TypeError) {
-          // a network error can hide a cors blocked redirect; the browser retries
-          if (navState.push) {
-            window.location.assign(targetUrl.href);
-          } else {
-            window.location.replace(targetUrl.href);
+          // a probe tells a dead server from a cors blocked redirect
+          const alive = await fetch(targetUrl, {
+            method: 'HEAD',
+            redirect: 'manual',
+          }).then(
+            () => true,
+            () => false,
+          );
+          if (isAborted()) {
+            return;
           }
-          return;
+          if (alive) {
+            // the browser retries the url itself and follows any redirect
+            if (navState.push) {
+              window.location.assign(targetUrl.href);
+            } else {
+              window.location.replace(targetUrl.href);
+            }
+            return;
+          }
         }
         // write the url now; an unrecoverable rethrow discards the commit
         if (window.location.href !== targetUrl.href) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -871,11 +871,15 @@ const FollowError = ({
           follow: true,
         }).then(
           (followable) => {
+            // the same error object can be thrown again, by a module scoped
+            // error or one revived from the record, and must follow again
+            followPromiseMap.delete(error as object);
             if (followable !== undefined) {
               fail(error, followable);
             }
           },
           (err) => {
+            followPromiseMap.delete(error as object);
             fail(error, err);
           },
         ),

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -805,8 +805,14 @@ const FollowError = ({
     if (info?.location) {
       const parsed = parseRedirectUrl(info.location, attemptedUrl);
       if (!parsed) {
-        // an unusable protocol; the boundary shows the error instead of a blank
-        fail(error, error);
+        // a plain error carries no location, so the boundary stops following
+        // it and shows it instead of a blank slot
+        fail(
+          error,
+          new Error(`cannot follow a redirect to ${info.location}`, {
+            cause: error,
+          }),
+        );
         return;
       }
       if (parsed.origin !== window.location.origin) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -842,8 +842,9 @@ const FollowError = ({
       followPromiseMap.set(
         error as object,
         changeRoute(target, {
-          shouldScroll:
-            routerStateRef.current?.scrollIntent ?? target.path !== caught.path,
+          shouldScroll: routerStateRef.current
+            ? routerStateRef.current.scroll !== null
+            : target.path !== caught.path,
           history: 'replace',
           url,
         }).then(
@@ -1091,8 +1092,10 @@ const InnerRouter = ({
     ? destination.route
     : { ...initialRoute, hash: restoredHash };
   const routeRef = useRef(currentRoute);
+  // what the last reconcile did; a state reconciles again when its destination
+  // moves, so the push and the scroll must not repeat
   const reconciledRef = useRef<
-    { routerState: RouterState; href: string } | undefined
+    { routerState: RouterState; href: string; pushed: boolean } | undefined
   >(undefined);
   useLayoutEffect(() => {
     routeRef.current = currentRoute;
@@ -1100,28 +1103,31 @@ const InnerRouter = ({
       return;
     }
     const { url } = destination;
-    const stateChanged = routerState !== reconciledRef.current?.routerState;
-    if (!stateChanged && url.href === reconciledRef.current?.href) {
+    const reconciled =
+      reconciledRef.current?.routerState === routerState
+        ? reconciledRef.current
+        : undefined;
+    if (reconciled?.href === url.href) {
       return;
     }
-    reconciledRef.current = { routerState, href: url.href };
+    let pushed = reconciled?.pushed ?? false;
     // the state carries the url that should show, so a null history still
     // writes when the destination moved away from it
     if (window.location.href !== url.href) {
-      if (routerState.history === 'push') {
-        routerState.history = 'replace'; // consumed, so a later commit does not push again
+      if (routerState.history === 'push' && !pushed) {
+        pushed = true;
         window.history.pushState(window.history.state, '', url);
       } else {
         window.history.replaceState(window.history.state, '', url);
       }
     }
-    if (routerState.scroll) {
-      const scroll = routerState.scroll;
-      routerState.scroll = null; // consumed, so a later commit does not scroll again
+    reconciledRef.current = { routerState, href: url.href, pushed };
+    if (routerState.scroll && !reconciled) {
+      const { pathChanged } = routerState.scroll;
       scrollToRoute(
         currentRoute,
-        scroll.pathChanged ? 'instant' : 'auto',
-        scroll.pathChanged,
+        pathChanged ? 'instant' : 'auto',
+        pathChanged,
       );
     }
   });

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -242,13 +242,17 @@ const useResolveSearchCodec = () => {
   );
 };
 
-// a transition, so the eager elements merge suspends without blanking the tree
-const changeRouteInTransition = (
+const dispatchChangeRoute = (
   changeRoute: ChangeRoute,
   route: RouteProps,
   options: ChangeRouteOptions,
-): Promise<void> =>
-  new Promise<void>((resolve, reject) => {
+): Promise<void> => {
+  if (options.instant) {
+    // instant paints from the cache; a transition would hold that back
+    return changeRoute(route, options).then(() => undefined);
+  }
+  // a transition, so the eager elements merge suspends without blanking the tree
+  return new Promise<void>((resolve, reject) => {
     startTransition(() => {
       try {
         changeRoute(route, options).then(() => resolve(), reject);
@@ -257,6 +261,7 @@ const changeRouteInTransition = (
       }
     });
   });
+};
 
 const useRouterOrThrow = () => {
   const router = useContext(RouterContext);
@@ -290,7 +295,7 @@ export function useRouter() {
       options?: NavigateOptions,
     ) => {
       const url = resolveRouteUrl(to, resolveCodec);
-      await changeRouteInTransition(changeRoute, parseRoute(url), {
+      await dispatchChangeRoute(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
         history: 'push',
         url,
@@ -305,7 +310,7 @@ export function useRouter() {
       options?: NavigateOptions,
     ) => {
       const url = resolveRouteUrl(to, resolveCodec);
-      await changeRouteInTransition(changeRoute, parseRoute(url), {
+      await dispatchChangeRoute(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
         history: 'replace',
         url,
@@ -315,7 +320,7 @@ export function useRouter() {
     [changeRoute, resolveCodec],
   ) as Navigate;
   const reload = useCallback(async () => {
-    await changeRouteInTransition(changeRoute, parseRouteFromLocation(), {
+    await dispatchChangeRoute(changeRoute, parseRouteFromLocation(), {
       shouldScroll: true,
       refetch: true,
       history: 'replace',
@@ -466,7 +471,7 @@ export function useSetSearch_UNSTABLE<Path extends RoutePath>({
       const nextQuery = codec.serialize({ ...prev, ...partial });
       const url = new URL(window.location.href);
       url.search = nextQuery;
-      await changeRouteInTransition(changeRoute, parseRoute(url), {
+      await dispatchChangeRoute(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? false,
         history: options?.history ?? 'push',
         url,
@@ -1266,7 +1271,7 @@ const InnerRouter = ({
         return;
       }
       const route = { path, query, hash: '' };
-      await changeRouteInTransition(changeRoute, route, {
+      await dispatchChangeRoute(changeRoute, route, {
         refetch: false,
         shouldScroll: false,
         // the 404 route renders where the user already is

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1052,14 +1052,25 @@ const InnerRouter = ({
   // meta keys persist across merges, so they read from the current elements
   const has404 = has404FromElements(elements);
   const staticPathSet = useRef(new Set<string>()).current;
+  // only a response tells a route's staticness; a record mid navigation pairs
+  // the target route id with the previous route's pinned flag
+  const learnStaticPath = useCallback(
+    (responseElements: Record<string, unknown>) => {
+      const route = getRouteFromElements(responseElements);
+      if (route && isStaticFromElements(responseElements)) {
+        staticPathSet.add(route.path);
+      }
+    },
+    [staticPathSet],
+  );
+  const initialElements = useRef(elements).current;
+  useEffect(() => {
+    learnStaticPath(initialElements);
+  }, [initialElements, learnStaticPath]);
   const resolvedElementsRef = useRef(elements);
   useEffect(() => {
     resolvedElementsRef.current = elements;
-    const route = getRouteFromElements(elements);
-    if (route && isStaticFromElements(elements)) {
-      staticPathSet.add(route.path);
-    }
-  }, [elements, staticPathSet]);
+  }, [elements]);
   const prefetchManager = useRef(createPrefetchManager()).current;
 
   const refetch = useRefetch();
@@ -1203,6 +1214,7 @@ const InnerRouter = ({
           return;
         }
         abortRef.current = null;
+        learnStaticPath(resolved);
         emitRouteChangeEvent(
           'complete',
           getServerRedirect(resolved, nextRoute) ?? nextRoute,
@@ -1256,6 +1268,7 @@ const InnerRouter = ({
       has404,
       emitRouteChangeEvent,
       staticPathSet,
+      learnStaticPath,
       resolvedElementsRef,
       prefetchManager,
     ],

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -323,6 +323,7 @@ export function useRouter() {
       shouldScroll: true,
       refetch: true,
       history: 'replace',
+      url: new URL(window.location.href), // reloading moves nothing
     });
   }, [changeRoute]);
   const back = useCallback(() => {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -161,6 +161,7 @@ type ChangeRouteOptions = {
   history: 'push' | 'replace' | null;
   url?: URL | undefined;
   instant?: boolean | undefined;
+  follow?: boolean | undefined; // dispatched by the error boundary, not a user
 };
 
 /** Resolves with a followable error instead of rejecting: a follow is a handoff. */
@@ -740,8 +741,10 @@ export class ErrorBoundary extends Component<
 const MAX_FOLLOW_HOPS = 20;
 
 // a hop that commits a suspense fallback before it throws resets the chain
-// count, so the boundary caps its follows for good as well
-const MAX_TOTAL_FOLLOWS = 100;
+// count, so the follows one navigation may spend are capped as well
+const MAX_FOLLOWS_PER_NAVIGATION = 100;
+
+type FollowBudget = { spent: number };
 
 const FollowError = ({
   error,
@@ -865,6 +868,7 @@ const FollowError = ({
             : target.path !== caught.path,
           history: 'replace',
           url,
+          follow: true,
         }).then(
           (followable) => {
             if (followable !== undefined) {
@@ -883,13 +887,16 @@ const FollowError = ({
 };
 
 class CustomErrorHandler extends Component<
-  { has404: boolean; children?: ReactNode },
+  { has404: boolean; budget: FollowBudget; children?: ReactNode },
   { error: unknown | null }
 > {
   private followPromiseMap = new WeakMap<object, Promise<unknown>>();
   private followHops = 0;
-  private totalFollows = 0;
-  constructor(props: { has404: boolean; children?: ReactNode }) {
+  constructor(props: {
+    has404: boolean;
+    budget: FollowBudget;
+    children?: ReactNode;
+  }) {
     super(props);
     this.state = { error: null };
     this.reset = this.reset.bind(this);
@@ -904,10 +911,10 @@ class CustomErrorHandler extends Component<
   }
   countHop() {
     this.followHops += 1;
-    this.totalFollows += 1;
+    this.props.budget.spent += 1;
     return (
       this.followHops <= MAX_FOLLOW_HOPS &&
-      this.totalFollows <= MAX_TOTAL_FOLLOWS
+      this.props.budget.spent <= MAX_FOLLOWS_PER_NAVIGATION
     );
   }
   componentDidUpdate() {
@@ -1183,6 +1190,7 @@ const InnerRouter = ({
     createRouteChangeListeners,
   );
 
+  const followBudget = useRef<FollowBudget>({ spent: 0 }).current;
   const abortRef = useRef<AbortController | null>(null);
 
   const changeRoute: ChangeRoute = useCallback(
@@ -1192,6 +1200,9 @@ const InnerRouter = ({
       abortRef.current = abortController;
       const isAborted = () => abortController.signal.aborted;
       emitRouteChangeEvent('start', nextRoute);
+      if (!options.follow) {
+        followBudget.spent = 0; // a navigation of its own starts a fresh budget
+      }
       const routeBefore = routeRef.current;
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
       const routerState = makeRouterState(nextRoute, targetUrl, {
@@ -1307,6 +1318,7 @@ const InnerRouter = ({
       emitRouteChangeEvent,
       staticPathSet,
       learnStaticPath,
+      followBudget,
       resolvedElementsRef,
       prefetchManager,
     ],
@@ -1402,7 +1414,9 @@ const InnerRouter = ({
     );
   const rootElement = (
     <Slot id="root">
-      <CustomErrorHandler has404={has404}>{routeElement}</CustomErrorHandler>
+      <CustomErrorHandler has404={has404} budget={followBudget}>
+        {routeElement}
+      </CustomErrorHandler>
     </Slot>
   );
   return (

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -776,6 +776,7 @@ const FollowError = ({
     const dispatched = dispatchedRef.current;
     if (
       dispatched &&
+      !routerState?.failed && // a failed follow committed no route
       routerState?.attempted[0] === dispatched[0] &&
       routerState?.attempted[1] === dispatched[1]
     ) {
@@ -1248,9 +1249,7 @@ const InnerRouter = ({
             ...routerState,
             history: null, // the url above is already written
             scroll: null,
-            // attempted mirrors routeBefore; the stale ROUTE_ID must not
-            // read as a server redirect
-            attempted: [routeBefore.path, routeBefore.query],
+            failed: true,
           },
         });
         setErr(e);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1301,13 +1301,14 @@ const InnerRouter = ({
   );
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
+      learnStaticPath(elements);
       const { [ROUTE_ID]: routeData, [IS_STATIC_ID]: isStatic } = elements;
       applyChangeRouteData(routeData, isStatic).catch((err) => {
         console.log('Error while handling route updates:', err);
       });
     };
     return registerCallServerElementsListener(listener);
-  }, [applyChangeRouteData]);
+  }, [applyChangeRouteData, learnStaticPath]);
 
   const prefetchRoute: PrefetchRoute = useCallback(
     (route, options) => {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1205,8 +1205,17 @@ const InnerRouter = ({
         signal: abortController.signal,
         unstable_overlay: {
           [ROUTER_STATE_ID]: routerState,
-          // instant routerState paints from the cache, so route meta comes with it
-          ...(instant ? { [ROUTE_ID]: [nextRoute.path, nextRoute.query] } : {}),
+          // instant nav paints from the cache, so route meta comes with it.
+          // meta is pinned, and only an overlay key is refreshed from the
+          // response, so both keys have to ride here to avoid going stale
+          ...(instant
+            ? {
+                [ROUTE_ID]: [nextRoute.path, nextRoute.query],
+                [IS_STATIC_ID]: isStaticFromElements(
+                  resolvedElementsRef.current,
+                ),
+              }
+            : {}),
         },
         ...(instant
           ? {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -801,13 +801,16 @@ const FollowError = ({
     if (info?.location) {
       const parsed = parseRedirectUrl(info.location, attemptedUrl);
       if (!parsed) {
+        // an unusable protocol; the boundary shows the error instead of a blank
+        fail(error, error);
         return;
       }
       if (parsed.origin !== window.location.origin) {
         window.location.replace(parsed.href);
         return;
       }
-      if (info.location.startsWith('/')) {
+      // a protocol-relative location is another origin's, never an app path
+      if (info.location.startsWith('/') && !info.location.startsWith('//')) {
         // an app location has no base path; the browser url gets it back
         target = {
           path: pathnameToRoutePath(parsed.pathname),
@@ -894,6 +897,9 @@ class CustomErrorHandler extends Component<
   }
   // a clean commit settles the chain; a rendering cycle would keep the count
   componentDidUpdate() {
+    // a chain that redirects on every render never commits an error free
+    // state, so this counts its hops; reset() alone would not, because each
+    // hop does change the route
     if (this.state.error === null) {
       this.followHops = 0;
     }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -51,7 +51,7 @@ import {
 import {
   ROUTER_STATE_ID,
   canCommitInstantly,
-  deriveCommitted,
+  getCommittedRoute,
   getRouteUrl,
   isSameRoute,
   makeRouterState,
@@ -1064,20 +1064,20 @@ const InnerRouter = ({
     setRestoredHash(window.location.hash || initialHash);
   }, [initialHash]);
 
-  const derived = deriveCommitted(elements, initialRoute);
-  const { routerState, url: committedUrl } = derived;
-  const currentRoute = routerState
-    ? derived.route
-    : { ...derived.route, hash: restoredHash };
+  const committed = getCommittedRoute(elements, initialRoute.path);
+  const currentRoute = committed
+    ? committed.route
+    : { ...initialRoute, hash: restoredHash };
   const routeRef = useRef(currentRoute);
   const reconciledRef = useRef<
     { routerState: RouterState; href: string } | undefined
   >(undefined);
   useLayoutEffect(() => {
     routeRef.current = currentRoute;
-    if (!routerState || !committedUrl) {
+    if (!committed) {
       return;
     }
+    const { routerState, url: committedUrl } = committed;
     const stateChanged = routerState !== reconciledRef.current?.routerState;
     if (!stateChanged && committedUrl.href === reconciledRef.current?.href) {
       return;
@@ -1339,7 +1339,7 @@ const InnerRouter = ({
     <RouterContext
       value={{
         route: currentRoute,
-        routerState,
+        routerState: committed?.routerState,
         changeRoute,
         prefetchRoute,
         routeChangeEvents,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -160,7 +160,7 @@ const createRscParams = (query: string): URLSearchParams => {
 type ChangeRouteOptions = {
   shouldScroll: boolean;
   refetch?: boolean; // true: force refetch, false: don't refetch, undefined: auto-decide based on route change
-  push?: boolean;
+  history: 'push' | 'replace' | null;
   url?: URL | undefined;
   instant?: boolean | undefined;
 };
@@ -289,7 +289,7 @@ export function useRouter() {
       const url = resolveRouteUrl(to, resolveCodec);
       await changeRouteInTransition(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
-        push: true,
+        history: 'push',
         url,
         instant: options?.unstable_instant,
       });
@@ -304,6 +304,7 @@ export function useRouter() {
       const url = resolveRouteUrl(to, resolveCodec);
       await changeRouteInTransition(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
+        history: 'replace',
         url,
         instant: options?.unstable_instant,
       });
@@ -314,6 +315,7 @@ export function useRouter() {
     await changeRouteInTransition(changeRoute, parseRouteFromLocation(), {
       shouldScroll: true,
       refetch: true,
+      history: 'replace',
     });
   }, [changeRoute]);
   const back = useCallback(() => {
@@ -463,7 +465,7 @@ export function useSetSearch_UNSTABLE<Path extends RoutePath>({
       url.search = nextQuery;
       await changeRouteInTransition(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? false,
-        push: (options?.history ?? 'push') === 'push',
+        history: options?.history ?? 'push',
         url,
       });
     },
@@ -624,7 +626,7 @@ export function Link<Path extends RoutePath>({
       if (unstable_instant) {
         changeRoute(route, {
           shouldScroll: scroll ?? shouldScrollByDefault(url),
-          push: true,
+          history: 'push',
           url,
           instant: true,
         }).catch(() => {});
@@ -632,7 +634,7 @@ export function Link<Path extends RoutePath>({
         startTransitionFn(async () => {
           await changeRoute(route, {
             shouldScroll: scroll ?? shouldScrollByDefault(url),
-            push: true,
+            history: 'push',
             url,
           });
         });
@@ -836,6 +838,7 @@ const FollowError = ({
         changeRoute(target, {
           shouldScroll:
             navRef.current?.scrollIntent ?? target.path !== caught.path,
+          history: 'replace',
           url,
         }).then(
           (followable) => {
@@ -1082,10 +1085,10 @@ const InnerRouter = ({
       return;
     }
     reconciledRef.current = { nav, href: committedUrl.href };
-    if (nav.push && window.location.href !== committedUrl.href) {
-      nav.push = false; // consumed, so a later commit does not push again
+    if (nav.history === 'push' && window.location.href !== committedUrl.href) {
+      nav.history = 'replace'; // consumed, so a later commit does not push again
       window.history.pushState(window.history.state, '', committedUrl);
-    } else {
+    } else if (nav.history) {
       window.history.replaceState(window.history.state, '', committedUrl);
     }
     if (nav.scroll) {
@@ -1134,7 +1137,7 @@ const InnerRouter = ({
       const routeBefore = routeRef.current;
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
       const navState = makeNavState(nextRoute, targetUrl, {
-        push: !!options.push,
+        history: options.history,
         scroll: options.shouldScroll,
         pathChanged: nextRoute.path !== routeBefore.path,
       });
@@ -1197,7 +1200,7 @@ const InnerRouter = ({
           abortRef.current = null;
           // a fetch level redirect may leave waku; the browser follows it
           const url = new URL(info.location, targetUrl);
-          if (navState.push) {
+          if (navState.history === 'push') {
             window.location.assign(url.href);
           } else {
             window.location.replace(url.href);
@@ -1229,7 +1232,7 @@ const InnerRouter = ({
           if (alive) {
             abortRef.current = null;
             // the browser retries the url itself and follows any redirect
-            if (navState.push) {
+            if (navState.history === 'push') {
               window.location.assign(targetUrl.href);
             } else {
               window.location.replace(targetUrl.href);
@@ -1240,7 +1243,7 @@ const InnerRouter = ({
         abortRef.current = null;
         // write the url now; an unrecoverable rethrow discards the commit
         if (window.location.href !== targetUrl.href) {
-          if (navState.push) {
+          if (navState.history === 'push') {
             window.history.pushState(window.history.state, '', targetUrl);
           } else {
             window.history.replaceState(window.history.state, '', targetUrl);
@@ -1249,7 +1252,7 @@ const InnerRouter = ({
         mergeElements({
           [NAV_ID]: {
             ...navState,
-            push: false,
+            history: null, // the url above is already written
             scroll: null,
             // attempted mirrors routeBefore; the stale ROUTE_ID must not
             // read as a server redirect
@@ -1289,13 +1292,12 @@ const InnerRouter = ({
         return;
       }
       const route = { path, query, hash: '' };
-      const is404 = path === '/404';
       await changeRouteInTransition(changeRoute, route, {
         refetch: false,
         shouldScroll: false,
-        push: !is404,
-        // the 404 route keeps the url the user is on
-        url: is404 ? new URL(window.location.href) : getRouteUrl(route),
+        // the 404 route renders where the user already is
+        history: path === '/404' ? null : 'push',
+        url: getRouteUrl(route),
       });
     },
     [changeRoute],
@@ -1339,6 +1341,7 @@ const InnerRouter = ({
       startTransition(() => {
         changeRoute(nextRoute, {
           shouldScroll: shouldScrollForRouteChange(nextRoute, routeRef.current),
+          history: null, // the browser already moved the address bar
         }).catch((err) => {
           console.log('Error while navigating back:', err);
         });

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1281,14 +1281,17 @@ const InnerRouter = ({
           return;
         }
         const info = getErrorInfo(e);
-        if (info?.location) {
+        // a fetch level redirect may leave waku; the browser follows it, so
+        // only a location the browser should navigate to gets there
+        const redirectUrl = info?.location
+          ? parseRedirectUrl(info.location, targetUrl)
+          : undefined;
+        if (redirectUrl) {
           abortRef.current = null;
-          // a fetch level redirect may leave waku; the browser follows it
-          const url = new URL(info.location, targetUrl);
           if (routerState.history === 'push') {
-            window.location.assign(url.href);
+            window.location.assign(redirectUrl.href);
           } else {
-            window.location.replace(url.href);
+            window.location.replace(redirectUrl.href);
           }
           return;
         }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1206,19 +1206,23 @@ const InnerRouter = ({
         }
         if (!info && e instanceof TypeError) {
           // a probe tells a dead server from a cors blocked redirect
-          const alive = await Promise.race([
-            fetch(targetUrl, {
-              method: 'HEAD',
-              redirect: 'manual',
-              signal: abortController.signal,
-            }).then(
-              () => true,
-              () => false,
-            ),
-            new Promise<boolean>((resolve) => {
-              setTimeout(() => resolve(false), PROBE_TIMEOUT);
-            }),
-          ]);
+          const probeController = new AbortController();
+          abortController.signal.addEventListener('abort', () =>
+            probeController.abort(),
+          );
+          const timer = setTimeout(
+            () => probeController.abort(),
+            PROBE_TIMEOUT,
+          );
+          const alive = await fetch(targetUrl, {
+            method: 'HEAD',
+            redirect: 'manual',
+            signal: probeController.signal,
+          }).then(
+            () => true,
+            () => false,
+          );
+          clearTimeout(timer);
           if (isAborted()) {
             return;
           }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1207,8 +1207,9 @@ const InnerRouter = ({
           }
           return;
         }
-        if (!info && e instanceof TypeError) {
-          // a probe tells a dead server from a cors blocked redirect
+        if (!info) {
+          // no waku error means no usable response; a probe tells a dead
+          // server from a fetch that never reached one
           const probeController = new AbortController();
           abortController.signal.addEventListener('abort', () =>
             probeController.abort(),

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -737,8 +737,6 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOW_HOPS = 20;
 
-const PROBE_TIMEOUT = 3000;
-
 const FollowError = ({
   error,
   has404,
@@ -1206,40 +1204,6 @@ const InnerRouter = ({
             window.location.replace(url.href);
           }
           return;
-        }
-        if (!info) {
-          // no waku error means no usable response; a probe tells a dead
-          // server from a fetch that never reached one
-          const probeController = new AbortController();
-          abortController.signal.addEventListener('abort', () =>
-            probeController.abort(),
-          );
-          const timer = setTimeout(
-            () => probeController.abort(),
-            PROBE_TIMEOUT,
-          );
-          const alive = await fetch(targetUrl, {
-            method: 'HEAD',
-            redirect: 'manual',
-            signal: probeController.signal,
-          }).then(
-            () => true,
-            () => false,
-          );
-          clearTimeout(timer);
-          if (isAborted()) {
-            return;
-          }
-          if (alive) {
-            abortRef.current = null;
-            // the browser retries the url itself and follows any redirect
-            if (navState.history === 'push') {
-              window.location.assign(targetUrl.href);
-            } else {
-              window.location.replace(targetUrl.href);
-            }
-            return;
-          }
         }
         abortRef.current = null;
         // write the url now; an unrecoverable rethrow discards the commit

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -45,22 +45,22 @@ import {
   isStaticFromElements,
 } from './client-utils/elements-meta.js';
 import {
-  NAV_ID,
+  type PrefetchOptions,
+  createPrefetchManager,
+} from './client-utils/prefetch-cache.js';
+import {
+  ROUTER_STATE_ID,
   canCommitInstantly,
   deriveCommitted,
   getRouteUrl,
   isSameRoute,
-  makeNavState,
+  makeRouterState,
   parseRedirectUrl,
   parseRoute,
   pathnameToCurrentRoutePath,
   pinForSwr,
-} from './client-utils/navigate.js';
-import type { NavState } from './client-utils/navigate.js';
-import {
-  type PrefetchOptions,
-  createPrefetchManager,
-} from './client-utils/prefetch-cache.js';
+} from './client-utils/router-state.js';
+import type { RouterState } from './client-utils/router-state.js';
 import type {
   RouteParams,
   RouteSearch,
@@ -215,7 +215,7 @@ const createRouteChangeListeners = (): [
 // This is an internal thing, not a public API
 const RouterContext = createContext<{
   route: RouteProps;
-  nav?: NavState | undefined;
+  routerState?: RouterState | undefined;
   changeRoute: ChangeRoute;
   prefetchRoute: PrefetchRoute;
   routeChangeEvents: Record<
@@ -752,7 +752,7 @@ const FollowError = ({
   countHop: () => number;
   followPromiseMap: WeakMap<object, Promise<unknown>>;
 }) => {
-  const { route, nav, changeRoute } = useRouterOrThrow();
+  const { route, routerState, changeRoute } = useRouterOrThrow();
   const { path: routePath, query: routeQuery } = route;
   const caughtAtRef = useRef<readonly [string, string] | undefined>(undefined);
   if (caughtAtRef.current === undefined) {
@@ -761,10 +761,10 @@ const FollowError = ({
   const dispatchedRef = useRef<readonly [string, string] | undefined>(
     undefined,
   );
-  const navRef = useRef(nav);
+  const routerStateRef = useRef(routerState);
   useEffect(() => {
-    navRef.current = nav;
-  }, [nav]);
+    routerStateRef.current = routerState;
+  }, [routerState]);
   useEffect(() => {
     const [caughtPath, caughtQuery] = caughtAtRef.current!;
     // a route change means the followed slot is committed; safe to reset
@@ -775,8 +775,8 @@ const FollowError = ({
     const dispatched = dispatchedRef.current;
     if (
       dispatched &&
-      nav?.attempted[0] === dispatched[0] &&
-      nav?.attempted[1] === dispatched[1]
+      routerState?.attempted[0] === dispatched[0] &&
+      routerState?.attempted[1] === dispatched[1]
     ) {
       if (dispatched[0] === routePath && dispatched[1] === routeQuery) {
         // the follow bounced back to the rendered route; it can render
@@ -786,12 +786,12 @@ const FollowError = ({
         fail(error, new Error('detected a redirect loop', { cause: error }));
       }
     }
-  }, [routePath, routeQuery, nav, reset, fail, error]);
+  }, [routePath, routeQuery, routerState, reset, fail, error]);
   useEffect(() => {
     const info = getErrorInfo(error);
     // the attempted url may not have reached the address bar yet
-    const attemptedUrl = navRef.current
-      ? new URL(navRef.current.url, window.location.href)
+    const attemptedUrl = routerStateRef.current
+      ? new URL(routerStateRef.current.url, window.location.href)
       : new URL(window.location.href);
     let target: RouteProps;
     let url: URL;
@@ -835,7 +835,7 @@ const FollowError = ({
         error as object,
         changeRoute(target, {
           shouldScroll:
-            navRef.current?.scrollIntent ?? target.path !== caught.path,
+            routerStateRef.current?.scrollIntent ?? target.path !== caught.path,
           history: 'replace',
           url,
         }).then(
@@ -1065,33 +1065,36 @@ const InnerRouter = ({
   }, [initialHash]);
 
   const derived = deriveCommitted(elements, initialRoute);
-  const { nav, url: committedUrl } = derived;
-  const currentRoute = nav
+  const { routerState, url: committedUrl } = derived;
+  const currentRoute = routerState
     ? derived.route
     : { ...derived.route, hash: restoredHash };
   const routeRef = useRef(currentRoute);
-  const reconciledRef = useRef<{ nav: NavState; href: string } | undefined>(
-    undefined,
-  );
+  const reconciledRef = useRef<
+    { routerState: RouterState; href: string } | undefined
+  >(undefined);
   useLayoutEffect(() => {
     routeRef.current = currentRoute;
-    if (!nav || !committedUrl) {
+    if (!routerState || !committedUrl) {
       return;
     }
-    const navChanged = nav !== reconciledRef.current?.nav;
-    if (!navChanged && committedUrl.href === reconciledRef.current?.href) {
+    const stateChanged = routerState !== reconciledRef.current?.routerState;
+    if (!stateChanged && committedUrl.href === reconciledRef.current?.href) {
       return;
     }
-    reconciledRef.current = { nav, href: committedUrl.href };
-    if (nav.history === 'push' && window.location.href !== committedUrl.href) {
-      nav.history = 'replace'; // consumed, so a later commit does not push again
+    reconciledRef.current = { routerState, href: committedUrl.href };
+    if (
+      routerState.history === 'push' &&
+      window.location.href !== committedUrl.href
+    ) {
+      routerState.history = 'replace'; // consumed, so a later commit does not push again
       window.history.pushState(window.history.state, '', committedUrl);
-    } else if (nav.history) {
+    } else if (routerState.history) {
       window.history.replaceState(window.history.state, '', committedUrl);
     }
-    if (nav.scroll) {
-      const scroll = nav.scroll;
-      nav.scroll = null; // consumed, so a later commit does not scroll again
+    if (routerState.scroll) {
+      const scroll = routerState.scroll;
+      routerState.scroll = null; // consumed, so a later commit does not scroll again
       scrollToRoute(
         currentRoute,
         scroll.pathChanged ? 'instant' : 'auto',
@@ -1134,7 +1137,7 @@ const InnerRouter = ({
       emitRouteChangeEvent('start', nextRoute);
       const routeBefore = routeRef.current;
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
-      const navState = makeNavState(nextRoute, targetUrl, {
+      const routerState = makeRouterState(nextRoute, targetUrl, {
         history: options.history,
         scroll: options.shouldScroll,
         pathChanged: nextRoute.path !== routeBefore.path,
@@ -1145,7 +1148,7 @@ const InnerRouter = ({
       if (staticPathSet.has(nextRoute.path) || !shouldRefetch) {
         mergeElements({
           [ROUTE_ID]: [nextRoute.path, nextRoute.query],
-          [NAV_ID]: navState,
+          [ROUTER_STATE_ID]: routerState,
         });
         abortRef.current = null;
         emitRouteChangeEvent('complete', nextRoute);
@@ -1164,8 +1167,8 @@ const InnerRouter = ({
       const dataPromise = refetch(rscPath, createRscParams(nextRoute.query), {
         signal: abortController.signal,
         unstable_overlay: {
-          [NAV_ID]: navState,
-          // instant nav paints from the cache, so route meta comes with it
+          [ROUTER_STATE_ID]: routerState,
+          // instant routerState paints from the cache, so route meta comes with it
           ...(instant ? { [ROUTE_ID]: [nextRoute.path, nextRoute.query] } : {}),
         },
         ...(instant
@@ -1198,7 +1201,7 @@ const InnerRouter = ({
           abortRef.current = null;
           // a fetch level redirect may leave waku; the browser follows it
           const url = new URL(info.location, targetUrl);
-          if (navState.history === 'push') {
+          if (routerState.history === 'push') {
             window.location.assign(url.href);
           } else {
             window.location.replace(url.href);
@@ -1208,15 +1211,15 @@ const InnerRouter = ({
         abortRef.current = null;
         // write the url now; an unrecoverable rethrow discards the commit
         if (window.location.href !== targetUrl.href) {
-          if (navState.history === 'push') {
+          if (routerState.history === 'push') {
             window.history.pushState(window.history.state, '', targetUrl);
           } else {
             window.history.replaceState(window.history.state, '', targetUrl);
           }
         }
         mergeElements({
-          [NAV_ID]: {
-            ...navState,
+          [ROUTER_STATE_ID]: {
+            ...routerState,
             history: null, // the url above is already written
             scroll: null,
             // attempted mirrors routeBefore; the stale ROUTE_ID must not
@@ -1333,7 +1336,7 @@ const InnerRouter = ({
     <RouterContext
       value={{
         route: currentRoute,
-        nav,
+        routerState,
         changeRoute,
         prefetchRoute,
         routeChangeEvents,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -789,7 +789,6 @@ const FollowError = ({
       routerState?.attempted[0] === dispatched[0] &&
       routerState?.attempted[1] === dispatched[1]
     ) {
-      // path only: a 404 renders with the attempted query, not the asked one
       if (dispatched[0] === routePath) {
         reset();
       } else {
@@ -834,7 +833,12 @@ const FollowError = ({
         url = parsed;
       }
     } else if (info?.status === 404 && has404) {
-      target = { path: '/404', query: '', hash: '' };
+      // the same query a direct request would render the 404 page with
+      target = {
+        path: '/404',
+        query: attemptedUrl.searchParams.toString(),
+        hash: '',
+      };
       // the 404 route renders while the url keeps the attempted location
       url = attemptedUrl;
     } else {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -739,6 +739,10 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOW_HOPS = 20;
 
+// a hop that commits a suspense fallback before it throws resets the chain
+// count, so the boundary caps its follows for good as well
+const MAX_TOTAL_FOLLOWS = 100;
+
 const FollowError = ({
   error,
   has404,
@@ -751,7 +755,7 @@ const FollowError = ({
   has404: boolean;
   reset: () => void;
   fail: (original: unknown, error: unknown) => void;
-  countHop: () => number;
+  countHop: () => boolean;
   followPromiseMap: WeakMap<object, Promise<unknown>>;
 }) => {
   const { route, routerState, changeRoute } = useRouterOrThrow();
@@ -838,7 +842,7 @@ const FollowError = ({
       fail(error, new Error('detected a redirect loop', { cause: error }));
       return;
     }
-    if (countHop() > MAX_FOLLOW_HOPS) {
+    if (!countHop()) {
       fail(
         error,
         new Error('too many redirect or 404 follows', { cause: error }),
@@ -878,6 +882,7 @@ class CustomErrorHandler extends Component<
 > {
   private followPromiseMap = new WeakMap<object, Promise<unknown>>();
   private followHops = 0;
+  private totalFollows = 0;
   constructor(props: { has404: boolean; children?: ReactNode }) {
     super(props);
     this.state = { error: null };
@@ -893,12 +898,15 @@ class CustomErrorHandler extends Component<
   }
   countHop() {
     this.followHops += 1;
-    return this.followHops;
+    this.totalFollows += 1;
+    return (
+      this.followHops <= MAX_FOLLOW_HOPS &&
+      this.totalFollows <= MAX_TOTAL_FOLLOWS
+    );
   }
-  // a clean commit settles the chain; a rendering cycle would keep the count
   componentDidUpdate() {
-    // a chain that redirects on every render never commits an error free
-    // state, so this counts its hops; reset() alone would not, because each
+    // a chain that redirects during render never commits an error free state,
+    // so its hops accumulate; reset() alone would not count them, because a
     // hop does change the route
     if (this.state.error === null) {
       this.followHops = 0;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -61,7 +61,7 @@ import {
   getRouterState,
   makeRouterState,
   pinForSwr,
-  resolveCommitted,
+  resolveServerRedirect,
 } from './client-utils/router-state.js';
 import type { RouterState } from './client-utils/router-state.js';
 import type {
@@ -1068,10 +1068,11 @@ const InnerRouter = ({
   }, [initialHash]);
 
   const routerState = getRouterState(elements);
-  const committed =
-    routerState && resolveCommitted(elements, routerState, initialRoute.path);
-  const currentRoute = committed
-    ? committed.route
+  const destination =
+    routerState &&
+    resolveServerRedirect(elements, routerState, initialRoute.path);
+  const currentRoute = destination
+    ? destination.route
     : { ...initialRoute, hash: restoredHash };
   const routeRef = useRef(currentRoute);
   const reconciledRef = useRef<
@@ -1079,23 +1080,20 @@ const InnerRouter = ({
   >(undefined);
   useLayoutEffect(() => {
     routeRef.current = currentRoute;
-    if (!routerState || !committed) {
+    if (!routerState || !destination) {
       return;
     }
-    const committedUrl = committed.url;
+    const { url } = destination;
     const stateChanged = routerState !== reconciledRef.current?.routerState;
-    if (!stateChanged && committedUrl.href === reconciledRef.current?.href) {
+    if (!stateChanged && url.href === reconciledRef.current?.href) {
       return;
     }
-    reconciledRef.current = { routerState, href: committedUrl.href };
-    if (
-      routerState.history === 'push' &&
-      window.location.href !== committedUrl.href
-    ) {
+    reconciledRef.current = { routerState, href: url.href };
+    if (routerState.history === 'push' && window.location.href !== url.href) {
       routerState.history = 'replace'; // consumed, so a later commit does not push again
-      window.history.pushState(window.history.state, '', committedUrl);
+      window.history.pushState(window.history.state, '', url);
     } else if (routerState.history) {
-      window.history.replaceState(window.history.state, '', committedUrl);
+      window.history.replaceState(window.history.state, '', url);
     }
     if (routerState.scroll) {
       const scroll = routerState.scroll;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -49,15 +49,17 @@ import {
   createPrefetchManager,
 } from './client-utils/prefetch-cache.js';
 import {
-  ROUTER_STATE_ID,
-  canCommitInstantly,
   getRouteUrl,
-  getRouterState,
   isSameRoute,
-  makeRouterState,
   parseRedirectUrl,
   parseRoute,
   pathnameToCurrentRoutePath,
+} from './client-utils/route-url.js';
+import {
+  ROUTER_STATE_ID,
+  canCommitInstantly,
+  getRouterState,
+  makeRouterState,
   pinForSwr,
   resolveCommitted,
 } from './client-utils/router-state.js';

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -791,7 +791,9 @@ const FollowError = ({
       routerState?.attempted[0] === dispatched[0] &&
       routerState?.attempted[1] === dispatched[1]
     ) {
-      if (dispatched[0] === routePath && dispatched[1] === routeQuery) {
+      // the path is the only axis to compare: a 404 keeps the attempted
+      // query, so the rendered query is not the one the follow asked for
+      if (dispatched[0] === routePath) {
         // the follow bounced back to the rendered route; it can render
         reset();
       } else {
@@ -1136,7 +1138,11 @@ const InnerRouter = ({
     { routerState: RouterState; href: string; pushed: boolean } | undefined
   >(undefined);
   useLayoutEffect(() => {
-    routeRef.current = currentRoute;
+    if (!routerState?.failed) {
+      // a failed navigation renders the route it came from with the url it
+      // tried; publishing that pair would make a retry look like a no op
+      routeRef.current = currentRoute;
+    }
     if (!routerState || !destination) {
       return;
     }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -109,9 +109,10 @@ type NavigateOptions = {
 
 /**
  * Resolves once the requested navigation has been handled: after its response
- * when the route needs one, right away when it does not. It does not wait for
- * a redirect or 404 follow that starts afterwards, nor for React to finish
- * rendering the destination.
+ * when the route needs one, right away when it does not, and when a newer
+ * navigation supersedes it. It does not wait for a redirect or 404 follow that
+ * starts afterwards, nor for React to render the destination, so the address
+ * bar may still show the previous url.
  */
 type Navigate = {
   (to: RouteHref, options?: NavigateOptions): Promise<void>;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1158,7 +1158,7 @@ const InnerRouter = ({
       }
     }
     reconciledRef.current = { routerState, href: url.href, pushed };
-    if (routerState.scroll && !reconciled) {
+    if (routerState.scroll && !reconciled && !routerState.failed) {
       const { pathChanged } = routerState.scroll;
       scrollToRoute(
         currentRoute,
@@ -1304,7 +1304,6 @@ const InnerRouter = ({
           [ROUTER_STATE_ID]: {
             ...routerState,
             history: null, // the url above is already written
-            scroll: null,
             failed: true,
           },
         });

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -51,7 +51,6 @@ import {
 import {
   ROUTER_STATE_ID,
   canCommitInstantly,
-  getCommitted,
   getRouteUrl,
   getRouterState,
   isSameRoute,
@@ -60,6 +59,7 @@ import {
   parseRoute,
   pathnameToCurrentRoutePath,
   pinForSwr,
+  resolveCommitted,
 } from './client-utils/router-state.js';
 import type { RouterState } from './client-utils/router-state.js';
 import type {
@@ -1065,7 +1065,9 @@ const InnerRouter = ({
     setRestoredHash(window.location.hash || initialHash);
   }, [initialHash]);
 
-  const committed = getCommitted(elements, initialRoute.path);
+  const routerState = getRouterState(elements);
+  const committed =
+    routerState && resolveCommitted(elements, routerState, initialRoute.path);
   const currentRoute = committed
     ? committed.route
     : { ...initialRoute, hash: restoredHash };
@@ -1075,10 +1077,10 @@ const InnerRouter = ({
   >(undefined);
   useLayoutEffect(() => {
     routeRef.current = currentRoute;
-    if (!committed) {
+    if (!routerState || !committed) {
       return;
     }
-    const { routerState, url: committedUrl } = committed;
+    const committedUrl = committed.url;
     const stateChanged = routerState !== reconciledRef.current?.routerState;
     if (!stateChanged && committedUrl.href === reconciledRef.current?.href) {
       return;
@@ -1340,7 +1342,7 @@ const InnerRouter = ({
     <RouterContext
       value={{
         route: currentRoute,
-        routerState: getRouterState(elements),
+        routerState,
         changeRoute,
         prefetchRoute,
         routeChangeEvents,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -852,6 +852,16 @@ const FollowError = ({
       fail(error, new Error('detected a redirect loop', { cause: error }));
       return;
     }
+    const dispatchedBefore = dispatchedRef.current;
+    if (
+      dispatchedBefore &&
+      dispatchedBefore[0] === target.path &&
+      dispatchedBefore[1] === target.query
+    ) {
+      // the target this error already went to failed as well
+      fail(error, new Error('the follow target failed too', { cause: error }));
+      return;
+    }
     if (!countHop()) {
       fail(
         error,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1176,10 +1176,11 @@ const InnerRouter = ({
         staticPathSet.clear();
         const route = routeRef.current;
         startTransition(() => {
+          // the reload clears the set, so the response has to teach it again
           void refetch(
             encodeRoutePath(route.path),
             createRscParams(route.query),
-          );
+          ).then(learnStaticPath, () => {});
         });
       };
       upsertRscReloadListener(
@@ -1187,7 +1188,7 @@ const InnerRouter = ({
         refetchRouteOnHmr,
       );
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
-    }, [refetch, prefetchManager, staticPathSet]);
+    }, [refetch, prefetchManager, staticPathSet, learnStaticPath]);
   }
 
   const [[routeChangeEvents, emitRouteChangeEvent]] = useState(

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1208,6 +1208,10 @@ const InnerRouter = ({
       abortRef.current = abortController;
       const isAborted = () => abortController.signal.aborted;
       emitRouteChangeEvent('start', nextRoute);
+      // a start listener can navigate synchronously, which aborts this one
+      if (isAborted()) {
+        return;
+      }
       if (!options.follow) {
         followBudget.spent = 0; // a navigation of its own starts a fresh budget
       }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -51,8 +51,9 @@ import {
 import {
   ROUTER_STATE_ID,
   canCommitInstantly,
-  getCommittedRoute,
+  getCommitted,
   getRouteUrl,
+  getRouterState,
   isSameRoute,
   makeRouterState,
   parseRedirectUrl,
@@ -1064,7 +1065,7 @@ const InnerRouter = ({
     setRestoredHash(window.location.hash || initialHash);
   }, [initialHash]);
 
-  const committed = getCommittedRoute(elements, initialRoute.path);
+  const committed = getCommitted(elements, initialRoute.path);
   const currentRoute = committed
     ? committed.route
     : { ...initialRoute, hash: restoredHash };
@@ -1339,7 +1340,7 @@ const InnerRouter = ({
     <RouterContext
       value={{
         route: currentRoute,
-        routerState: committed?.routerState,
+        routerState: getRouterState(elements),
         changeRoute,
         prefetchRoute,
         routeChangeEvents,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1094,11 +1094,15 @@ const InnerRouter = ({
       return;
     }
     reconciledRef.current = { routerState, href: url.href };
-    if (routerState.history === 'push' && window.location.href !== url.href) {
-      routerState.history = 'replace'; // consumed, so a later commit does not push again
-      window.history.pushState(window.history.state, '', url);
-    } else if (routerState.history) {
-      window.history.replaceState(window.history.state, '', url);
+    // the state carries the url that should show, so a null history still
+    // writes when the destination moved away from it
+    if (window.location.href !== url.href) {
+      if (routerState.history === 'push') {
+        routerState.history = 'replace'; // consumed, so a later commit does not push again
+        window.history.pushState(window.history.state, '', url);
+      } else {
+        window.history.replaceState(window.history.state, '', url);
+      }
     }
     if (routerState.scroll) {
       const scroll = routerState.scroll;
@@ -1271,12 +1275,13 @@ const InnerRouter = ({
         return;
       }
       const route = { path, query, hash: '' };
+      const is404 = path === '/404';
       await dispatchChangeRoute(changeRoute, route, {
         refetch: false,
         shouldScroll: false,
         // the 404 route renders where the user already is
-        history: path === '/404' ? null : 'push',
-        url: getRouteUrl(route),
+        history: is404 ? null : 'push',
+        url: is404 ? new URL(window.location.href) : getRouteUrl(route),
       });
     },
     [changeRoute],
@@ -1313,7 +1318,8 @@ const InnerRouter = ({
 
   useEffect(() => {
     const callback = () => {
-      const nextRoute = routeInterceptor(parseRouteFromLocation());
+      const popped = parseRouteFromLocation();
+      const nextRoute = routeInterceptor(popped);
       if (!nextRoute) {
         return;
       }
@@ -1321,6 +1327,10 @@ const InnerRouter = ({
         changeRoute(nextRoute, {
           shouldScroll: shouldScrollForRouteChange(nextRoute, routeRef.current),
           history: null, // the browser already moved the address bar
+          // keep the url it moved to; an interceptor rewrite needs a new one
+          url: isSameRoute(nextRoute, popped)
+            ? new URL(window.location.href)
+            : getRouteUrl(nextRoute),
         }).catch((err) => {
           console.log('Error while navigating back:', err);
         });

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -108,9 +108,10 @@ type NavigateOptions = {
 };
 
 /**
- * Resolves once the response for the requested route has been handled. It does
- * not wait for a redirect or 404 follow that starts afterwards, nor for React
- * to finish rendering the destination.
+ * Resolves once the requested navigation has been handled: after its response
+ * when the route needs one, right away when it does not. It does not wait for
+ * a redirect or 404 follow that starts afterwards, nor for React to finish
+ * rendering the destination.
  */
 type Navigate = {
   (to: RouteHref, options?: NavigateOptions): Promise<void>;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -83,6 +83,7 @@ import {
   encodeSliceId,
   getRouteSlotId,
   getSliceSlotId,
+  pathnameToRoutePath,
 } from './isomorphic-utils/route-path.js';
 import type { RouteProps } from './isomorphic-utils/route-path.js';
 import {
@@ -806,8 +807,18 @@ const FollowError = ({
         window.location.replace(parsed.href);
         return;
       }
-      target = parseRoute(parsed);
-      url = parsed;
+      if (info.location.startsWith('/')) {
+        // an app location has no base path; the browser url gets it back
+        target = {
+          path: pathnameToRoutePath(parsed.pathname),
+          query: parsed.searchParams.toString(),
+          hash: parsed.hash,
+        };
+        url = getRouteUrl(target);
+      } else {
+        target = parseRoute(parsed);
+        url = parsed;
+      }
     } else if (info?.status === 404 && has404) {
       target = { path: '/404', query: '', hash: '' };
       // the 404 route renders while the url keeps the attempted location

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -136,14 +136,8 @@ const shouldScrollByDefault = (url: URL) =>
     pathnameToCurrentRoutePath(window.location.pathname) ||
   url.hash !== window.location.hash;
 
-const isPathChange = (next: RouteProps, prev: RouteProps) =>
-  next.path !== prev.path;
-
-const isHashChange = (next: RouteProps, prev: RouteProps) =>
-  next.hash !== prev.hash;
-
 const shouldScrollForRouteChange = (next: RouteProps, prev: RouteProps) =>
-  isPathChange(next, prev) || isHashChange(next, prev);
+  next.path !== prev.path || next.hash !== prev.hash;
 
 const isAltClick = (event: MouseEvent<HTMLAnchorElement>) =>
   event.button !== 0 ||

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1106,7 +1106,7 @@ const InnerRouter = ({
   if (import.meta.hot) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
-      const refetchRoute = () => {
+      const refetchRouteOnHmr = () => {
         prefetchManager.clear();
         staticPathSet.clear();
         const route = routeRef.current;
@@ -1117,8 +1117,11 @@ const InnerRouter = ({
           );
         });
       };
-      upsertRscReloadListener(globalThis.__WAKU_REFETCH_ROUTE__, refetchRoute);
-      globalThis.__WAKU_REFETCH_ROUTE__ = refetchRoute;
+      upsertRscReloadListener(
+        globalThis.__WAKU_REFETCH_ROUTE__,
+        refetchRouteOnHmr,
+      );
+      globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
     }, [refetch, prefetchManager, staticPathSet]);
   }
 

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1291,7 +1291,12 @@ const InnerRouter = ({
           : undefined;
         if (redirectUrl) {
           abortRef.current = null;
-          if (routerState.history === 'push') {
+          // an instant commit already pushed the attempted url, so pushing
+          // again would cost the navigation a second entry
+          if (
+            routerState.history === 'push' &&
+            window.location.href !== targetUrl.href
+          ) {
             window.location.assign(redirectUrl.href);
           } else {
             window.location.replace(redirectUrl.href);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -249,8 +249,7 @@ const dispatchChangeRoute = (
     // instant paints from the cache; a transition would hold that back
     return changeRoute(route, options).then(() => undefined);
   }
-  // a transition, so the eager elements merge suspends without blanking the
-  // tree, and it stays pending until the navigation settles
+  // a transition keeps the tree up while the eager merge suspends
   return new Promise<void>((resolve, reject) => {
     startTransitionFn(async () => {
       try {
@@ -742,8 +741,7 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOW_HOPS = 20;
 
-// a hop that commits a suspense fallback before it throws resets the chain
-// count, so the follows one navigation may spend are capped as well
+// followHops resets when a hop commits, so it alone cannot bound a chain
 const MAX_FOLLOWS_PER_NAVIGATION = 100;
 
 type FollowBudget = { spent: number };
@@ -791,13 +789,10 @@ const FollowError = ({
       routerState?.attempted[0] === dispatched[0] &&
       routerState?.attempted[1] === dispatched[1]
     ) {
-      // the path is the only axis to compare: a 404 keeps the attempted
-      // query, so the rendered query is not the one the follow asked for
+      // path only: a 404 renders with the attempted query, not the asked one
       if (dispatched[0] === routePath) {
-        // the follow bounced back to the rendered route; it can render
         reset();
       } else {
-        // the followed navigation committed without moving the route: a loop
         fail(error, new Error('detected a redirect loop', { cause: error }));
       }
     }
@@ -813,8 +808,6 @@ const FollowError = ({
     if (info?.location) {
       const parsed = parseRedirectUrl(info.location, attemptedUrl);
       if (!parsed) {
-        // a plain error carries no location, so the boundary stops following
-        // it and shows it instead of a blank slot
         fail(
           error,
           new Error(`cannot follow a redirect to ${info.location}`, {
@@ -850,13 +843,11 @@ const FollowError = ({
     if (followPromiseMap.has(error as object)) {
       return;
     }
-    // redirecting back to the route the error came from cannot recover
     const caught = parseRoute(attemptedUrl);
     if (isSameRoute(target, caught)) {
       fail(error, new Error('detected a redirect loop', { cause: error }));
       return;
     }
-    // a target that already failed cannot be the way out of this error
     if (
       failedTargetRef.current &&
       isSameRoute(target, failedTargetRef.current)
@@ -884,8 +875,7 @@ const FollowError = ({
           follow: true,
         }).then(
           (followable) => {
-            // the same error object can be thrown again, by a module scoped
-            // error or one revived from the record, and must follow again
+            // a module scoped error is thrown again, so let it follow again
             followPromiseMap.delete(error as object);
             if (followable !== undefined) {
               failedTargetRef.current = target;
@@ -937,13 +927,12 @@ class CustomErrorHandler extends Component<
     );
   }
   componentDidUpdate() {
-    // a chain that redirects during render never commits an error free state,
-    // so its hops accumulate; reset() alone would not count them, because a
-    // hop does change the route
+    // clearing in reset() would let a chain that redirects on render run free
     if (this.state.error === null) {
       this.followHops = 0;
     }
   }
+  // error is a wrapper: the original still carries a location and would follow
   fail(original: unknown, error: unknown) {
     this.setState((state) => (state.error === original ? { error } : null));
   }
@@ -1090,11 +1079,9 @@ const InnerRouter = ({
   const initialHash = useRef(resolvedRoute.hash).current;
   const initialRoute = useRef({ ...resolvedRoute, hash: '' }).current;
 
-  // meta keys persist across merges, so they read from the current elements
   const has404 = has404FromElements(elements);
   const staticPathSet = useRef(new Set<string>()).current;
-  // only a response tells a route's staticness; a record mid navigation pairs
-  // the target route id with the previous route's pinned flag
+  // a record mid navigation pairs the new route id with the old static flag
   const learnStaticPath = useCallback(
     (responseElements: Record<string, unknown>) => {
       const route = getRouteFromElements(responseElements);
@@ -1117,8 +1104,7 @@ const InnerRouter = ({
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
   const [err, setErr] = useState<unknown>(null);
-  // the hash appears after hydration; an empty one bails out, leaving
-  // hydrating suspense boundaries undisturbed
+  // starts empty so hydration matches the server, then the effect fills it
   const [restoredHash, setRestoredHash] = useState('');
   useEffect(() => {
     setRestoredHash(window.location.hash || initialHash);
@@ -1132,8 +1118,7 @@ const InnerRouter = ({
     ? destination.route
     : { ...initialRoute, hash: restoredHash };
   const routeRef = useRef(currentRoute);
-  // what the last reconcile did; a state reconciles again when its destination
-  // moves, so the push and the scroll must not repeat
+  // what the last reconcile did, so a second pass does not repeat it
   const reconciledRef = useRef<
     { routerState: RouterState; href: string; pushed: boolean } | undefined
   >(undefined);
@@ -1155,8 +1140,7 @@ const InnerRouter = ({
       return;
     }
     let pushed = reconciled?.pushed ?? false;
-    // the state carries the url that should show, so a null history still
-    // writes when the destination moved away from it
+    // history null still writes: the state's url is the one that should show
     if (window.location.href !== url.href) {
       if (routerState.history === 'push' && !pushed) {
         pushed = true;
@@ -1251,9 +1235,7 @@ const InnerRouter = ({
         signal: abortController.signal,
         unstable_overlay: {
           [ROUTER_STATE_ID]: routerState,
-          // instant nav paints from the cache, so route meta comes with it.
-          // meta is pinned, and only an overlay key is refreshed from the
-          // response, so both keys have to ride here to avoid going stale
+          // meta is pinned, so an instant nav has to carry it or it goes stale
           ...(instant
             ? {
                 [ROUTE_ID]: [nextRoute.path, nextRoute.query],
@@ -1290,8 +1272,7 @@ const InnerRouter = ({
           return;
         }
         const info = getErrorInfo(e);
-        // a fetch level redirect may leave waku; the browser follows it, so
-        // only a location the browser should navigate to gets there
+        // a fetch level redirect may leave waku, so the browser takes it on
         const redirectUrl = info?.location
           ? parseRedirectUrl(info.location, targetUrl)
           : undefined;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -240,16 +240,19 @@ const dispatchChangeRoute = (
   changeRoute: ChangeRoute,
   route: RouteProps,
   options: ChangeRouteOptions,
+  startTransitionFn: (fn: TransitionFunction) => void = startTransition,
 ): Promise<void> => {
   if (options.instant) {
     // instant paints from the cache; a transition would hold that back
     return changeRoute(route, options).then(() => undefined);
   }
-  // a transition, so the eager elements merge suspends without blanking the tree
+  // a transition, so the eager elements merge suspends without blanking the
+  // tree, and it stays pending until the navigation settles
   return new Promise<void>((resolve, reject) => {
-    startTransition(() => {
+    startTransitionFn(async () => {
       try {
-        changeRoute(route, options).then(() => resolve(), reject);
+        await changeRoute(route, options);
+        resolve();
       } catch (e) {
         reject(e);
       }
@@ -283,35 +286,35 @@ export function useRouter() {
   const router = useRouterOrThrow();
   const { route, changeRoute, prefetchRoute } = router;
   const resolveCodec = useResolveSearchCodec();
-  const push = useCallback(
-    async (
+  const navigate = useCallback(
+    (
+      history: 'push' | 'replace',
       to: RouteHref | BuildRouteHrefTarget<RoutePath>,
       options?: NavigateOptions,
     ) => {
       const url = resolveRouteUrl(to, resolveCodec);
-      await dispatchChangeRoute(changeRoute, parseRoute(url), {
+      return dispatchChangeRoute(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
-        history: 'push',
+        history,
         url,
         instant: options?.unstable_instant,
       });
     },
     [changeRoute, resolveCodec],
+  );
+  const push = useCallback(
+    (
+      to: RouteHref | BuildRouteHrefTarget<RoutePath>,
+      options?: NavigateOptions,
+    ) => navigate('push', to, options),
+    [navigate],
   ) as Navigate;
   const replace = useCallback(
-    async (
+    (
       to: RouteHref | BuildRouteHrefTarget<RoutePath>,
       options?: NavigateOptions,
-    ) => {
-      const url = resolveRouteUrl(to, resolveCodec);
-      await dispatchChangeRoute(changeRoute, parseRoute(url), {
-        shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
-        history: 'replace',
-        url,
-        instant: options?.unstable_instant,
-      });
-    },
-    [changeRoute, resolveCodec],
+    ) => navigate('replace', to, options),
+    [navigate],
   ) as Navigate;
   const reload = useCallback(async () => {
     await dispatchChangeRoute(changeRoute, parseRouteFromLocation(), {
@@ -625,22 +628,18 @@ export function Link<Path extends RoutePath>({
     if (url.href !== window.location.href) {
       const route = parseRoute(url);
       preloadRouteModules(route.path);
-      if (unstable_instant) {
-        changeRoute(route, {
+      // a click has no caller to reject to; the boundary shows the failure
+      dispatchChangeRoute(
+        changeRoute,
+        route,
+        {
           shouldScroll: scroll ?? shouldScrollByDefault(url),
           history: 'push',
           url,
-          instant: true,
-        }).catch(() => {});
-      } else {
-        startTransitionFn(async () => {
-          await changeRoute(route, {
-            shouldScroll: scroll ?? shouldScrollByDefault(url),
-            history: 'push',
-            url,
-          });
-        });
-      }
+          instant: unstable_instant,
+        },
+        startTransitionFn,
+      ).catch(() => {});
     } else if (url.hash && scroll !== false) {
       scrollToRoute(parseRoute(url), 'auto', false);
     }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -107,6 +107,11 @@ type NavigateOptions = {
   unstable_instant?: boolean;
 };
 
+/**
+ * Resolves once the response for the requested route has been handled. It does
+ * not wait for a redirect or 404 follow that starts afterwards, nor for React
+ * to finish rendering the destination.
+ */
 type Navigate = {
   (to: RouteHref, options?: NavigateOptions): Promise<void>;
   <Path extends RoutePath>(

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -772,6 +772,7 @@ const FollowError = ({
   const dispatchedRef = useRef<readonly [string, string] | undefined>(
     undefined,
   );
+  const failedTargetRef = useRef<RouteProps | undefined>(undefined);
   const routerStateRef = useRef(routerState);
   useEffect(() => {
     routerStateRef.current = routerState;
@@ -853,13 +854,11 @@ const FollowError = ({
       fail(error, new Error('detected a redirect loop', { cause: error }));
       return;
     }
-    const dispatchedBefore = dispatchedRef.current;
+    // a target that already failed cannot be the way out of this error
     if (
-      dispatchedBefore &&
-      dispatchedBefore[0] === target.path &&
-      dispatchedBefore[1] === target.query
+      failedTargetRef.current &&
+      isSameRoute(target, failedTargetRef.current)
     ) {
-      // the target this error already went to failed as well
       fail(error, new Error('the follow target failed too', { cause: error }));
       return;
     }
@@ -887,11 +886,13 @@ const FollowError = ({
             // error or one revived from the record, and must follow again
             followPromiseMap.delete(error as object);
             if (followable !== undefined) {
+              failedTargetRef.current = target;
               fail(error, followable);
             }
           },
           (err) => {
             followPromiseMap.delete(error as object);
+            failedTargetRef.current = target;
             fail(error, err);
           },
         ),

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1289,11 +1289,13 @@ const InnerRouter = ({
         return;
       }
       const route = { path, query, hash: '' };
+      const is404 = path === '/404';
       await changeRouteInTransition(changeRoute, route, {
         refetch: false,
         shouldScroll: false,
-        push: path !== '/404',
-        url: getRouteUrl(route),
+        push: !is404,
+        // the 404 route keeps the url the user is on
+        url: is404 ? new URL(window.location.href) : getRouteUrl(route),
       });
     },
     [changeRoute],

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -221,6 +221,7 @@ const RouterContext = createContext<{
     'on' | 'off',
     (event: ChangeRouteEvent, handler: ChangeRouteCallback) => void
   >;
+  fetchingSlices: Set<SliceId>;
 } | null>(null);
 
 const SearchCodecsContext = createContext<ReadonlyMap<string, AnyCodec>>(
@@ -975,17 +976,6 @@ const preloadRouteModules = (path: string) => {
   });
 };
 
-// in flight slice fetches; the refetch identity scopes them per Root
-const fetchingSlicesMap = new WeakMap<object, Set<SliceId>>();
-const getFetchingSlices = (refetch: object): Set<SliceId> => {
-  let set = fetchingSlicesMap.get(refetch);
-  if (!set) {
-    set = new Set();
-    fetchingSlicesMap.set(refetch, set);
-  }
-  return set;
-};
-
 export function Slice({
   id,
   children,
@@ -1002,6 +992,7 @@ export function Slice({
       fallback: ReactNode;
     }
 )) {
+  const { fetchingSlices } = useRouterOrThrow();
   const refetch = useRefetch();
   const slotId = getSliceSlotId(id);
   const elementsPromise = useElementsPromise();
@@ -1010,7 +1001,6 @@ export function Slice({
     props.lazy &&
     (!(slotId in elements) || !isImmutableElement(elements, slotId));
   useEffect(() => {
-    const fetchingSlices = getFetchingSlices(refetch);
     if (needsToFetchSlice && !fetchingSlices.has(id)) {
       fetchingSlices.add(id);
       const rscPath = encodeSliceId(id);
@@ -1022,7 +1012,7 @@ export function Slice({
           fetchingSlices.delete(id);
         });
     }
-  }, [refetch, id, needsToFetchSlice]);
+  }, [fetchingSlices, refetch, id, needsToFetchSlice]);
   if (props.lazy && !(slotId in elements)) {
     // FIXME the fallback doesn't show on refetch after the first one.
     return props.fallback;
@@ -1206,6 +1196,8 @@ const InnerRouter = ({
     createRouteChangeListeners,
   );
 
+  // FIXME this "fetchingSlices" hack feels suboptimal.
+  const fetchingSlices = useRef(new Set<SliceId>()).current;
   const followBudget = useRef<FollowBudget>({ spent: 0 }).current;
   const abortRef = useRef<AbortController | null>(null);
 
@@ -1444,6 +1436,7 @@ const InnerRouter = ({
         routerState,
         changeRoute,
         prefetchRoute,
+        fetchingSlices,
         routeChangeEvents,
       }}
     >
@@ -1494,6 +1487,7 @@ export function INTERNAL_ServerRouter({ route }: { route: RouteProps }) {
           changeRoute: notAvailableInServer('changeRoute'),
           prefetchRoute: notAvailableInServer('prefetchRoute'),
           routeChangeEvents: MOCK_ROUTE_CHANGE_LISTENER,
+          fetchingSlices: new Set<SliceId>(),
         }}
       >
         {rootElement}

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -67,7 +67,7 @@ export const createRequestHandler = ({
       };
 
       // html has to carry every slot, so a client etag must not omit one
-      const clientEtags = input.type === 'http' ? {} : (input.etags ?? {});
+      const clientEtags = (input.type !== 'http' && input.etags) || {};
       const withRerender = async <T,>(fn: () => Promise<T>) => {
         let entriesPromise: Promise<RouteEntries> = Promise.resolve({
           elements: {},

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -234,7 +234,8 @@ export const createRequestHandler = ({
           }
         }
         if (configRegistry.has404()) {
-          return renderPage('/404', '', 404);
+          // the 404 page renders for the url that was asked for, query and all
+          return renderPage('/404', query, 404);
         } else {
           return null;
         }

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -66,7 +66,8 @@ export const createRequestHandler = ({
         return cachedPath2moduleIds!;
       };
 
-      const clientEtags = input.etags ?? {};
+      // html has to carry every slot, so a client etag must not omit one
+      const clientEtags = input.type === 'http' ? {} : (input.etags ?? {});
       const withRerender = async <T,>(fn: () => Promise<T>) => {
         let entriesPromise: Promise<RouteEntries> = Promise.resolve({
           elements: {},

--- a/packages/waku/tests/define-router-etag.test.ts
+++ b/packages/waku/tests/define-router-etag.test.ts
@@ -100,6 +100,32 @@ const getEntriesWithEtagsHeader = (
 ): Promise<Record<string, unknown>> =>
   drive(router, parseClientEtags(etagsHeader));
 
+// Same as `drive`, but for a page request: an html render must carry every
+// slot, so the etags a client sends along have to be ignored.
+const driveHtml = async (
+  router: ReturnType<typeof unstable_defineRouter>,
+  etags: Etags,
+): Promise<Record<string, unknown>> => {
+  let captured: Record<string, unknown> = {};
+  await router.handleRequest(
+    {
+      type: 'http',
+      pathname: '/foo',
+      req: new Request('http://localhost/foo'),
+      etags,
+    },
+    {
+      renderRsc: vi.fn(async (elements: Record<string, unknown>) => {
+        captured = { ...elements };
+        return makeStream();
+      }),
+      renderHtml: vi.fn(async () => new Response('ok')),
+      loadBuildMetadata: vi.fn(),
+    },
+  );
+  return captured;
+};
+
 const etagKey = (slotId: string) => `${ETAG_ID_PREFIX}${slotId}`;
 
 describe('define-router etags (per-slot omit)', () => {
@@ -129,6 +155,19 @@ describe('define-router etags (per-slot omit)', () => {
     const entries = await getEntries(router, { page: 'v1' });
     expect('page' in entries).toBe(false);
     expect(etagKey('page') in entries).toBe(false);
+  });
+
+  it('keeps a slot in html even when the client etag matches', async () => {
+    const router = buildRouter({
+      page: {
+        isStatic: false,
+        renderer: () => createElement('div', null, 'page'),
+        getEtagFromOption: async () => 'v1',
+      },
+    });
+
+    const entries = await driveHtml(router, { page: 'v1' });
+    expect('page' in entries).toBe(true);
   });
 
   it('re-sends a dynamic slot with the new etag when it changed', async () => {

--- a/packages/waku/tests/define-router-request-handler.test.ts
+++ b/packages/waku/tests/define-router-request-handler.test.ts
@@ -163,6 +163,27 @@ describe('request dispatch', () => {
     expect(apiContext).toEqual({ params: { slug: 'hello' } });
   });
 
+  it('renders the 404 route with the query that was asked for', async () => {
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [dynamicRoute('/404')],
+    });
+    const utils = makeUtils();
+    await handleRequest(
+      {
+        type: 'http',
+        pathname: '/nowhere',
+        req: new Request('http://localhost/nowhere?foo=bar'),
+      },
+      utils,
+    );
+    // a client side 404 keeps the attempted query, so a direct load must too
+    const elements = utils.renderRsc.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(elements?.ROUTE).toEqual(['/404', 'foo=bar']);
+  });
+
   it('renders the 404 route for an unknown http page', async () => {
     const { handleRequest } = unstable_defineRouter({
       getConfigs: async () => [dynamicRoute('/404')],

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -330,7 +330,7 @@ describe('minimal/client eager merge', () => {
     mocks.createFromFetch.mockReturnValueOnce(
       resolvedThenable({ dynamic: 'D2', extra: 'X' }),
     );
-    const unstable_isEager = (key: string) => key === 'cached';
+    const unstable_isEager = (key: string | symbol) => key === 'cached';
     await act(async () => {
       await refetch!('R/next.txt', undefined, {
         unstable_swr: { pin: unstable_isEager },
@@ -432,7 +432,7 @@ describe('minimal/client eager merge', () => {
         resolveB = resolve;
       }),
     );
-    const isSwr = (key: string) => key === 'eager';
+    const isSwr = (key: string | symbol) => key === 'eager';
     await act(async () => {
       void refetch!('R/next.txt', undefined, { unstable_swr: { pin: isSwr } });
     });

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -159,6 +159,39 @@ describe('minimal/client prefetch', () => {
 });
 
 describe('minimal/client transport failures', () => {
+  const redirectedResponse = (url: string) =>
+    ({
+      redirected: true,
+      url,
+      ok: true,
+      status: 200,
+      text: async () => '',
+    }) as unknown as Response;
+
+  test('a redirect within the rsc endpoint is decoded as the payload', async () => {
+    track(
+      unstable_registerFetchEnhancer(
+        () => async () =>
+          redirectedResponse(`${window.location.origin}/RSC/R/exists.txt`),
+      ),
+    );
+
+    await expect(unstable_fetchRsc('R/redirect.txt')).resolves.toBeDefined();
+  });
+
+  test('a redirect to another origin leaves the rsc endpoint', async () => {
+    const url = 'https://login.example/RSC/R/next.txt';
+    track(
+      unstable_registerFetchEnhancer(() => async () => redirectedResponse(url)),
+    );
+
+    const error = await unstable_fetchRsc('R/next.txt').catch(
+      (e: unknown) => e,
+    );
+
+    expect(getErrorInfo(error)).toEqual({ status: 307, location: url });
+  });
+
   test('a network error is marked as such', async () => {
     track(
       unstable_registerFetchEnhancer(() => () => {

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -13,6 +13,7 @@ import {
   test,
   vi,
 } from 'vitest';
+import { getErrorInfo } from '../src/lib/utils/custom-errors.js';
 import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import { fetchRscStore } from '../src/minimal/client-utils/fetch-store.js';
 import {
@@ -154,6 +155,38 @@ describe('minimal/client prefetch', () => {
 
     expect(prefetchFetch).toHaveBeenCalledTimes(1); // only the prefetch request
     expect(actionFetch).toHaveBeenCalledTimes(1); // the server action request
+  });
+});
+
+describe('minimal/client transport failures', () => {
+  test('a request that never got a response is marked as such', async () => {
+    track(
+      unstable_registerFetchEnhancer(() => () => {
+        return Promise.reject(new TypeError('Failed to fetch'));
+      }),
+    );
+
+    const error = await unstable_fetchRsc('R/next.txt').catch(
+      (e: unknown) => e,
+    );
+
+    expect(getErrorInfo(error)).toEqual({ noResponse: true });
+    expect((error as Error).message).toBe('Failed to fetch');
+  });
+
+  test('an aborted request passes through untouched', async () => {
+    track(
+      unstable_registerFetchEnhancer(() => () => {
+        return Promise.reject(new DOMException('Aborted', 'AbortError'));
+      }),
+    );
+
+    const error = await unstable_fetchRsc('R/next.txt').catch(
+      (e: unknown) => e,
+    );
+
+    expect((error as Error).name).toBe('AbortError');
+    expect(getErrorInfo(error)).toBeNull();
   });
 });
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -179,6 +179,19 @@ describe('minimal/client transport failures', () => {
     await expect(unstable_fetchRsc('R/redirect.txt')).resolves.toBeDefined();
   });
 
+  test('a redirect off the rsc endpoint leaves it, same origin or not', async () => {
+    const url = `${window.location.origin}/login`;
+    track(
+      unstable_registerFetchEnhancer(() => async () => redirectedResponse(url)),
+    );
+
+    const error = await unstable_fetchRsc('R/next.txt').catch(
+      (e: unknown) => e,
+    );
+
+    expect(getErrorInfo(error)).toEqual({ status: 307, location: url });
+  });
+
   test('a redirect to another origin leaves the rsc endpoint', async () => {
     const url = 'https://login.example/RSC/R/next.txt';
     track(
@@ -583,6 +596,82 @@ describe('minimal/client eager merge', () => {
     expect(finalElements.hole).toBe(holeThenable);
     expect(finalElements.eager).toBe('A1');
     await expect(finalElements.hole).resolves.toBe('H2');
+
+    act(() => root.unmount());
+  });
+
+  test('an overlay lands with the response it came with', async () => {
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ _value: null, page: 'A' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Probe />
+        </Root>,
+      );
+    });
+
+    mocks.createFromFetch.mockReturnValueOnce(resolvedThenable({ page: 'B' }));
+    await act(async () => {
+      await refetch!('R/next.txt', undefined, {
+        unstable_overlay: { nav: 'from the client' },
+      });
+    });
+
+    const merged = await elementsPromise!;
+    expect(merged.page).toBe('B');
+    expect(merged.nav).toBe('from the client');
+
+    act(() => root.unmount());
+  });
+
+  test('an overlay is dropped when the response fails', async () => {
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({ _value: null, page: 'A' }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Probe />
+        </Root>,
+      );
+    });
+
+    mocks.createFromFetch.mockRejectedValueOnce(new Error('rejected'));
+    await act(async () => {
+      await refetch!('R/next.txt', undefined, {
+        unstable_overlay: { nav: 'from the client' },
+      }).catch(() => {});
+    });
+
+    const merged = await elementsPromise!;
+    expect(merged.page).toBe('A');
+    expect('nav' in merged).toBe(false);
 
     act(() => root.unmount());
   });

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -587,6 +587,66 @@ describe('minimal/client eager merge', () => {
     act(() => root.unmount());
   });
 
+  test('an overlay key takes the response value once it lands', async () => {
+    // How the router keeps pinned meta fresh: a pinned key is never refreshed,
+    // so the keys it needs current ride in the overlay instead.
+    mocks.createFromFetch.mockReturnValueOnce(
+      resolvedThenable({
+        _value: null,
+        ROUTE: ['/start', ''],
+        IS_STATIC: false,
+      }),
+    );
+    stubFetch();
+
+    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let elementsPromise: Promise<Record<string, unknown>> | undefined;
+    const Probe = () => {
+      refetch = useRefetch();
+      elementsPromise = useElementsPromise_UNSTABLE();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <Root initialRscPath="R/app.txt">
+          <Probe />
+        </Root>,
+      );
+    });
+
+    let resolveB: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveB = resolve;
+      }),
+    );
+    let refetched: Promise<unknown> | undefined;
+    await act(async () => {
+      refetched = refetch!('R/next.txt', undefined, {
+        unstable_overlay: { ROUTE: ['/next', 'x=1'], IS_STATIC: false },
+        unstable_swr: {
+          pin: (key) => key === 'ROUTE' || key === 'IS_STATIC',
+        },
+      });
+    });
+    // the eager commit paints the overlay
+    expect((await elementsPromise!).ROUTE).toEqual(['/next', 'x=1']);
+
+    await act(async () => {
+      resolveB({ ROUTE: ['/next', ''], IS_STATIC: true });
+      await refetched;
+    });
+
+    const finalElements = await elementsPromise!;
+    expect(finalElements.ROUTE).toEqual(['/next', '']);
+    expect(finalElements.IS_STATIC).toBe(true);
+
+    act(() => root.unmount());
+  });
+
   test('merges new keys even while the previous elements are still streaming', async () => {
     // The response can resolve before the previous elements do. The second
     // commit cannot inspect a pending state synchronously, so it chains on

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -160,10 +160,9 @@ describe('minimal/client prefetch', () => {
 
 describe('minimal/client transport failures', () => {
   test('a request that never got a response is marked as such', async () => {
-    const networkError = new TypeError('Failed to fetch');
     track(
       unstable_registerFetchEnhancer(() => () => {
-        return Promise.reject(networkError);
+        return Promise.reject(new TypeError('Failed to fetch'));
       }),
     );
 
@@ -171,9 +170,8 @@ describe('minimal/client transport failures', () => {
       (e: unknown) => e,
     );
 
-    // the original error is marked, not replaced, so its type and stack survive
-    expect(error).toBe(networkError);
     expect(getErrorInfo(error)).toEqual({ noResponse: true });
+    expect((error as Error).message).toBe('Failed to fetch');
   });
 
   test('an aborted request passes through untouched', async () => {

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -159,7 +159,7 @@ describe('minimal/client prefetch', () => {
 });
 
 describe('minimal/client transport failures', () => {
-  test('a request that never got a response is marked as such', async () => {
+  test('a network error is marked as such', async () => {
     track(
       unstable_registerFetchEnhancer(() => () => {
         return Promise.reject(new TypeError('Failed to fetch'));
@@ -170,23 +170,35 @@ describe('minimal/client transport failures', () => {
       (e: unknown) => e,
     );
 
-    expect(getErrorInfo(error)).toEqual({ noResponse: true });
+    expect(getErrorInfo(error)).toEqual({ unstable_networkError: true });
     expect((error as Error).message).toBe('Failed to fetch');
   });
 
-  test('an aborted request passes through untouched', async () => {
+  test('any other failure passes through untouched', async () => {
+    const unregisterAbort = unstable_registerFetchEnhancer(() => () => {
+      return Promise.reject(new DOMException('Aborted', 'AbortError'));
+    });
+    const aborted = await unstable_fetchRsc('R/next.txt').catch(
+      (e: unknown) => e,
+    );
+    unregisterAbort();
+
+    expect((aborted as Error).name).toBe('AbortError');
+    expect(getErrorInfo(aborted)).toBeNull();
+
+    // an app's own failure (a fetch enhancer, an unserializable argument)
+    // reaches the caller as it is
+    const appError = new Error('could not serialize');
     track(
       unstable_registerFetchEnhancer(() => () => {
-        return Promise.reject(new DOMException('Aborted', 'AbortError'));
+        return Promise.reject(appError);
       }),
     );
-
-    const error = await unstable_fetchRsc('R/next.txt').catch(
+    const thrown = await unstable_fetchRsc('R/other.txt').catch(
       (e: unknown) => e,
     );
 
-    expect((error as Error).name).toBe('AbortError');
-    expect(getErrorInfo(error)).toBeNull();
+    expect(thrown).toBe(appError);
   });
 });
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -160,9 +160,10 @@ describe('minimal/client prefetch', () => {
 
 describe('minimal/client transport failures', () => {
   test('a request that never got a response is marked as such', async () => {
+    const networkError = new TypeError('Failed to fetch');
     track(
       unstable_registerFetchEnhancer(() => () => {
-        return Promise.reject(new TypeError('Failed to fetch'));
+        return Promise.reject(networkError);
       }),
     );
 
@@ -170,8 +171,9 @@ describe('minimal/client transport failures', () => {
       (e: unknown) => e,
     );
 
+    // the original error is marked, not replaced, so its type and stack survive
+    expect(error).toBe(networkError);
     expect(getErrorInfo(error)).toEqual({ noResponse: true });
-    expect((error as Error).message).toBe('Failed to fetch');
   });
 
   test('an aborted request passes through untouched', async () => {

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -165,7 +165,7 @@ describe('minimal/client transport failures', () => {
       url,
       ok: true,
       status: 200,
-      text: async () => '',
+      text: async () => 'the payload',
     }) as unknown as Response;
 
   test('a redirect within the rsc endpoint is decoded as the payload', async () => {
@@ -176,7 +176,10 @@ describe('minimal/client transport failures', () => {
       ),
     );
 
-    await expect(unstable_fetchRsc('R/redirect.txt')).resolves.toBeDefined();
+    // decoded from the response the redirect landed on
+    await expect(unstable_fetchRsc('R/redirect.txt')).resolves.toMatchObject({
+      text: 'the payload',
+    });
   });
 
   test('a redirect off the rsc endpoint leaves it, same origin or not', async () => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3391,6 +3391,7 @@ describe('Router integration', () => {
   }: {
     responses: (
       | { reject: { status: number; location?: string } }
+      | { redirect: { from: string; fromQuery?: string; location: string } }
       | { resolve: Record<string, unknown> }
     )[];
     slots?: string[];
@@ -3398,7 +3399,23 @@ describe('Router integration', () => {
   }) => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     for (const response of responses) {
-      if ('reject' in response) {
+      if ('redirect' in response) {
+        const err = createCustomError('redirect', {
+          status: 307,
+          location: response.redirect.location,
+        });
+        const Thrower = () => {
+          throw err;
+        };
+        refetch.mockResolvedValueOnce({
+          [unstable_getRouteSlotId(response.redirect.from)]: <Thrower />,
+          [ROUTE_ID]: [
+            response.redirect.from,
+            response.redirect.fromQuery ?? '',
+          ],
+          [IS_STATIC_ID]: false,
+        });
+      } else if ('reject' in response) {
         refetch.mockImplementationOnce(() =>
           Promise.reject(createCustomError('follow-error', response.reject)),
         );
@@ -3431,36 +3448,39 @@ describe('Router integration', () => {
     return { view, refetch, capture, router: capture.router };
   };
 
-  test('a navigation follows a redirect error inline', async () => {
+  test('a rejected fetch redirect hard navigates with a new entry', async () => {
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
     const { view, refetch, capture, router } = await renderFollowRouter({
-      responses: [
-        { reject: { status: 307, location: '/next' } },
-        { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
-      ],
-      slots: ['/next'],
+      responses: [{ reject: { status: 307, location: '/next' } }],
     });
     await act(async () => {
       await router.push('/moved').catch(() => {});
       await flush();
       await flush();
     });
-    expect(refetch).toHaveBeenCalledTimes(2);
-    expect(capture.router!.path).toBe('/next');
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    expect(assignSpy.mock.calls[0]![0]).toContain('/next');
+    expect(capture.router!.path).toBe('/start');
+    assignSpy.mockRestore();
     view.unmount();
   });
 
-  test('an instant navigation resolves a relative redirect against the attempted url', async () => {
+  test('a rejected redirect resolves a relative location against the attempted url', async () => {
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
+      .mockImplementation(() => {});
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
-    refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: 'login' }),
-        ),
-      )
-      .mockResolvedValueOnce({
-        [ROUTE_ID]: ['/account/login', ''],
-        [IS_STATIC_ID]: false,
-      });
+    refetch.mockImplementationOnce(() =>
+      Promise.reject(
+        createCustomError('moved', { status: 307, location: 'login' }),
+      ),
+    );
     installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
@@ -3469,74 +3489,6 @@ describe('Router integration', () => {
     const elements = {
       [unstable_getRouteSlotId('/start')]: <Probe />,
       [profileSlotId]: <div>profile</div>,
-      [unstable_getRouteSlotId('/account/login')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-      // mark the attempted route static so the instant branch engages
-      [`${ETAG_ID_PREFIX}${profileSlotId}`]: IMMUTABLE_ETAG,
-    };
-
-    const view = await renderRouter(
-      { initialRoute: { path: '/start', query: '', hash: '' } },
-      elements,
-    );
-    if (!capture.router) {
-      throw new Error('router not initialized');
-    }
-
-    // the rejection can arrive before the history effect writes the
-    // attempted url, so the previous url must not be the base
-    const pushStateSpy = vi
-      .spyOn(window.history, 'pushState')
-      .mockImplementation(() => {});
-    const replaceStateSpy = vi
-      .spyOn(window.history, 'replaceState')
-      .mockImplementation(() => {});
-    try {
-      await act(async () => {
-        await capture
-          .router!.push('/account/profile', {
-            unstable_instant: true,
-          })
-          .catch(() => {});
-        await flush();
-        await flush();
-      });
-    } finally {
-      pushStateSpy.mockRestore();
-      replaceStateSpy.mockRestore();
-    }
-
-    // "login" resolves against /account/profile, not the previous url
-    expect(refetch.mock.calls[1]?.[0]).toBe(
-      unstable_encodeRoutePath('/account/login'),
-    );
-    expect(capture.router.path).toBe('/account/login');
-
-    view.unmount();
-  });
-
-  test('an instant redirect keeps the attempted history entry', async () => {
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
-    refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: 'login' }),
-        ),
-      )
-      .mockResolvedValueOnce({
-        [ROUTE_ID]: ['/account/login', ''],
-        [IS_STATIC_ID]: false,
-      });
-    installRefetch(refetch);
-
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    const profileSlotId = unstable_getRouteSlotId('/account/profile');
-    const elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [profileSlotId]: <div>profile</div>,
-      [unstable_getRouteSlotId('/account/login')]: <Probe />,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
       [`${ETAG_ID_PREFIX}${profileSlotId}`]: IMMUTABLE_ETAG,
@@ -3550,22 +3502,67 @@ describe('Router integration', () => {
       throw new Error('router not initialized');
     }
 
-    const lengthBefore = window.history.length;
     await act(async () => {
       await capture
-        .router!.push('/account/profile', {
-          unstable_instant: true,
-        })
+        .router!.push('/account/profile', { unstable_instant: true })
         .catch(() => {});
       await flush();
       await flush();
     });
 
-    // the attempted entry is pushed, then replaced by the redirect
-    expect(window.location.pathname).toBe('/account/login');
-    expect(window.history.length).toBe(lengthBefore + 1);
-    expect(capture.router.path).toBe('/account/login');
+    // the commit races the rejection, so either write style can happen
+    const calls = [...assignSpy.mock.calls, ...replaceLocationSpy.mock.calls];
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![0]).toContain('/account/login');
 
+    assignSpy.mockRestore();
+    replaceLocationSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a rejected redirect on replace navigates without a new entry', async () => {
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
+      .mockImplementation(() => {});
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch.mockImplementationOnce(() =>
+      Promise.reject(
+        createCustomError('moved', { status: 307, location: 'login' }),
+      ),
+    );
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.replace('/account/profile').catch(() => {});
+      await flush();
+      await flush();
+    });
+
+    expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
+    expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/account/login');
+    expect(assignSpy).not.toHaveBeenCalled();
+
+    assignSpy.mockRestore();
+    replaceLocationSpy.mockRestore();
     view.unmount();
   });
 
@@ -3625,27 +3622,31 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const RedirectErrorObject = createCustomError('moved', {
+      status: 307,
+      location: '/account/profile?login=1',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', {
-            status: 307,
-            location: '/account/profile?login=1',
-          }),
-        ),
-      )
       .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/account/profile')]: <ThrowRedirect />,
+        [ROUTE_ID]: ['/account/profile', ''],
+        [IS_STATIC_ID]: false,
+      })
+      .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/account/profile')]: <Probe />,
         [ROUTE_ID]: ['/account/profile', 'login=1'],
         [IS_STATIC_ID]: false,
       });
     installRefetch(refetch);
 
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
     const elements = {
       [unstable_getRouteSlotId('/start')]: <Probe />,
-      [unstable_getRouteSlotId('/account/profile')]: <Probe />,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
     };
@@ -3662,11 +3663,13 @@ describe('Router integration', () => {
       await capture.router!.push('/account/profile').catch(() => {});
       await flush();
       await flush();
+      await flush();
+      await flush();
     });
 
     // the visible navigation is from /start, so the page scrolls even
     // though the redirect keeps the attempted pathname
-    expect(capture.router.path).toBe('/account/profile');
+    expect(capture.router.query).toBe('login=1');
     expect(scrollToSpy).toHaveBeenCalled();
 
     scrollToSpy.mockRestore();
@@ -3674,21 +3677,28 @@ describe('Router integration', () => {
   });
 
   test('a query-only navigation that redirects writes one history entry', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const RedirectErrorObject = createCustomError('moved', {
+      status: 307,
+      location: '/login',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: '/login' }),
-        ),
-      )
+      .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/products')]: <ThrowRedirect />,
+        [ROUTE_ID]: ['/products', 'page=2'],
+        [IS_STATIC_ID]: false,
+      })
       .mockResolvedValueOnce({
         [ROUTE_ID]: ['/login', ''],
         [IS_STATIC_ID]: false,
       });
     installRefetch(refetch);
 
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
     const elements = {
       [unstable_getRouteSlotId('/products')]: <Probe />,
       [unstable_getRouteSlotId('/login')]: <Probe />,
@@ -3710,6 +3720,8 @@ describe('Router integration', () => {
       await capture.router!.push('/products?page=2').catch(() => {});
       await flush();
       await flush();
+      await flush();
+      await flush();
     });
 
     // the attempted entry is written once, then replaced by the redirect
@@ -3721,14 +3733,21 @@ describe('Router integration', () => {
   });
 
   test('a slow redirect after an instant error writes one attempted entry', async () => {
+    const RedirectErrorObject = createCustomError('moved', {
+      status: 307,
+      location: 'login',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
     let resolveSecond!: (value: Record<string, unknown>) => void;
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: 'login' }),
-        ),
-      )
+      .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/account/profile')]: <ThrowRedirect />,
+        [ROUTE_ID]: ['/account/profile', ''],
+        [IS_STATIC_ID]: false,
+      })
       .mockImplementationOnce(
         () =>
           new Promise((resolve) => {
@@ -3742,7 +3761,7 @@ describe('Router integration', () => {
     const profileSlotId = unstable_getRouteSlotId('/account/profile');
     const elements = {
       [unstable_getRouteSlotId('/start')]: <Probe />,
-      [profileSlotId]: <div>profile</div>,
+      [profileSlotId]: <ThrowRedirect />,
       [unstable_getRouteSlotId('/account/login')]: <Probe />,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
@@ -3790,13 +3809,15 @@ describe('Router integration', () => {
       .mockImplementation(() => {});
     const { view, capture, router } = await renderFollowRouter({
       responses: [
-        { reject: { status: 307, location: '/next' } },
+        { redirect: { from: '/moved', location: '/next' } },
         { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
       ],
       slots: ['/next'],
     });
     await act(async () => {
       await router.push('/moved', { scroll: false }).catch(() => {});
+      await flush();
+      await flush();
       await flush();
       await flush();
     });
@@ -3810,24 +3831,29 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const RedirectErrorObject = createCustomError('moved', {
+      status: 307,
+      location: '/products?page=3',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', {
-            status: 307,
-            location: '/products?page=3',
-          }),
-        ),
-      )
       .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/products')]: <ThrowRedirect />,
+        [ROUTE_ID]: ['/products', 'page=2'],
+        [IS_STATIC_ID]: false,
+      })
+      .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/products')]: <Probe />,
         [ROUTE_ID]: ['/products', 'page=3'],
         [IS_STATIC_ID]: false,
       });
     installRefetch(refetch);
 
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
     const elements = {
       [unstable_getRouteSlotId('/products')]: <Probe />,
       [ROUTE_ID]: ['/products', 'page=1'],
@@ -3849,6 +3875,8 @@ describe('Router integration', () => {
         .catch(() => {});
       await flush();
       await flush();
+      await flush();
+      await flush();
     });
 
     expect(capture.router.query).toBe('page=3');
@@ -3862,13 +3890,20 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
+    const RedirectErrorObject = createCustomError('moved', {
+      status: 307,
+      location: '/next',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: '/next' }),
-        ),
-      )
+      .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/moved')]: <ThrowRedirect />,
+        [ROUTE_ID]: ['/moved', ''],
+        [IS_STATIC_ID]: false,
+      })
       .mockResolvedValueOnce({
         [ROUTE_ID]: ['/next', ''],
         [IS_STATIC_ID]: false,
@@ -3909,6 +3944,8 @@ describe('Router integration', () => {
       );
       await flush();
       await flush();
+      await flush();
+      await flush();
     });
 
     expect(capture.router.path).toBe('/next');
@@ -3924,8 +3961,8 @@ describe('Router integration', () => {
       .mockImplementation(() => {});
     const { view, capture, router } = await renderFollowRouter({
       responses: [
-        { reject: { status: 307, location: '/b' } },
-        { reject: { status: 307, location: '/c' } },
+        { redirect: { from: '/a', location: '/b' } },
+        { redirect: { from: '/b', location: '/c' } },
         { resolve: { [ROUTE_ID]: ['/c', ''], [IS_STATIC_ID]: false } },
       ],
       slots: ['/c'],
@@ -3934,10 +3971,9 @@ describe('Router integration', () => {
     const lengthBefore = window.history.length;
     await act(async () => {
       await router.push('/a', { scroll: false }).catch(() => {});
-      await flush();
-      await flush();
-      await flush();
-      await flush();
+      for (let i = 0; i < 8; i += 1) {
+        await flush();
+      }
     });
     expect(capture.router!.path).toBe('/c');
     expect(window.location.pathname).toBe('/c');
@@ -3948,10 +3984,19 @@ describe('Router integration', () => {
   });
 
   test('a redirect cycle surfaces a redirect loop error', async () => {
+    const RedirectErrorObject = createCustomError('moved', {
+      status: 307,
+      location: '/a',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
-      Promise.reject(
-        createCustomError('moved', { status: 307, location: '/a' }),
-      ),
+      Promise.resolve({
+        [unstable_getRouteSlotId('/a')]: <ThrowRedirect />,
+        [ROUTE_ID]: ['/a', ''],
+        [IS_STATIC_ID]: false,
+      }),
     );
     installRefetch(refetch);
 
@@ -3993,15 +4038,23 @@ describe('Router integration', () => {
   });
 
   test('an endless redirect chain stops at the hop limit', async () => {
-    let hop = 0;
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
-      Promise.reject(
-        createCustomError('moved', {
-          status: 307,
-          location: `/hop/${(hop += 1)}`,
-        }),
-      ),
-    );
+    let calls = 0;
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(() => {
+      const path = `/hop/${calls}`;
+      calls += 1;
+      const err = createCustomError('moved', {
+        status: 307,
+        location: `/hop/${calls}`,
+      });
+      const Thrower = () => {
+        throw err;
+      };
+      return Promise.resolve({
+        [unstable_getRouteSlotId(path)]: <Thrower />,
+        [ROUTE_ID]: [path, ''],
+        [IS_STATIC_ID]: false,
+      });
+    });
     installRefetch(refetch);
 
     const capture = { router: null as RouterApi | null };
@@ -4025,7 +4078,7 @@ describe('Router integration', () => {
     try {
       await act(async () => {
         await capture.router!.push('/hop/0');
-        for (let i = 0; i < 25; i += 1) {
+        for (let i = 0; i < 120; i += 1) {
           await flush();
         }
       });
@@ -4036,34 +4089,89 @@ describe('Router integration', () => {
       consoleErrorSpy.mockRestore();
       view.unmount();
     }
-  });
+  }, 20_000);
+
+  test('a committing redirect cycle stops at the hop limit', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {
+      const path = rscPath === unstable_encodeRoutePath('/a') ? '/a' : '/b';
+      const next = path === '/a' ? '/b' : '/a';
+      const err = createCustomError('moved', { status: 307, location: next });
+      const Thrower = () => {
+        throw err;
+      };
+      return Promise.resolve({
+        [unstable_getRouteSlotId(path)]: <Thrower />,
+        [ROUTE_ID]: [path, ''],
+        [IS_STATIC_ID]: false,
+      });
+    }) as never);
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <ErrorBoundary>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </ErrorBoundary>
+      </Unstable_SearchCodecsProvider>,
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/a');
+        for (let i = 0; i < 120; i += 1) {
+          await flush();
+        }
+      });
+      expect(view.container.textContent).toContain(
+        'too many redirect or 404 follows',
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  }, 20_000);
 
   test('an instant redirect scrolls when the visible navigation changed paths', async () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const RedirectErrorObject = createCustomError('moved', {
+      status: 307,
+      location: '/account/profile?login=1',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
+    const profileSlotId = unstable_getRouteSlotId('/account/profile');
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', {
-            status: 307,
-            location: '/account/profile?login=1',
-          }),
-        ),
-      )
       .mockResolvedValueOnce({
+        [profileSlotId]: <ThrowRedirect />,
+        [ROUTE_ID]: ['/account/profile', ''],
+        [IS_STATIC_ID]: false,
+      })
+      .mockResolvedValueOnce({
+        [profileSlotId]: <Probe />,
         [ROUTE_ID]: ['/account/profile', 'login=1'],
         [IS_STATIC_ID]: false,
       });
     installRefetch(refetch);
 
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    const profileSlotId = unstable_getRouteSlotId('/account/profile');
     const elements = {
       [unstable_getRouteSlotId('/start')]: <Probe />,
-      [profileSlotId]: <Probe />,
+      [profileSlotId]: <ThrowRedirect />,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
       [`${ETAG_ID_PREFIX}${profileSlotId}`]: IMMUTABLE_ETAG,
@@ -4085,6 +4193,8 @@ describe('Router integration', () => {
         .catch(() => {});
       await flush();
       await flush();
+      await flush();
+      await flush();
     });
 
     // the visible navigation is /start -> /account/profile?login=1, so
@@ -4102,12 +4212,14 @@ describe('Router integration', () => {
       .mockImplementation(() => {});
     const { view, capture, router } = await renderFollowRouter({
       responses: [
-        { reject: { status: 307, location: '/start' } },
+        { redirect: { from: '/a', location: '/start' } },
         { resolve: { [ROUTE_ID]: ['/start', ''], [IS_STATIC_ID]: false } },
       ],
     });
     await act(async () => {
       await router.push('/a').catch(() => {});
+      await flush();
+      await flush();
       await flush();
       await flush();
     });
@@ -4118,14 +4230,21 @@ describe('Router integration', () => {
   });
 
   test('a navigation during a redirect follow aborts the chain', async () => {
+    const RedirectErrorObject = createCustomError('moved', {
+      status: 307,
+      location: '/slow',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
     let resolveSecond!: (value: Record<string, unknown>) => void;
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          createCustomError('moved', { status: 307, location: '/slow' }),
-        ),
-      )
+      .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/a')]: <ThrowRedirect />,
+        [ROUTE_ID]: ['/a', ''],
+        [IS_STATIC_ID]: false,
+      })
       .mockImplementationOnce(
         () =>
           new Promise((resolve) => {
@@ -4210,7 +4329,7 @@ describe('Router integration', () => {
   test('a redirect that lands on a missing route goes to the 404 route', async () => {
     const { view, refetch, capture, router } = await renderFollowRouter({
       responses: [
-        { reject: { status: 307, location: '/gone' } },
+        { redirect: { from: '/moved', location: '/gone' } },
         { reject: { status: 404 } },
         { resolve: { [ROUTE_ID]: ['/404', ''], [IS_STATIC_ID]: false } },
       ],
@@ -4219,10 +4338,9 @@ describe('Router integration', () => {
     });
     await act(async () => {
       await router.push('/moved').catch(() => {});
-      await flush();
-      await flush();
-      await flush();
-      await flush();
+      for (let i = 0; i < 8; i += 1) {
+        await flush();
+      }
     });
     expect(refetch).toHaveBeenCalledTimes(3);
     expect(capture.router!.path).toBe('/404');
@@ -4235,7 +4353,9 @@ describe('Router integration', () => {
       .mockImplementation(() => {});
     const { view, capture, router } = await renderFollowRouter({
       responses: [
-        { reject: { status: 307, location: '/login' } },
+        {
+          redirect: { from: '/start', fromQuery: 'page=2', location: '/login' },
+        },
         { resolve: { [ROUTE_ID]: ['/login', ''], [IS_STATIC_ID]: false } },
       ],
       slots: ['/login'],
@@ -4243,6 +4363,8 @@ describe('Router integration', () => {
     window.history.replaceState(null, '', '/start?page=1');
     await act(async () => {
       await router.push('/start?page=2').catch(() => {});
+      await flush();
+      await flush();
       await flush();
       await flush();
     });
@@ -4463,7 +4585,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a render-time redirect whose target also redirects reconciles the url to the final route', async () => {
+  test('a follow whose fetch is redirected hard navigates', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const ThrowRedirectErrorObject = createCustomError('redirect', {
@@ -4474,7 +4596,9 @@ describe('Router integration', () => {
       throw ThrowRedirectErrorObject;
     };
 
-    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
+      .mockImplementation(() => {});
 
     getRefetchMock().mockImplementation(((rscPath: string) =>
       rscPath === unstable_encodeRoutePath('/login')
@@ -4499,18 +4623,18 @@ describe('Router integration', () => {
       },
       elements,
     );
-    // the first follow redirects again, so let both follows settle
-    await flush();
-    await flush();
-    await flush();
-    await flush();
-    await flush();
+    try {
+      await flush();
+      await flush();
+      await flush();
 
-    expect(capture.router?.path).toBe('/dashboard');
-    expect(window.location.pathname).toBe('/dashboard');
-    expect(replaceStateSpy).toHaveBeenCalled();
-
-    view.unmount();
+      // the follow dispatch is not a push, so the browser replaces
+      expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
+      expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/dashboard');
+    } finally {
+      view.unmount();
+      replaceLocationSpy.mockRestore();
+    }
   });
 
   test('a followed redirect keeps the base path in the url', async () => {
@@ -4838,15 +4962,15 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a cross origin redirect on push keeps the attempted history entry', async () => {
+  test('a cross origin rejected redirect hard navigates on push', async () => {
     const { view, router } = await renderFollowRouter({
       responses: [
         { reject: { status: 307, location: 'http://elsewhere.test/login' } },
       ],
       slots: [],
     });
-    const replaceLocationSpy = vi
-      .spyOn(window.location, 'replace')
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
       .mockImplementation(() => {});
     window.history.replaceState(null, '', '/dashboard');
     const lengthBefore = window.history.length;
@@ -4855,13 +4979,11 @@ describe('Router integration', () => {
       await flush();
       await flush();
     });
-    // the attempted url is pushed first, so Back returns to /dashboard
-    expect(window.location.pathname).toBe('/protected');
-    expect(window.history.length).toBe(lengthBefore + 1);
-    expect(replaceLocationSpy).toHaveBeenCalledWith(
-      'http://elsewhere.test/login',
-    );
-    replaceLocationSpy.mockRestore();
+    // the browser follows and records the entry itself
+    expect(window.location.pathname).toBe('/dashboard');
+    expect(window.history.length).toBe(lengthBefore);
+    expect(assignSpy).toHaveBeenCalledWith('http://elsewhere.test/login');
+    assignSpy.mockRestore();
     view.unmount();
   });
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4987,6 +4987,47 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a network error on push retries as a browser navigation', async () => {
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [],
+    });
+    refetch.mockImplementationOnce(() =>
+      Promise.reject(new TypeError('Failed to fetch')),
+    );
+    await act(async () => {
+      await router.push('/protected').catch(() => {});
+      await flush();
+    });
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    expect(assignSpy.mock.calls[0]![0]).toContain('/protected');
+    expect(capture.router!.path).toBe('/start');
+    assignSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a network error on replace retries without a new entry', async () => {
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
+      .mockImplementation(() => {});
+    const { view, refetch, router } = await renderFollowRouter({
+      responses: [],
+    });
+    refetch.mockImplementationOnce(() =>
+      Promise.reject(new TypeError('Failed to fetch')),
+    );
+    await act(async () => {
+      await router.replace('/protected').catch(() => {});
+      await flush();
+    });
+    expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
+    expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/protected');
+    replaceLocationSpy.mockRestore();
+    view.unmount();
+  });
+
   test('redirect error with a different origin leaves the app', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -282,32 +282,42 @@ vi.mock('../src/minimal/client.js', async () => {
   // Per-root refetch: calls the shared inner mock, then merges the response into
   // this Root's own store.
   const noopMergeElements = () => {};
+  const refetchByStore = new WeakMap<
+    object,
+    (
+      rscPath: string,
+      ...rest: [rscParams?: unknown, options?: unknown]
+    ) => unknown
+  >();
   const useMockRefetch = () => {
     const store = React.use(StoreContext);
-    return React.useMemo(
-      () =>
-        (
-          rscPath: string,
-          ...rest: [rscParams?: unknown, options?: unknown]
-        ) => {
-          const overlay = (
-            rest[1] as
-              { unstable_overlay?: Record<string, unknown> } | undefined
-          )?.unstable_overlay;
-          const dataPromise = Promise.resolve(
-            testHoisted.inner!(rscPath, ...rest),
-          ).then((result) => withRouteMeta(result, rscPath, rest[0]));
-          // like minimal's refetch: the overlay merges atomically on success
-          store?.applyAsync(
-            dataPromise.then(
-              (result) => ({ ...result, ...overlay }),
-              () => ({}),
-            ),
-          );
-          return dataPromise;
-        },
-      [store],
-    );
+    // one function identity per store, like the real RefetchContext value
+    let fn = store && refetchByStore.get(store);
+    if (!fn) {
+      fn = (
+        rscPath: string,
+        ...rest: [rscParams?: unknown, options?: unknown]
+      ) => {
+        const overlay = (
+          rest[1] as { unstable_overlay?: Record<string, unknown> } | undefined
+        )?.unstable_overlay;
+        const dataPromise = Promise.resolve(
+          testHoisted.inner!(rscPath, ...rest),
+        ).then((result) => withRouteMeta(result, rscPath, rest[0]));
+        // like minimal's refetch: the overlay merges atomically on success
+        store?.applyAsync(
+          dataPromise.then(
+            (result) => ({ ...result, ...overlay }),
+            () => ({}),
+          ),
+        );
+        return dataPromise;
+      };
+      if (store) {
+        refetchByStore.set(store, fn);
+      }
+    }
+    return fn;
   };
 
   return {
@@ -610,7 +620,6 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents,
-          fetchingSlices: new Set(),
         }}
       >
         <Probe />
@@ -703,7 +712,6 @@ describe('useRouter + Link with context', () => {
             changeRoute,
             prefetchRoute: vi.fn(),
             routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-            fetchingSlices: new Set(),
           }}
         >
           <Probe />
@@ -773,7 +781,6 @@ describe('useRouter + Link with context', () => {
               changeRoute: vi.fn(async () => {}),
               prefetchRoute,
               routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-              fetchingSlices: new Set(),
             }}
           >
             <Probe />
@@ -832,7 +839,6 @@ describe('useRouter + Link with context', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Probe />
@@ -857,7 +863,6 @@ describe('useRouter + Link with context', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Probe />
@@ -913,7 +918,6 @@ describe('useRouter + Link with context', () => {
             changeRoute: vi.fn(async () => {}),
             prefetchRoute: vi.fn(),
             routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-            fetchingSlices: new Set(),
           }}
         >
           <Probe />
@@ -943,7 +947,6 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <>
@@ -1034,7 +1037,6 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Link to="/start#target" data-testid="hash-link">
@@ -1095,7 +1097,6 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Link to="/start#target" scroll={false} data-testid="hash-link">
@@ -1138,7 +1139,6 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <>
@@ -1213,7 +1213,6 @@ describe('useRouter + Link with context', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Link
@@ -1272,7 +1271,6 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Link to="/next" unstable_startTransition={unstableStartTransition}>
@@ -1311,7 +1309,6 @@ describe('useRouter + Link with context', () => {
       changeRoute: vi.fn(async () => {}),
       prefetchRoute: vi.fn(),
       routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-      fetchingSlices: new Set<string>(),
     };
 
     const objectRef: { current: HTMLAnchorElement | null } = { current: null };
@@ -1344,9 +1341,9 @@ describe('useRouter + Link with context', () => {
 });
 
 describe('Slice', () => {
-  test('throws without RouterContext', async () => {
+  test('throws without a Root', async () => {
     await expect(renderApp(<Slice id="slice-1" />)).rejects.toThrow(
-      'Missing Router',
+      'Missing Root component',
     );
   });
 
@@ -1363,7 +1360,6 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Slice id="slice-1" />
@@ -1376,8 +1372,6 @@ describe('Slice', () => {
   });
 
   test('lazy slice fetches once, dedupes, and clears in-flight set on completion', async () => {
-    const fetchingSlices = new Set<string>();
-
     const view = await renderWithMinimalRoot(
       <RouterContext
         value={{
@@ -1385,7 +1379,6 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices,
         }}
       >
         <>
@@ -1409,7 +1402,6 @@ describe('Slice', () => {
     expect(view.container.textContent).toContain('loading 2');
     expect(refetch).toHaveBeenCalledTimes(1);
     expect(refetch).toHaveBeenCalledWith(unstable_encodeSliceId('slice-1'));
-    expect(fetchingSlices.size).toBe(0);
 
     view.unmount();
   });
@@ -1428,7 +1420,6 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Slice id="slice-1" lazy fallback={<div>fallback</div>} />
@@ -1457,7 +1448,6 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set(),
         }}
       >
         <Slice id="slice-1" lazy fallback={<div>fallback</div>} />
@@ -1474,7 +1464,6 @@ describe('Slice', () => {
   });
 
   test('logs refetch failures and clears fetching set', async () => {
-    const fetchingSlices = new Set<string>();
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
     refetch.mockRejectedValueOnce(new Error('slice failed'));
@@ -1487,7 +1476,6 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices,
         }}
       >
         <Slice id="slice-1" lazy fallback={<div>fallback</div>} />
@@ -1499,7 +1487,6 @@ describe('Slice', () => {
       'Failed to fetch slice:',
       expect.any(Error),
     );
-    expect(fetchingSlices.size).toBe(0);
 
     view.unmount();
   });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -5036,6 +5036,64 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a hung probe falls back to the error path', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => new Promise<Response>(() => {}));
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+    refetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      </ErrorBoundary>,
+    );
+    try {
+      if (!capture.router) {
+        throw new Error('router not initialized');
+      }
+      let rejected: unknown;
+      await act(async () => {
+        capture.router!.push('/protected').catch((e: unknown) => {
+          rejected = e;
+        });
+        await flush();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(3001);
+        await flush();
+      });
+      expect(rejected).toBeInstanceOf(TypeError);
+      expect(assignSpy).not.toHaveBeenCalled();
+      expect(view.container.textContent).toContain(
+        'Caught an unexpected error',
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      assignSpy.mockRestore();
+      fetchSpy.mockRestore();
+      vi.useRealTimers();
+      view.unmount();
+    }
+  });
+
   test('a superseded navigation ignores a late probe result', async () => {
     let resolveProbe!: (response: Response) => void;
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -5036,6 +5036,56 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a superseded navigation ignores a late probe result', async () => {
+    let resolveProbe!: (response: Response) => void;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveProbe = resolve;
+        }),
+    );
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
+      .mockImplementation(() => {});
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [],
+      slots: ['/b'],
+    });
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(new TypeError('Failed to fetch')),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ [ROUTE_ID]: ['/b', ''], [IS_STATIC_ID]: false }),
+      );
+    let pushA: Promise<unknown> | undefined;
+    await act(async () => {
+      pushA = router.push('/a');
+      pushA.catch(() => {});
+      await flush();
+    });
+    await act(async () => {
+      await router.push('/b');
+      await flush();
+    });
+    expect(capture.router!.path).toBe('/b');
+    await act(async () => {
+      resolveProbe(new Response(''));
+      await pushA;
+      await flush();
+    });
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(replaceLocationSpy).not.toHaveBeenCalled();
+    expect(capture.router!.path).toBe('/b');
+    assignSpy.mockRestore();
+    replaceLocationSpy.mockRestore();
+    fetchSpy.mockRestore();
+    view.unmount();
+  });
+
   test('a network error with the server unreachable stays an error', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4988,6 +4988,9 @@ describe('Router integration', () => {
   });
 
   test('a network error on push retries as a browser navigation', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(''));
     const assignSpy = vi
       .spyOn(window.location, 'assign')
       .mockImplementation(() => {});
@@ -5005,10 +5008,14 @@ describe('Router integration', () => {
     expect(assignSpy.mock.calls[0]![0]).toContain('/protected');
     expect(capture.router!.path).toBe('/start');
     assignSpy.mockRestore();
+    fetchSpy.mockRestore();
     view.unmount();
   });
 
   test('a network error on replace retries without a new entry', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(''));
     const replaceLocationSpy = vi
       .spyOn(window.location, 'replace')
       .mockImplementation(() => {});
@@ -5025,7 +5032,58 @@ describe('Router integration', () => {
     expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
     expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/protected');
     replaceLocationSpy.mockRestore();
+    fetchSpy.mockRestore();
     view.unmount();
+  });
+
+  test('a network error with the server unreachable stays an error', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new TypeError('Failed to fetch'));
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+    refetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      </ErrorBoundary>,
+    );
+    try {
+      if (!capture.router) {
+        throw new Error('router not initialized');
+      }
+      await act(async () => {
+        await expect(capture.router!.push('/protected')).rejects.toThrow(
+          'Failed to fetch',
+        );
+        await flush();
+      });
+      expect(assignSpy).not.toHaveBeenCalled();
+      expect(view.container.textContent).toContain(
+        'Caught an unexpected error',
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      assignSpy.mockRestore();
+      fetchSpy.mockRestore();
+      view.unmount();
+    }
   });
 
   test('redirect error with a different origin leaves the app', async () => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -201,6 +201,34 @@ vi.mock('../src/minimal/client.js', async () => {
       value,
     });
 
+  const chainMergeCache = new WeakMap<
+    object,
+    WeakMap<object, Promise<Record<string, unknown>>>
+  >();
+  const chainMerge = (
+    prev: Promise<Record<string, unknown>>,
+    data: Record<string, unknown> | Promise<Record<string, unknown>>,
+  ): Promise<Record<string, unknown>> => {
+    let byData = chainMergeCache.get(prev);
+    if (!byData) {
+      byData = new WeakMap();
+      chainMergeCache.set(prev, byData);
+    }
+    let result = byData.get(data);
+    if (!result) {
+      const prevValue =
+        (prev as { status?: string }).status === 'fulfilled'
+          ? (prev as unknown as { value: Record<string, unknown> }).value
+          : undefined;
+      result =
+        prevValue && !('then' in data)
+          ? makeThenable({ ...prevValue, ...data })
+          : Promise.all([prev, data]).then(([a, b]) => ({ ...a, ...b }));
+      byData.set(data, result);
+    }
+    return result;
+  };
+
   // Each mocked Root provides its own store through this context, so a refetch
   // or merge from within a Root targets that Root's elements state.
   const StoreContext = React.createContext<RootStore | null>(null);
@@ -220,19 +248,17 @@ vi.mock('../src/minimal/client.js', async () => {
     if (!storeRef.current) {
       storeRef.current = {
         // synchronous merge of a value (route metadata with no fetch)
+        // both merges chain off the previous elements like the real
+        // client's setElements(prev => merge(prev, ...)). The result is
+        // cached per (prev, data) like minimal's merge helpers, so React
+        // rebasing the updater re-runs it idempotently.
         applySync: (data) => {
-          valueRef.current = { ...valueRef.current, ...data };
-          setElements(makeThenable(valueRef.current));
+          setElements((prev) => chainMerge(prev, data));
         },
         // eager merge of a pending fetch: elements suspend until it resolves,
         // like the real client, so a transition stays pending across the fetch
         applyAsync: (dataPromise) => {
-          setElements(
-            dataPromise.then((data) => {
-              valueRef.current = { ...valueRef.current, ...data };
-              return valueRef.current!;
-            }),
-          );
+          setElements((prev) => chainMerge(prev, dataPromise));
         },
       };
     }
@@ -255,6 +281,7 @@ vi.mock('../src/minimal/client.js', async () => {
 
   // Per-root refetch: calls the shared inner mock, then merges the response into
   // this Root's own store.
+  const noopMergeElements = () => {};
   const useMockRefetch = () => {
     const store = React.use(StoreContext);
     return React.useMemo(
@@ -263,10 +290,20 @@ vi.mock('../src/minimal/client.js', async () => {
           rscPath: string,
           ...rest: [rscParams?: unknown, options?: unknown]
         ) => {
+          const overlay = (
+            rest[1] as
+              { unstable_overlay?: Record<string, unknown> } | undefined
+          )?.unstable_overlay;
           const dataPromise = Promise.resolve(
             testHoisted.inner!(rscPath, ...rest),
           ).then((result) => withRouteMeta(result, rscPath, rest[0]));
-          store?.applyAsync(dataPromise.catch(() => ({})));
+          // like minimal's refetch: the overlay merges atomically on success
+          store?.applyAsync(
+            dataPromise.then(
+              (result) => ({ ...result, ...overlay }),
+              () => ({}),
+            ),
+          );
           return dataPromise;
         },
       [store],
@@ -282,7 +319,7 @@ vi.mock('../src/minimal/client.js', async () => {
     // to the calling Root's own store.
     useMergeElements_UNSTABLE: () => {
       const store = React.use(StoreContext);
-      return store ? store.applySync : () => {};
+      return store ? store.applySync : noopMergeElements;
     },
     unstable_prefetchRsc: vi.fn(),
     useRefetch: vi.fn(useMockRefetch),
@@ -307,6 +344,11 @@ const renderApp = async (element: ReactElement) => {
 };
 
 const flush = async () => {
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve));
+  });
+  // one more round so effect-driven updates (e.g. a boundary reset after a
+  // followed commit) also land
   await act(async () => {
     await new Promise<void>((resolve) => setTimeout(resolve));
   });
@@ -598,17 +640,15 @@ describe('useRouter + Link with context', () => {
       { path: '/start', query: 'query=1', hash: '' },
       expect.objectContaining({
         shouldScroll: false,
-        mode: 'push',
+        push: true,
         url: expect.any(URL),
       }),
     );
     expect(changeRoute).toHaveBeenNthCalledWith(
       2,
       { path: '/start', query: 'query=2', hash: '' },
-      expect.objectContaining({
-        shouldScroll: false,
-        mode: 'replace',
-        url: expect.any(URL),
+      expect.not.objectContaining({
+        push: true,
       }),
     );
     expect(changeRoute).toHaveBeenNthCalledWith(
@@ -698,12 +738,12 @@ describe('useRouter + Link with context', () => {
     expect(changeRoute).toHaveBeenNthCalledWith(
       1,
       expectedRoute,
-      expect.objectContaining({ mode: 'push', url: expect.any(URL) }),
+      expect.objectContaining({ push: true, url: expect.any(URL) }),
     );
     expect(changeRoute).toHaveBeenNthCalledWith(
       2,
       expectedRoute,
-      expect.objectContaining({ mode: 'replace', url: expect.any(URL) }),
+      expect.not.objectContaining({ push: true }),
     );
     const pushedUrl = (
       (changeRoute.mock.calls[0] as unknown[] | undefined)?.[1] as
@@ -933,7 +973,7 @@ describe('useRouter + Link with context', () => {
       { path: '/next', query: '', hash: '' },
       expect.objectContaining({
         shouldScroll: true,
-        mode: 'push',
+        push: true,
         url: expect.any(URL),
       }),
     );
@@ -1258,7 +1298,7 @@ describe('useRouter + Link with context', () => {
     expect(changeRoute).toHaveBeenCalledWith(
       { path: '/next', query: '', hash: '' },
       expect.objectContaining({
-        startTransition: unstableStartTransition,
+        push: true,
       }),
     );
 
@@ -2313,24 +2353,36 @@ describe('Router integration', () => {
       [IS_STATIC_ID]: false,
     };
 
-    const view = await renderRouter(
-      {
-        initialRoute: { path: '/start', query: '', hash: '' },
-      },
-      elements,
+    testHoisted.elements = elements;
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      </ErrorBoundary>,
     );
     try {
       if (!capture.router) {
         throw new Error('router not initialized');
       }
 
-      await expect(capture.router.push('/next')).rejects.toThrow(
-        'refetch failed',
-      );
+      await act(async () => {
+        await expect(capture.router!.push('/next')).rejects.toThrow(
+          'refetch failed',
+        );
+        await flush();
+      });
       expect(historyPushSpy).toHaveBeenCalledTimes(1);
       expect(window.location.pathname).toBe('/next');
-      expect(capture.router.path).toBe('/start');
+      // the unrecoverable error rethrows to the app boundary
+      expect(view.container.textContent).toContain(
+        'Caught an unexpected error',
+      );
     } finally {
+      consoleErrorSpy.mockRestore();
       view.unmount();
     }
   });
@@ -2507,7 +2559,9 @@ describe('Router integration', () => {
       expect.any(URLSearchParams),
       expect.objectContaining({
         unstable_prefetched: shellPromise,
-        unstable_overlay: { [ROUTE_ID]: ['/next', ''] },
+        unstable_overlay: expect.objectContaining({
+          [ROUTE_ID]: ['/next', ''],
+        }),
         unstable_swr: {
           pin: expect.any(Function),
           base: shell,
@@ -3399,7 +3453,8 @@ describe('Router integration', () => {
       slots: ['/next'],
     });
     await act(async () => {
-      await router.push('/moved');
+      await router.push('/moved').catch(() => {});
+      await flush();
       await flush();
     });
     expect(refetch).toHaveBeenCalledTimes(2);
@@ -3452,9 +3507,12 @@ describe('Router integration', () => {
       .mockImplementation(() => {});
     try {
       await act(async () => {
-        await capture.router!.push('/account/profile', {
-          unstable_instant: true,
-        });
+        await capture
+          .router!.push('/account/profile', {
+            unstable_instant: true,
+          })
+          .catch(() => {});
+        await flush();
         await flush();
       });
     } finally {
@@ -3507,9 +3565,12 @@ describe('Router integration', () => {
 
     const lengthBefore = window.history.length;
     await act(async () => {
-      await capture.router!.push('/account/profile', {
-        unstable_instant: true,
-      });
+      await capture
+        .router!.push('/account/profile', {
+          unstable_instant: true,
+        })
+        .catch(() => {});
+      await flush();
       await flush();
     });
 
@@ -3556,9 +3617,12 @@ describe('Router integration', () => {
 
     const lengthBefore = window.history.length;
     await act(async () => {
-      await capture.router!.push('/account/profile', {
-        unstable_instant: true,
-      });
+      await capture
+        .router!.push('/account/profile', {
+          unstable_instant: true,
+        })
+        .catch(() => {});
+      await flush();
       await flush();
     });
 
@@ -3608,7 +3672,8 @@ describe('Router integration', () => {
     }
 
     await act(async () => {
-      await capture.router!.push('/account/profile');
+      await capture.router!.push('/account/profile').catch(() => {});
+      await flush();
       await flush();
     });
 
@@ -3655,7 +3720,8 @@ describe('Router integration', () => {
     window.history.replaceState(null, '', '/products?page=1');
     const lengthBefore = window.history.length;
     await act(async () => {
-      await capture.router!.push('/products?page=2');
+      await capture.router!.push('/products?page=2').catch(() => {});
+      await flush();
       await flush();
     });
 
@@ -3713,13 +3779,15 @@ describe('Router integration', () => {
       });
       // flush the attempted route's commit while the redirect is pending
       await flush();
+      await flush();
     });
     await act(async () => {
       resolveSecond({
         [ROUTE_ID]: ['/account/login', ''],
         [IS_STATIC_ID]: false,
       });
-      await pushPromise;
+      await pushPromise!.catch(() => {});
+      await flush();
       await flush();
     });
 
@@ -3741,7 +3809,8 @@ describe('Router integration', () => {
       slots: ['/next'],
     });
     await act(async () => {
-      await router.push('/moved', { scroll: false });
+      await router.push('/moved', { scroll: false }).catch(() => {});
+      await flush();
       await flush();
     });
     expect(capture.router!.path).toBe('/next');
@@ -3788,7 +3857,10 @@ describe('Router integration', () => {
 
     window.history.replaceState(null, '', '/products?page=1');
     await act(async () => {
-      await capture.router!.push('/products?page=2', { scroll: true });
+      await capture
+        .router!.push('/products?page=2', { scroll: true })
+        .catch(() => {});
+      await flush();
       await flush();
     });
 
@@ -3849,6 +3921,7 @@ describe('Router integration', () => {
         }),
       );
       await flush();
+      await flush();
     });
 
     expect(capture.router.path).toBe('/next');
@@ -3873,7 +3946,10 @@ describe('Router integration', () => {
     window.history.replaceState(null, '', '/start');
     const lengthBefore = window.history.length;
     await act(async () => {
-      await router.push('/a', { scroll: false });
+      await router.push('/a', { scroll: false }).catch(() => {});
+      await flush();
+      await flush();
+      await flush();
       await flush();
     });
     expect(capture.router!.path).toBe('/c');
@@ -3884,7 +3960,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a redirect cycle stops at the hop limit and rejects', async () => {
+  test('a redirect cycle surfaces a redirect loop error', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
       Promise.reject(
         createCustomError('moved', { status: 307, location: '/a' }),
@@ -3917,13 +3993,58 @@ describe('Router integration', () => {
 
     try {
       await act(async () => {
-        await expect(capture.router!.push('/a')).rejects.toThrow(
-          'too many redirect or 404 follows',
-        );
-        await flush();
+        await capture.router!.push('/a');
+        for (let i = 0; i < 25; i += 1) {
+          await flush();
+        }
       });
-      // the original fetch plus one follow per allowed hop
-      expect(refetch).toHaveBeenCalledTimes(21);
+      expect(view.container.textContent).toContain('detected a redirect loop');
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('an endless redirect chain stops at the hop limit', async () => {
+    let hop = 0;
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
+      Promise.reject(
+        createCustomError('moved', {
+          status: 307,
+          location: `/hop/${(hop += 1)}`,
+        }),
+      ),
+    );
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <ErrorBoundary>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </ErrorBoundary>
+      </Unstable_SearchCodecsProvider>,
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/hop/0');
+        for (let i = 0; i < 25; i += 1) {
+          await flush();
+        }
+      });
+      expect(view.container.textContent).toContain(
+        'too many redirect or 404 follows',
+      );
     } finally {
       consoleErrorSpy.mockRestore();
       view.unmount();
@@ -3970,9 +4091,12 @@ describe('Router integration', () => {
     }
 
     await act(async () => {
-      await capture.router!.push('/account/profile', {
-        unstable_instant: true,
-      });
+      await capture
+        .router!.push('/account/profile', {
+          unstable_instant: true,
+        })
+        .catch(() => {});
+      await flush();
       await flush();
     });
 
@@ -3996,7 +4120,8 @@ describe('Router integration', () => {
       ],
     });
     await act(async () => {
-      await router.push('/a');
+      await router.push('/a').catch(() => {});
+      await flush();
       await flush();
     });
     expect(capture.router!.path).toBe('/start');
@@ -4049,10 +4174,12 @@ describe('Router integration', () => {
       firstPush = capture.router!.push('/a');
       firstPush.catch(() => {});
       await flush();
+      await flush();
     });
     // the follow to /slow is in flight; a second navigation supersedes it
     await act(async () => {
-      await capture.router!.push('/other');
+      await capture.router!.push('/other').catch(() => {});
+      await flush();
       await flush();
     });
     await act(async () => {
@@ -4060,6 +4187,7 @@ describe('Router integration', () => {
         [ROUTE_ID]: ['/slow', ''],
         [IS_STATIC_ID]: false,
       });
+      await flush();
       await flush();
     });
 
@@ -4080,7 +4208,8 @@ describe('Router integration', () => {
     window.history.replaceState(null, '', '/start');
     const lengthBefore = window.history.length;
     await act(async () => {
-      await router.push('/missing');
+      await router.push('/missing').catch(() => {});
+      await flush();
       await flush();
     });
     expect(refetch).toHaveBeenCalledTimes(2);
@@ -4102,7 +4231,10 @@ describe('Router integration', () => {
       meta: { [HAS404_ID]: true },
     });
     await act(async () => {
-      await router.push('/moved');
+      await router.push('/moved').catch(() => {});
+      await flush();
+      await flush();
+      await flush();
       await flush();
     });
     expect(refetch).toHaveBeenCalledTimes(3);
@@ -4123,7 +4255,8 @@ describe('Router integration', () => {
     });
     window.history.replaceState(null, '', '/start?page=1');
     await act(async () => {
-      await router.push('/start?page=2');
+      await router.push('/start?page=2').catch(() => {});
+      await flush();
       await flush();
     });
     // the attempted query update does not scroll, and the redirect
@@ -4142,14 +4275,18 @@ describe('Router integration', () => {
     await act(async () => {
       await expect(router.push('/missing')).rejects.toThrow('follow-error');
       await flush();
+      await flush();
     });
     expect(refetch).toHaveBeenCalledTimes(1);
     view.unmount();
   });
 
   test('custom 404 handling without a /404 page keeps Not Found fallback', async () => {
+    const ThrowNotFoundErrorObject = createCustomError('not-found', {
+      status: 404,
+    });
     const ThrowNotFound = () => {
-      throw createCustomError('not-found', { status: 404 });
+      throw ThrowNotFoundErrorObject;
     };
 
     const elements = {
@@ -4219,8 +4356,11 @@ describe('Router integration', () => {
   test('custom 404 handling with a /404 page triggers client navigation to /404', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
+    const ThrowNotFoundErrorObject = createCustomError('not-found', {
+      status: 404,
+    });
     const ThrowNotFound = () => {
-      throw createCustomError('not-found', { status: 404 });
+      throw ThrowNotFoundErrorObject;
     };
 
     const elements = {
@@ -4252,8 +4392,11 @@ describe('Router integration', () => {
   test('custom 404 handling with a /404 page avoids strict-mode refetching race', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
+    const ThrowNotFoundErrorObject = createCustomError('not-found', {
+      status: 404,
+    });
     const ThrowNotFound = () => {
-      throw createCustomError('not-found', { status: 404 });
+      throw ThrowNotFoundErrorObject;
     };
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -4295,8 +4438,11 @@ describe('Router integration', () => {
   test('redirect error triggers same-origin client navigation', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      location: '/target?ok=1',
+    });
     const ThrowRedirect = () => {
-      throw createCustomError('redirect', { location: '/target?ok=1' });
+      throw ThrowRedirectErrorObject;
     };
 
     const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
@@ -4333,8 +4479,12 @@ describe('Router integration', () => {
   test('a render-time redirect whose target also redirects reconciles the url to the final route', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      status: 307,
+      location: '/login',
+    });
     const ThrowRedirect = () => {
-      throw createCustomError('redirect', { status: 307, location: '/login' });
+      throw ThrowRedirectErrorObject;
     };
 
     const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
@@ -4366,6 +4516,8 @@ describe('Router integration', () => {
     await flush();
     await flush();
     await flush();
+    await flush();
+    await flush();
 
     expect(capture.router?.path).toBe('/dashboard');
     expect(window.location.pathname).toBe('/dashboard');
@@ -4380,11 +4532,12 @@ describe('Router integration', () => {
       window.history.replaceState({}, '', '/docs/start');
       const capture = { router: null as RouterApi | null };
       const Probe = makeProbe(capture);
+      const ThrowRedirectErrorObject = createCustomError('redirect', {
+        status: 307,
+        location: '/docs/login',
+      });
       const ThrowRedirect = () => {
-        throw createCustomError('redirect', {
-          status: 307,
-          location: '/docs/login',
-        });
+        throw ThrowRedirectErrorObject;
       };
 
       const elements = {
@@ -4415,8 +4568,12 @@ describe('Router integration', () => {
   test('a followed redirect whose response redirects again replaces instead of pushing', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      status: 307,
+      location: '/login',
+    });
     const ThrowRedirect = () => {
-      throw createCustomError('redirect', { status: 307, location: '/login' });
+      throw ThrowRedirectErrorObject;
     };
 
     const pushStateSpy = vi.spyOn(window.history, 'pushState');
@@ -4459,11 +4616,12 @@ describe('Router integration', () => {
       window.history.replaceState({}, '', '/docs/start');
       const capture = { router: null as RouterApi | null };
       const Probe = makeProbe(capture);
+      const ThrowRedirectErrorObject = createCustomError('redirect', {
+        status: 307,
+        location: '/docs/login',
+      });
       const ThrowRedirect = () => {
-        throw createCustomError('redirect', {
-          status: 307,
-          location: '/docs/login',
-        });
+        throw ThrowRedirectErrorObject;
       };
 
       const pushStateSpy = vi.spyOn(window.history, 'pushState');
@@ -4505,8 +4663,12 @@ describe('Router integration', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      status: 307,
+      location: '/start',
+    });
     const ThrowRedirect = () => {
-      throw createCustomError('redirect', { status: 307, location: '/start' });
+      throw ThrowRedirectErrorObject;
     };
 
     testHoisted.elements = {
@@ -4538,8 +4700,12 @@ describe('Router integration', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      status: 307,
+      location: '/login',
+    });
     const ThrowRedirect = () => {
-      throw createCustomError('redirect', { status: 307, location: '/login' });
+      throw ThrowRedirectErrorObject;
     };
 
     getRefetchMock().mockImplementation(((rscPath: string) =>
@@ -4575,10 +4741,11 @@ describe('Router integration', () => {
   });
 
   test('redirect error with cross-origin location uses window.location.replace', async () => {
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      location: 'https://example.com/target?ok=1',
+    });
     const ThrowRedirect = () => {
-      throw createCustomError('redirect', {
-        location: 'https://example.com/target?ok=1',
-      });
+      throw ThrowRedirectErrorObject;
     };
 
     const replaceLocationSpy = vi
@@ -4646,7 +4813,8 @@ describe('Router integration', () => {
     window.history.replaceState(null, '', '/dashboard');
     const lengthBefore = window.history.length;
     await act(async () => {
-      await router.push('/protected');
+      await router.push('/protected').catch(() => {});
+      await flush();
       await flush();
     });
     // the attempted url is pushed first, so Back returns to /dashboard
@@ -4662,10 +4830,11 @@ describe('Router integration', () => {
   test('redirect error with a different origin leaves the app', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      location: 'http://localhost:4321/target?ok=1',
+    });
     const ThrowRedirect = () => {
-      throw createCustomError('redirect', {
-        location: 'http://localhost:4321/target?ok=1',
-      });
+      throw ThrowRedirectErrorObject;
     };
 
     const replaceLocationSpy = vi

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4683,6 +4683,57 @@ describe('Router integration', () => {
     }
   });
 
+  test('a redirect that only adds a hash is followed, not a loop', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      status: 307,
+      location: '/start#section',
+    });
+    const ThrowRedirect = () => {
+      throw ThrowRedirectErrorObject;
+    };
+
+    getRefetchMock().mockImplementation(((rscPath: string) =>
+      Promise.resolve(
+        rscPath === unstable_encodeRoutePath('/start')
+          ? {
+              [unstable_getRouteSlotId('/start')]: <p>Start Section</p>,
+              [ROUTE_ID]: ['/start', ''],
+            }
+          : {},
+      )) as never);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    try {
+      const view = await renderApp(
+        <ErrorBoundary>
+          <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+            <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+          </Unstable_SearchCodecsProvider>
+        </ErrorBoundary>,
+      );
+      await flush();
+      await flush();
+
+      expect(view.container.textContent).not.toContain(
+        'detected a redirect loop',
+      );
+      expect(view.container.textContent).toContain('Start Section');
+      expect(window.location.hash).toBe('#section');
+
+      view.unmount();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   test('a fetched redirect back to the caught route surfaces a redirect loop error', async () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2507,10 +2507,10 @@ describe('Router integration', () => {
       expect.any(URLSearchParams),
       expect.objectContaining({
         unstable_prefetched: shellPromise,
+        unstable_overlay: { [ROUTE_ID]: ['/next', ''] },
         unstable_swr: {
           pin: expect.any(Function),
           base: shell,
-          overlay: { [ROUTE_ID]: ['/next', ''] },
         },
       }),
     );

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -685,6 +685,7 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents,
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Probe />
@@ -782,6 +783,7 @@ describe('useRouter + Link with context', () => {
             changeRoute,
             prefetchRoute: vi.fn(),
             routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+            fetchingSlices: new Set<string>(),
           }}
         >
           <Probe />
@@ -851,6 +853,7 @@ describe('useRouter + Link with context', () => {
               changeRoute: vi.fn(async () => {}),
               prefetchRoute,
               routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+              fetchingSlices: new Set<string>(),
             }}
           >
             <Probe />
@@ -909,6 +912,7 @@ describe('useRouter + Link with context', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Probe />
@@ -933,6 +937,7 @@ describe('useRouter + Link with context', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Probe />
@@ -988,6 +993,7 @@ describe('useRouter + Link with context', () => {
             changeRoute: vi.fn(async () => {}),
             prefetchRoute: vi.fn(),
             routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+            fetchingSlices: new Set<string>(),
           }}
         >
           <Probe />
@@ -1017,6 +1023,7 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <>
@@ -1107,6 +1114,7 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Link to="/start#target" data-testid="hash-link">
@@ -1167,6 +1175,7 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Link to="/start#target" scroll={false} data-testid="hash-link">
@@ -1209,6 +1218,7 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <>
@@ -1283,6 +1293,7 @@ describe('useRouter + Link with context', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Link
@@ -1341,6 +1352,7 @@ describe('useRouter + Link with context', () => {
           changeRoute,
           prefetchRoute,
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Link to="/next" unstable_startTransition={unstableStartTransition}>
@@ -1379,6 +1391,7 @@ describe('useRouter + Link with context', () => {
       changeRoute: vi.fn(async () => {}),
       prefetchRoute: vi.fn(),
       routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+      fetchingSlices: new Set<string>(),
     };
 
     const objectRef: { current: HTMLAnchorElement | null } = { current: null };
@@ -1411,9 +1424,9 @@ describe('useRouter + Link with context', () => {
 });
 
 describe('Slice', () => {
-  test('throws without a Root', async () => {
+  test('throws without a Router', async () => {
     await expect(renderApp(<Slice id="slice-1" />)).rejects.toThrow(
-      'Missing Root component',
+      'Missing Router',
     );
   });
 
@@ -1430,6 +1443,7 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Slice id="slice-1" />
@@ -1449,6 +1463,7 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <>
@@ -1490,6 +1505,7 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Slice id="slice-1" lazy fallback={<div>fallback</div>} />
@@ -1518,6 +1534,7 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Slice id="slice-1" lazy fallback={<div>fallback</div>} />
@@ -1546,6 +1563,7 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
         }}
       >
         <Slice id="slice-1" lazy fallback={<div>fallback</div>} />

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4789,6 +4789,48 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a 404 route that itself 404s stops instead of hitting the hop limit', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
+      Promise.reject(createCustomError('nf', { status: 404 })),
+    );
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/404')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [HAS404_ID]: true,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      </ErrorBoundary>,
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/missing').catch(() => {});
+        for (let i = 0; i < 8; i += 1) {
+          await flush();
+        }
+      });
+
+      // one request for /missing, one for /404, then it gives up
+      expect(refetch).toHaveBeenCalledTimes(2);
+      expect(view.container.textContent).toContain('the follow target failed');
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('a 404 follow scrolls to the top like the navigation it replaces', async () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4980,6 +4980,110 @@ describe('Router integration', () => {
     }
   });
 
+  test('a retry after a failed navigation fetches again', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+    refetch.mockRejectedValueOnce(new Error('boom'));
+    installRefetch(refetch);
+
+    // an error boundary in the root layout, the documented pattern: the
+    // router keeps rendering after a navigation fails
+    testHoisted.elements = {
+      root: (
+        <ErrorBoundary>
+          <Children />
+        </ErrorBoundary>
+      ),
+      [unstable_getRouteSlotId('/list')]: <Probe />,
+      [ROUTE_ID]: ['/list', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <Router initialRoute={{ path: '/list', query: '', hash: '' }} />
+      </Unstable_SearchCodecsProvider>,
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/detail?id=5').catch(() => {});
+        await flush();
+      });
+      refetch.mockClear();
+
+      // the failed navigation must not make /list?id=5 look already loaded
+      await act(async () => {
+        await capture.router!.push('/list?id=5').catch(() => {});
+        await flush();
+      });
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('a second 404 with a query lands on the 404 route again', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) =>
+      rscPath === unstable_encodeRoutePath('/404')
+        ? Promise.resolve({
+            [unstable_getRouteSlotId('/404')]: <Probe />,
+            [ROUTE_ID]: ['/404', ''],
+            [IS_STATIC_ID]: false,
+          })
+        : Promise.reject(
+            createCustomError('nf', { status: 404 }),
+          )) as unknown as ReturnType<typeof useRefetch>);
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/404')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [HAS404_ID]: true,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      </ErrorBoundary>,
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/missing').catch(() => {});
+        for (let i = 0; i < 4; i += 1) {
+          await flush();
+        }
+      });
+      expect(view.container.textContent).toContain('/404|');
+
+      // now on /404, a second miss whose url carries a query
+      await act(async () => {
+        await capture.router!.push('/missing2?x=1').catch(() => {});
+        for (let i = 0; i < 4; i += 1) {
+          await flush();
+        }
+      });
+
+      expect(view.container.textContent).not.toContain('redirect loop');
+      expect(view.container.textContent).toContain('/404|');
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('a 404 follow scrolls to the top like the navigation it replaces', async () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3849,6 +3849,61 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a rejected redirect to an unusable protocol never reaches the browser', async () => {
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
+      .mockImplementation(() => {});
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+    refetch.mockImplementationOnce(() =>
+      Promise.reject(
+        createCustomError('moved', {
+          status: 307,
+          location: 'javascript:alert(1)',
+        }),
+      ),
+    );
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      </ErrorBoundary>,
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/moved').catch(() => {});
+        await flush();
+        await flush();
+      });
+
+      expect(assignSpy).not.toHaveBeenCalled();
+      expect(replaceLocationSpy).not.toHaveBeenCalled();
+      expect(view.container.textContent).toContain(
+        'cannot follow a redirect to javascript:alert(1)',
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      assignSpy.mockRestore();
+      replaceLocationSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('a rejected redirect resolves a relative location against the attempted url', async () => {
     const assignSpy = vi
       .spyOn(window.location, 'assign')

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4908,6 +4908,28 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a 404 follow fetches the 404 route with the attempted query', async () => {
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 404 } },
+        { resolve: { [ROUTE_ID]: ['/404', 'foo=bar'], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/404'],
+      meta: { [HAS404_ID]: true },
+    });
+    await act(async () => {
+      await router.push('/missing?foo=bar').catch(() => {});
+      await flush();
+      await flush();
+    });
+    expect(refetch.mock.calls[1]?.[0]).toBe(unstable_encodeRoutePath('/404'));
+    // the server renders the 404 page for the query it was asked for
+    const params = refetch.mock.calls[1]?.[1] as URLSearchParams;
+    expect(params.get('query')).toBe('foo=bar');
+    expect(capture.router!.query).toBe('foo=bar');
+    view.unmount();
+  });
+
   test('a chained redirect that only adds a hash is still followed', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3189,6 +3189,40 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('popstate that lands on another route moves the url with it', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
+      [ROUTE_ID]: ['/new', ''],
+      [IS_STATIC_ID]: false,
+    }));
+    installRefetch(refetch);
+
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/new')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+
+    // the browser restored /old, but the server redirects it to /new
+    window.history.pushState({}, '', '/old');
+    await act(async () => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      await flush();
+    });
+
+    expect(capture.router?.path).toBe('/new');
+    expect(window.location.pathname).toBe('/new');
+
+    view.unmount();
+  });
+
   test('popstate query-only transition preserves scroll behavior', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1620,6 +1620,42 @@ describe('Router integration', () => {
     }
   });
 
+  test('a server function 404 keeps the attempted url', async () => {
+    window.history.replaceState({}, '', '/start?a=1');
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/404')]: <Probe />,
+      [ROUTE_ID]: ['/start', 'a=1'],
+      [IS_STATIC_ID]: false,
+      [HAS404_ID]: true,
+    };
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: 'a=1', hash: '' } },
+      elements,
+    );
+
+    const store = fetchRscStore as unknown as Record<string, unknown>;
+    const listeners = store.l as Set<
+      (elements: Record<string, unknown>) => void
+    >;
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({ [ROUTE_ID]: ['/404', ''], [IS_STATIC_ID]: false });
+      }
+      await flush();
+    });
+    await flush();
+
+    expect(capture.router?.path).toBe('/404');
+    expect(window.location.pathname + window.location.search).toBe(
+      '/start?a=1',
+    );
+
+    view.unmount();
+  });
+
   test('push performs refetch for dynamic routes and emits start/complete events', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -649,7 +649,7 @@ describe('useRouter + Link with context', () => {
       { path: '/start', query: 'query=1', hash: '' },
       expect.objectContaining({
         shouldScroll: false,
-        push: true,
+        history: 'push',
         url: expect.any(URL),
       }),
     );
@@ -657,13 +657,13 @@ describe('useRouter + Link with context', () => {
       2,
       { path: '/start', query: 'query=2', hash: '' },
       expect.not.objectContaining({
-        push: true,
+        history: 'push',
       }),
     );
     expect(changeRoute).toHaveBeenNthCalledWith(
       3,
       { path: '/start', query: '', hash: '' },
-      { shouldScroll: true, refetch: true },
+      { shouldScroll: true, refetch: true, history: 'replace' },
     );
     const firstUrl = (
       (changeRoute.mock.calls[0] as unknown[] | undefined)?.[1] as
@@ -746,12 +746,12 @@ describe('useRouter + Link with context', () => {
     expect(changeRoute).toHaveBeenNthCalledWith(
       1,
       expectedRoute,
-      expect.objectContaining({ push: true, url: expect.any(URL) }),
+      expect.objectContaining({ history: 'push', url: expect.any(URL) }),
     );
     expect(changeRoute).toHaveBeenNthCalledWith(
       2,
       expectedRoute,
-      expect.not.objectContaining({ push: true }),
+      expect.not.objectContaining({ history: 'push' }),
     );
     const pushedUrl = (
       (changeRoute.mock.calls[0] as unknown[] | undefined)?.[1] as
@@ -976,7 +976,7 @@ describe('useRouter + Link with context', () => {
       { path: '/next', query: '', hash: '' },
       expect.objectContaining({
         shouldScroll: true,
-        push: true,
+        history: 'push',
         url: expect.any(URL),
       }),
     );
@@ -1296,7 +1296,7 @@ describe('useRouter + Link with context', () => {
     expect(changeRoute).toHaveBeenCalledWith(
       { path: '/next', query: '', hash: '' },
       expect.objectContaining({
-        push: true,
+        history: 'push',
       }),
     );
 
@@ -3097,6 +3097,37 @@ describe('Router integration', () => {
     );
     expect(capture.router?.path).toBe('/intercepted');
     expect(capture.router?.query).toBe('from=interceptor');
+
+    view.unmount();
+  });
+
+  test('popstate leaves the url the browser restored alone', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: true,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+
+    // a trailing slash and a percent-encoded space both survive the round trip
+    // through parseRoute, which the address bar must not be rewritten with
+    window.history.pushState({}, '', '/start/?q=hello%20world');
+    await act(async () => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      await flush();
+    });
+
+    expect(window.location.pathname + window.location.search).toBe(
+      '/start/?q=hello%20world',
+    );
+    expect(capture.router?.query).toBe('q=hello+world');
 
     view.unmount();
   });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1833,6 +1833,52 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a start listener that navigates beats the navigation it interrupted', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/a')]: <Probe />,
+        [unstable_getRouteSlotId('/b')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    const refetch = getRefetchMock();
+    for (const path of ['/a', '/b']) {
+      refetch.mockResolvedValueOnce({
+        [ROUTE_ID]: [path, ''],
+        [IS_STATIC_ID]: true,
+      });
+      await act(async () => {
+        await capture.router!.push(path as never);
+      });
+    }
+
+    const events: string[] = [];
+    capture.router!.unstable_events.on('start', (route) => {
+      events.push(`start ${route.path}`);
+      if (route.path === '/a') {
+        void capture.router!.push('/b' as never);
+      }
+    });
+    capture.router!.unstable_events.on('complete', (route) =>
+      events.push(`complete ${route.path}`),
+    );
+
+    await act(async () => {
+      await capture.router!.push('/a' as never);
+      await flush();
+    });
+
+    expect(events).toEqual(['start /a', 'start /b', 'complete /b']);
+    expect(capture.router!.path).toBe('/b');
+    expect(window.location.pathname).toBe('/b');
+    view.unmount();
+  });
+
   test('push performs refetch for dynamic routes and emits start/complete events', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4063,6 +4063,33 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a redirect location is an app path, so the base path is added', async () => {
+    vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/docs/');
+    try {
+      window.history.replaceState({}, '', '/docs/start');
+      const { view, capture, router } = await renderFollowRouter({
+        responses: [
+          { redirect: { from: '/moved', location: '/next' } },
+          { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
+        ],
+        slots: ['/next'],
+      });
+      await act(async () => {
+        await router.push('/moved').catch(() => {});
+        for (let i = 0; i < 4; i += 1) {
+          await flush();
+        }
+      });
+
+      expect(capture.router!.path).toBe('/next');
+      expect(window.location.pathname).toBe('/docs/next');
+
+      view.unmount();
+    } finally {
+      vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
+    }
+  });
+
   test('a redirect keeps an explicit scroll false option', async () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
@@ -4950,7 +4977,7 @@ describe('Router integration', () => {
       const Probe = makeProbe(capture);
       const ThrowRedirectErrorObject = createCustomError('redirect', {
         status: 307,
-        location: '/docs/login',
+        location: '/login', // an app path; the base path is the client's job
       });
       const ThrowRedirect = () => {
         throw ThrowRedirectErrorObject;
@@ -5034,7 +5061,7 @@ describe('Router integration', () => {
       const Probe = makeProbe(capture);
       const ThrowRedirectErrorObject = createCustomError('redirect', {
         status: 307,
-        location: '/docs/login',
+        location: '/login', // an app path; the base path is the client's job
       });
       const ThrowRedirect = () => {
         throw ThrowRedirectErrorObject;

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4807,6 +4807,58 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a chained redirect that only adds a hash is still followed', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const toNext = createCustomError('redirect', {
+      status: 307,
+      location: '/next',
+    });
+    const toHash = createCustomError('redirect', {
+      status: 307,
+      location: '/next#section',
+    });
+    const ThrowToNext = () => {
+      throw toNext;
+    };
+    const ThrowToHash = () => {
+      throw toHash;
+    };
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/next')]: <ThrowToHash />,
+        [ROUTE_ID]: ['/next', ''],
+        [IS_STATIC_ID]: false,
+      })
+      .mockResolvedValueOnce({
+        [unstable_getRouteSlotId('/next')]: <Probe />,
+        [ROUTE_ID]: ['/next', ''],
+        [IS_STATIC_ID]: false,
+      });
+    installRefetch(refetch);
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <ThrowToNext />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    await act(async () => {
+      for (let i = 0; i < 6; i += 1) {
+        await flush();
+      }
+    });
+
+    // the second target differs from the first only by its hash
+    expect(view.container.textContent).not.toContain('follow target failed');
+    expect(window.location.hash).toBe('#section');
+
+    view.unmount();
+  });
+
   test('a 404 route that itself 404s stops instead of hitting the hop limit', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2802,6 +2802,51 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a redirect after the url already moved replaces instead of pushing', async () => {
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
+      .mockImplementation(() => {});
+    // an instant commit writes the attempted url before the response lands
+    window.history.replaceState({}, '', '/next?x=1');
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
+      Promise.reject(
+        createCustomError('moved', { status: 307, location: '/login' }),
+      ),
+    );
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/next?x=1').catch(() => {});
+      await flush();
+    });
+
+    // that entry already exists, so the redirect must not add another
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
+    expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/login');
+
+    assignSpy.mockRestore();
+    replaceLocationSpy.mockRestore();
+    view.unmount();
+  });
+
   test('an instant nav to a static route keeps the query', async () => {
     // A static payload does not echo the query. The meta the eager pass pins
     // is the route being left, so without a refresh the record would call this

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2384,10 +2384,6 @@ describe('Router integration', () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
     refetch.mockRejectedValueOnce(new Error('refetch failed'));
     installRefetch(refetch);
-    // the probe finds nothing, so the failure stays in the app
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockRejectedValue(new TypeError('Failed to fetch'));
     const historyPushSpy = vi.spyOn(window.history, 'pushState');
 
     const elements = {
@@ -2426,7 +2422,6 @@ describe('Router integration', () => {
       );
     } finally {
       consoleErrorSpy.mockRestore();
-      fetchSpy.mockRestore();
       view.unmount();
     }
   });
@@ -5161,198 +5156,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a network error on push retries as a browser navigation', async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(''));
-    const assignSpy = vi
-      .spyOn(window.location, 'assign')
-      .mockImplementation(() => {});
-    const { view, refetch, capture, router } = await renderFollowRouter({
-      responses: [],
-    });
-    refetch.mockImplementationOnce(() =>
-      Promise.reject(new TypeError('Failed to fetch')),
-    );
-    await act(async () => {
-      await router.push('/protected').catch(() => {});
-      await flush();
-    });
-    expect(assignSpy).toHaveBeenCalledTimes(1);
-    expect(assignSpy.mock.calls[0]![0]).toContain('/protected');
-    expect(capture.router!.path).toBe('/start');
-    assignSpy.mockRestore();
-    fetchSpy.mockRestore();
-    view.unmount();
-  });
-
-  test('a failure without a waku error also retries as a browser navigation', async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(''));
-    const assignSpy = vi
-      .spyOn(window.location, 'assign')
-      .mockImplementation(() => {});
-    const { view, refetch, router } = await renderFollowRouter({
-      responses: [],
-    });
-    // a payload the client could not decode carries no server status
-    refetch.mockImplementationOnce(() =>
-      Promise.reject(new Error('could not decode')),
-    );
-    await act(async () => {
-      await router.push('/protected').catch(() => {});
-      await flush();
-    });
-    expect(assignSpy).toHaveBeenCalledTimes(1);
-    expect(assignSpy.mock.calls[0]![0]).toContain('/protected');
-    assignSpy.mockRestore();
-    fetchSpy.mockRestore();
-    view.unmount();
-  });
-
-  test('a network error on replace retries without a new entry', async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(''));
-    const replaceLocationSpy = vi
-      .spyOn(window.location, 'replace')
-      .mockImplementation(() => {});
-    const { view, refetch, router } = await renderFollowRouter({
-      responses: [],
-    });
-    refetch.mockImplementationOnce(() =>
-      Promise.reject(new TypeError('Failed to fetch')),
-    );
-    await act(async () => {
-      await router.replace('/protected').catch(() => {});
-      await flush();
-    });
-    expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
-    expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/protected');
-    replaceLocationSpy.mockRestore();
-    fetchSpy.mockRestore();
-    view.unmount();
-  });
-
-  test('a hung probe falls back to the error path', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
-      (_input, init) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener('abort', () =>
-            reject(new DOMException('Aborted', 'AbortError')),
-          );
-        }),
-    );
-    const assignSpy = vi
-      .spyOn(window.location, 'assign')
-      .mockImplementation(() => {});
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
-    refetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
-    installRefetch(refetch);
-
-    testHoisted.elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-    };
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-    const view = await renderApp(
-      <ErrorBoundary>
-        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
-          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
-        </Unstable_SearchCodecsProvider>
-      </ErrorBoundary>,
-    );
-    try {
-      if (!capture.router) {
-        throw new Error('router not initialized');
-      }
-      let rejected: unknown;
-      await act(async () => {
-        capture.router!.push('/protected').catch((e: unknown) => {
-          rejected = e;
-        });
-        await flush();
-      });
-      await act(async () => {
-        vi.advanceTimersByTime(3001);
-        await flush();
-      });
-      expect(rejected).toBeInstanceOf(TypeError);
-      expect(assignSpy).not.toHaveBeenCalled();
-      expect(fetchSpy.mock.calls[0]![1]!.signal!.aborted).toBe(true);
-      expect(view.container.textContent).toContain(
-        'Caught an unexpected error',
-      );
-    } finally {
-      consoleErrorSpy.mockRestore();
-      assignSpy.mockRestore();
-      fetchSpy.mockRestore();
-      vi.useRealTimers();
-      view.unmount();
-    }
-  });
-
-  test('a superseded navigation ignores a late probe result', async () => {
-    let resolveProbe!: (response: Response) => void;
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
-      () =>
-        new Promise<Response>((resolve) => {
-          resolveProbe = resolve;
-        }),
-    );
-    const assignSpy = vi
-      .spyOn(window.location, 'assign')
-      .mockImplementation(() => {});
-    const replaceLocationSpy = vi
-      .spyOn(window.location, 'replace')
-      .mockImplementation(() => {});
-    const { view, refetch, capture, router } = await renderFollowRouter({
-      responses: [],
-      slots: ['/b'],
-    });
-    refetch
-      .mockImplementationOnce(() =>
-        Promise.reject(new TypeError('Failed to fetch')),
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve({ [ROUTE_ID]: ['/b', ''], [IS_STATIC_ID]: false }),
-      );
-    let pushA: Promise<unknown> | undefined;
-    await act(async () => {
-      pushA = router.push('/a');
-      pushA.catch(() => {});
-      await flush();
-    });
-    await act(async () => {
-      await router.push('/b');
-      await flush();
-    });
-    expect(capture.router!.path).toBe('/b');
-    await act(async () => {
-      resolveProbe(new Response(''));
-      await pushA;
-      await flush();
-    });
-    expect(assignSpy).not.toHaveBeenCalled();
-    expect(replaceLocationSpy).not.toHaveBeenCalled();
-    expect(capture.router!.path).toBe('/b');
-    assignSpy.mockRestore();
-    replaceLocationSpy.mockRestore();
-    fetchSpy.mockRestore();
-    view.unmount();
-  });
-
-  test('a network error with the server unreachable stays an error', async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockRejectedValue(new TypeError('Failed to fetch'));
+  test('a network error stays an error instead of leaving the app', async () => {
     const assignSpy = vi
       .spyOn(window.location, 'assign')
       .mockImplementation(() => {});
@@ -5394,7 +5198,6 @@ describe('Router integration', () => {
     } finally {
       consoleErrorSpy.mockRestore();
       assignSpy.mockRestore();
-      fetchSpy.mockRestore();
       view.unmount();
     }
   });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2553,7 +2553,7 @@ describe('Router integration', () => {
     [`${ETAG_ID_PREFIX}${unstable_getRouteSlotId('/next')}`]: IMMUTABLE_ETAG,
   });
 
-  test('instant routerState reuses a prefetched response as data source and base', async () => {
+  test('instant nav reuses a prefetched response as data source and base', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
@@ -2611,7 +2611,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('instant routerState paints the target and writes the url before the response', async () => {
+  test('instant nav paints the target and writes the url before the response', async () => {
     const pending = createDeferred<Record<string, unknown>>();
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(() => pending.promise);
     installRefetch(refetch);
@@ -2757,7 +2757,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('instant routerState does not reuse a prefetch for a different query', async () => {
+  test('instant nav does not reuse a prefetch for a different query', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
@@ -2807,7 +2807,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('non-instant routerState adopts an in-flight prefetch as its data source', async () => {
+  test('non-instant nav adopts an in-flight prefetch as its data source', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
@@ -3086,7 +3086,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('instant routerState serves stored statics on a first visit', async () => {
+  test('instant nav serves stored statics on a first visit', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/fresh', ''],
       [IS_STATIC_ID]: false,

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -5227,6 +5227,42 @@ describe('Router integration', () => {
     }
   });
 
+  test('a protocol relative redirect is not treated as an app path', async () => {
+    vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/docs/');
+    try {
+      window.history.replaceState({}, '', '/docs/start');
+      const capture = { router: null as RouterApi | null };
+      const Probe = makeProbe(capture);
+      // same origin, so the router follows it rather than leaving the app
+      const ThrowRedirectErrorObject = createCustomError('redirect', {
+        status: 307,
+        location: `//${window.location.host}/docs/login`,
+      });
+      const ThrowRedirect = () => {
+        throw ThrowRedirectErrorObject;
+      };
+
+      const view = await renderRouter(
+        { initialRoute: { path: '/start', query: '', hash: '' } },
+        {
+          [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+          [unstable_getRouteSlotId('/login')]: <Probe />,
+          [ROUTE_ID]: ['/start', ''],
+          [IS_STATIC_ID]: false,
+        },
+      );
+      await flush();
+      await flush();
+
+      expect(capture.router?.path).toBe('/login');
+      expect(window.location.pathname).toBe('/docs/login');
+
+      view.unmount();
+    } finally {
+      vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
+    }
+  });
+
   test('a redirect the client cannot follow surfaces instead of blanking', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -5038,9 +5038,14 @@ describe('Router integration', () => {
 
   test('a hung probe falls back to the error path', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockImplementation(() => new Promise<Response>(() => {}));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        }),
+    );
     const assignSpy = vi
       .spyOn(window.location, 'assign')
       .mockImplementation(() => {});
@@ -5082,6 +5087,7 @@ describe('Router integration', () => {
       });
       expect(rejected).toBeInstanceOf(TypeError);
       expect(assignSpy).not.toHaveBeenCalled();
+      expect(fetchSpy.mock.calls[0]![1]!.signal!.aborted).toBe(true);
       expect(view.container.textContent).toContain(
         'Caught an unexpected error',
       );

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4701,6 +4701,35 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a 404 follow scrolls to the top like the navigation it replaces', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 404 } },
+        { resolve: { [ROUTE_ID]: ['/404', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/404'],
+      meta: { [HAS404_ID]: true },
+    });
+    scrollToSpy.mockClear();
+
+    await act(async () => {
+      await router.push('/missing').catch(() => {});
+      await flush();
+      await flush();
+    });
+
+    expect(capture.router!.path).toBe('/404');
+    // the user asked for a new path, so the 404 page starts at the top, and
+    // the failed commit on the way there does not scroll of its own
+    expect(scrollToSpy).toHaveBeenCalledTimes(1);
+
+    scrollToSpy.mockRestore();
+    view.unmount();
+  });
+
   test('a follow into a known static route does not fetch it', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -255,16 +255,17 @@ vi.mock('../src/minimal/client.js', async () => {
     let merged = byResult.get(result);
     if (!merged) {
       merged = Promise.resolve(prev).then((prevRes) => {
-        const next = { ...prevRes };
+        const next: Record<string | symbol, unknown> = { ...prevRes };
+        const from: Record<string | symbol, unknown> = result;
         for (const key of Reflect.ownKeys(result)) {
           if (key === '_value') {
             continue;
           }
           if (!(key in prevRes) || (overlay && key in overlay) || !pin(key)) {
-            next[key] = result[key];
+            next[key] = from[key];
           }
         }
-        return next;
+        return next as Record<string, unknown>;
       });
       byResult.set(result, merged);
     }

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2553,7 +2553,7 @@ describe('Router integration', () => {
     [`${ETAG_ID_PREFIX}${unstable_getRouteSlotId('/next')}`]: IMMUTABLE_ETAG,
   });
 
-  test('instant nav reuses a prefetched response as data source and base', async () => {
+  test('instant routerState reuses a prefetched response as data source and base', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
@@ -2611,7 +2611,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('instant nav paints the target and writes the url before the response', async () => {
+  test('instant routerState paints the target and writes the url before the response', async () => {
     const pending = createDeferred<Record<string, unknown>>();
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(() => pending.promise);
     installRefetch(refetch);
@@ -2652,7 +2652,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('instant nav adopts an in-flight prefetch as its data source', async () => {
+  test('instant routerState adopts an in-flight prefetch as its data source', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
@@ -2699,7 +2699,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('instant nav does not reuse a prefetch for a different query', async () => {
+  test('instant routerState does not reuse a prefetch for a different query', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
@@ -2749,7 +2749,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('non-instant nav adopts an in-flight prefetch as its data source', async () => {
+  test('non-instant routerState adopts an in-flight prefetch as its data source', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,
@@ -3028,7 +3028,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('instant nav serves stored statics on a first visit', async () => {
+  test('instant routerState serves stored statics on a first visit', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/fresh', ''],
       [IS_STATIC_ID]: false,

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { StrictMode, Suspense, act, use, useState } from 'react';
+import { StrictMode, act, use, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { preloadModule } from 'react-dom';
 import { createRoot } from 'react-dom/client';
@@ -4464,66 +4464,6 @@ describe('Router integration', () => {
       view.unmount();
     }
   }, 20_000);
-
-  test('a redirect cycle that suspends before throwing stays bounded', async () => {
-    const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {
-      const path = rscPath === unstable_encodeRoutePath('/a') ? '/a' : '/b';
-      const next = path === '/a' ? '/b' : '/a';
-      const err = createCustomError('moved', { status: 307, location: next });
-      // the slot commits a fallback first, then throws once the gate resolves
-      let resolveGate: () => void = () => {};
-      const gate = new Promise<void>((resolve) => {
-        resolveGate = resolve;
-      });
-      setTimeout(() => resolveGate(), 0);
-      const Thrower = () => {
-        use(gate);
-        throw err;
-      };
-      return Promise.resolve({
-        [unstable_getRouteSlotId(path)]: (
-          <Suspense fallback={<div>loading</div>}>
-            <Thrower />
-          </Suspense>
-        ),
-        [ROUTE_ID]: [path, ''],
-        [IS_STATIC_ID]: false,
-      });
-    }) as unknown as ReturnType<typeof useRefetch>);
-    installRefetch(refetch);
-
-    const capture = { router: null as RouterApi | null };
-    const Probe = makeProbe(capture);
-    testHoisted.elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [ROUTE_ID]: ['/start', ''],
-      [IS_STATIC_ID]: false,
-    };
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-    const view = await renderApp(
-      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
-        <ErrorBoundary>
-          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
-        </ErrorBoundary>
-      </Unstable_SearchCodecsProvider>,
-    );
-    try {
-      await act(async () => {
-        await capture.router!.push('/a').catch(() => {});
-        for (let i = 0; i < 300; i += 1) {
-          await flush();
-        }
-      });
-      // the hop counter resets on a clean commit, and a slot that commits a
-      // fallback before throwing gives it one; the chain must still not run on
-      expect(refetch.mock.calls.length).toBeLessThanOrEqual(22);
-    } finally {
-      consoleErrorSpy.mockRestore();
-      view.unmount();
-    }
-  }, 60_000);
 
   test('a committing redirect cycle stops at the hop limit', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1636,6 +1636,50 @@ describe('Router integration', () => {
     }
   });
 
+  test('a server function response marks a static route as static', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+    installRefetch(refetch);
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/next')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+
+    const store = fetchRscStore as unknown as Record<string, unknown>;
+    const listeners = store.l as Set<
+      (elements: Record<string, unknown>) => void
+    >;
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: true });
+      }
+      await flush();
+    });
+    expect(capture.router?.path).toBe('/next');
+
+    await act(async () => {
+      await capture.router!.push('/start');
+      await flush();
+    });
+    refetch.mockClear();
+    await act(async () => {
+      await capture.router!.push('/next');
+      await flush();
+    });
+
+    // the response said /next is static, so going back to it needs no request
+    expect(refetch).not.toHaveBeenCalled();
+
+    view.unmount();
+  });
+
   test('a server function 404 keeps the attempted url', async () => {
     window.history.replaceState({}, '', '/start?a=1');
     const capture = { router: null as RouterApi | null };

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -5227,6 +5227,53 @@ describe('Router integration', () => {
     }
   });
 
+  test('one router follows the same revived error twice', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    // a module scoped error, or one revived from the cached elements, is the
+    // same object every time it is thrown
+    const RedirectErrorObject = createCustomError('redirect', {
+      status: 307,
+      location: '/login',
+    });
+    const ThrowRedirect = () => {
+      throw RedirectErrorObject;
+    };
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+    installRefetch(refetch);
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+        [unstable_getRouteSlotId('/login')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    await flush();
+    await flush();
+    expect(view.container.textContent).toContain('/login');
+
+    // back to the route that throws it, with the very same error object
+    refetch.mockResolvedValueOnce({
+      [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    });
+    await act(async () => {
+      await capture.router!.push('/start').catch(() => {});
+      for (let i = 0; i < 4; i += 1) {
+        await flush();
+      }
+    });
+
+    // the followed route renders again instead of a blank slot
+    expect(view.container.textContent).toContain('/login');
+
+    view.unmount();
+  });
+
   test('a protocol relative redirect is not treated as an app path', async () => {
     vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/docs/');
     try {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -130,6 +130,11 @@ const withRouteMeta = (
 type RootStore = {
   applySync: (data: Record<string, unknown>) => void;
   applyAsync: (data: Promise<Record<string, unknown>>) => void;
+  applySwr: (
+    result: Record<string, unknown>,
+    overlay: Record<string, unknown> | undefined,
+    pin: (key: string | symbol) => boolean,
+  ) => void;
 };
 type RefetchInner = ReturnType<typeof useRefetch>;
 type MockedRefetch = ReturnType<typeof vi.fn<RefetchInner>>;
@@ -229,6 +234,43 @@ vi.mock('../src/minimal/client.js', async () => {
     return result;
   };
 
+  // A pinned key keeps the previous value: the eager pass held it instead of
+  // leaving a hole, and minimal's second pass only refreshes new and overlay
+  // keys. That staleness is real and the router has to plan for it.
+  const chainSwrCache = new WeakMap<
+    object,
+    WeakMap<object, Promise<Record<string, unknown>>>
+  >();
+  const chainSwr = (
+    prev: Promise<Record<string, unknown>>,
+    result: Record<string, unknown>,
+    overlay: Record<string, unknown> | undefined,
+    pin: (key: string | symbol) => boolean,
+  ): Promise<Record<string, unknown>> => {
+    let byResult = chainSwrCache.get(prev);
+    if (!byResult) {
+      byResult = new WeakMap();
+      chainSwrCache.set(prev, byResult);
+    }
+    let merged = byResult.get(result);
+    if (!merged) {
+      merged = Promise.resolve(prev).then((prevRes) => {
+        const next = { ...prevRes };
+        for (const key of Reflect.ownKeys(result)) {
+          if (key === '_value') {
+            continue;
+          }
+          if (!(key in prevRes) || (overlay && key in overlay) || !pin(key)) {
+            next[key] = result[key];
+          }
+        }
+        return next;
+      });
+      byResult.set(result, merged);
+    }
+    return merged;
+  };
+
   // Each mocked Root provides its own store through this context, so a refetch
   // or merge from within a Root targets that Root's elements state.
   const StoreContext = React.createContext<RootStore | null>(null);
@@ -259,6 +301,11 @@ vi.mock('../src/minimal/client.js', async () => {
         // like the real client, so a transition stays pending across the fetch
         applyAsync: (dataPromise) => {
           setElements((prev) => chainMerge(prev, dataPromise));
+        },
+        // the swr response landing: minimal refreshes the keys the eager pass
+        // left as holes plus the overlay keys, and keeps the pinned ones
+        applySwr: (result, overlay, pin) => {
+          setElements((prev) => chainSwr(prev, result, overlay, pin));
         },
       };
     }
@@ -301,21 +348,22 @@ vi.mock('../src/minimal/client.js', async () => {
         const options = rest[1] as
           | {
               unstable_overlay?: Record<string, unknown>;
-              unstable_swr?: unknown;
+              unstable_swr?: { pin: (key: string | symbol) => boolean };
             }
           | undefined;
         const overlay = options?.unstable_overlay;
+        const swr = options?.unstable_swr;
         const dataPromise = Promise.resolve(
           testHoisted.inner!(rscPath, ...rest),
         ).then((result) => withRouteMeta(result, rscPath, rest[0]));
-        if (options?.unstable_swr) {
+        if (swr) {
           // like minimal's swr merge: the overlay lands right away and the
           // record keeps rendering while the response streams into its holes
           if (overlay) {
             store?.applySync(overlay);
           }
           dataPromise.then(
-            (result) => store?.applySync({ ...result, ...overlay }),
+            (result) => store?.applySwr(result, overlay, swr.pin),
             () => {},
           );
           return dataPromise;

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1788,6 +1788,40 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a followed redirect emits events for the attempt and the follow', async () => {
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { redirect: { from: '/moved', location: '/next' } },
+        { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/next'],
+    });
+    const events: string[] = [];
+    capture.router!.unstable_events.on('start', (route) =>
+      events.push(`start ${route.path}`),
+    );
+    capture.router!.unstable_events.on('complete', (route) =>
+      events.push(`complete ${route.path}`),
+    );
+
+    await act(async () => {
+      await router.push('/moved').catch(() => {});
+      for (let i = 0; i < 4; i += 1) {
+        await flush();
+      }
+    });
+
+    // the attempt reports its own fetch, then the follow reports the landing
+    expect(events).toEqual([
+      'start /moved',
+      'complete /moved',
+      'start /next',
+      'complete /next',
+    ]);
+
+    view.unmount();
+  });
+
   test('push performs refetch for dynamic routes and emits start/complete events', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4908,6 +4908,31 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('push resolves before the 404 follow it hands to the boundary', async () => {
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 404 } },
+        { resolve: { [ROUTE_ID]: ['/404', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/404'],
+      meta: { [HAS404_ID]: true },
+    });
+    let callsWhenSettled = 0;
+    const record = () => {
+      callsWhenSettled = refetch.mock.calls.length;
+    };
+    await act(async () => {
+      await router.push('/missing').then(record, record);
+      await flush();
+      await flush();
+    });
+    // the promise covers the route it was given, not the follow that comes after
+    expect(callsWhenSettled).toBe(1);
+    expect(refetch).toHaveBeenCalledTimes(2);
+    expect(capture.router!.path).toBe('/404');
+    view.unmount();
+  });
+
   test('a 404 follow fetches the 404 route with the attempted query', async () => {
     const { view, refetch, capture, router } = await renderFollowRouter({
       responses: [

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -194,6 +194,8 @@ vi.mock('react-server-dom-webpack/client', () => ({
   },
 }));
 
+// This hand models minimal's merge semantics; minimal-client.test.tsx holds
+// the tests that keep the model honest (see its overlay cases).
 vi.mock('../src/minimal/client.js', async () => {
   const actual = await vi.importActual<
     typeof import('../src/minimal/client.js')
@@ -722,8 +724,10 @@ describe('useRouter + Link with context', () => {
     expect(changeRoute).toHaveBeenNthCalledWith(
       2,
       { path: '/start', query: 'query=2', hash: '' },
-      expect.not.objectContaining({
-        history: 'push',
+      expect.objectContaining({
+        shouldScroll: false,
+        history: 'replace',
+        url: expect.any(URL),
       }),
     );
     expect(changeRoute).toHaveBeenNthCalledWith(
@@ -823,7 +827,7 @@ describe('useRouter + Link with context', () => {
     expect(changeRoute).toHaveBeenNthCalledWith(
       2,
       expectedRoute,
-      expect.not.objectContaining({ history: 'push' }),
+      expect.objectContaining({ history: 'replace', url: expect.any(URL) }),
     );
     const pushedUrl = (
       (changeRoute.mock.calls[0] as unknown[] | undefined)?.[1] as
@@ -1456,6 +1460,7 @@ describe('Slice', () => {
   });
 
   test('lazy slice fetches once, dedupes, and clears in-flight set on completion', async () => {
+    const fetchingSlices = new Set<string>();
     const view = await renderWithMinimalRoot(
       <RouterContext
         value={{
@@ -1463,7 +1468,7 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set<string>(),
+          fetchingSlices,
         }}
       >
         <>
@@ -1487,6 +1492,8 @@ describe('Slice', () => {
     expect(view.container.textContent).toContain('loading 2');
     expect(refetch).toHaveBeenCalledTimes(1);
     expect(refetch).toHaveBeenCalledWith(unstable_encodeSliceId('slice-1'));
+    // released when it settles, so the slice can be fetched again later
+    expect(fetchingSlices.size).toBe(0);
 
     view.unmount();
   });
@@ -1551,6 +1558,8 @@ describe('Slice', () => {
   });
 
   test('logs refetch failures and clears fetching set', async () => {
+    const fetchingSlices = new Set<string>();
+
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
     refetch.mockRejectedValueOnce(new Error('slice failed'));
@@ -1563,7 +1572,7 @@ describe('Slice', () => {
           changeRoute: vi.fn(async () => {}),
           prefetchRoute: vi.fn(),
           routeChangeEvents: { on: vi.fn(), off: vi.fn() },
-          fetchingSlices: new Set<string>(),
+          fetchingSlices,
         }}
       >
         <Slice id="slice-1" lazy fallback={<div>fallback</div>} />
@@ -1575,6 +1584,8 @@ describe('Slice', () => {
       'Failed to fetch slice:',
       expect.any(Error),
     );
+    // a failed fetch releases the id too, so a retry is possible
+    expect(fetchingSlices.size).toBe(0);
 
     view.unmount();
   });
@@ -3474,6 +3485,7 @@ describe('Router integration', () => {
     expect(window.location.pathname + window.location.search).toBe(
       '/start/?q=hello%20world',
     );
+    expect(getRefetchMock()).toHaveBeenCalledTimes(1);
 
     view.unmount();
   });
@@ -3942,6 +3954,7 @@ describe('Router integration', () => {
     expect(assignSpy).toHaveBeenCalledTimes(1);
     expect(assignSpy.mock.calls[0]![0]).toContain('/next');
     expect(capture.router!.path).toBe('/start');
+    expect(window.location.pathname).toBe('/start');
     assignSpy.mockRestore();
     view.unmount();
   });
@@ -4203,7 +4216,8 @@ describe('Router integration', () => {
     // the visible navigation is from /start, so the page scrolls even
     // though the redirect keeps the attempted pathname
     expect(capture.router.query).toBe('login=1');
-    expect(scrollToSpy).toHaveBeenCalled();
+    // twice: the attempted commit, then the follow
+    expect(scrollToSpy).toHaveBeenCalledTimes(2);
 
     scrollToSpy.mockRestore();
     view.unmount();
@@ -4440,7 +4454,8 @@ describe('Router integration', () => {
     });
 
     expect(capture.router.query).toBe('page=3');
-    expect(scrollToSpy).toHaveBeenCalled();
+    // twice: the attempted commit, then the follow
+    expect(scrollToSpy).toHaveBeenCalledTimes(2);
 
     scrollToSpy.mockRestore();
     view.unmount();
@@ -4591,6 +4606,7 @@ describe('Router integration', () => {
         }
       });
       expect(view.container.textContent).toContain('detected a redirect loop');
+      expect(refetch).toHaveBeenCalledTimes(1);
     } finally {
       consoleErrorSpy.mockRestore();
       view.unmount();
@@ -4645,6 +4661,8 @@ describe('Router integration', () => {
       expect(view.container.textContent).toContain(
         'too many redirect or 404 follows',
       );
+      // the per chain cap fires, not the per navigation budget
+      expect(refetch).toHaveBeenCalledTimes(21);
     } finally {
       consoleErrorSpy.mockRestore();
       view.unmount();
@@ -4695,6 +4713,8 @@ describe('Router integration', () => {
       expect(view.container.textContent).toContain(
         'too many redirect or 404 follows',
       );
+      // the per chain cap fires, not the per navigation budget
+      expect(refetch).toHaveBeenCalledTimes(21);
     } finally {
       consoleErrorSpy.mockRestore();
       view.unmount();
@@ -4760,7 +4780,8 @@ describe('Router integration', () => {
     // the visible navigation is /start -> /account/profile?login=1, so
     // the redirect scrolls even though it only changed the query
     expect(capture.router.query).toBe('login=1');
-    expect(scrollToSpy).toHaveBeenCalled();
+    // twice: the attempted commit, then the follow
+    expect(scrollToSpy).toHaveBeenCalledTimes(2);
 
     scrollToSpy.mockRestore();
     view.unmount();
@@ -4770,7 +4791,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const { view, capture, router } = await renderFollowRouter({
+    const { view, refetch, router } = await renderFollowRouter({
       responses: [
         { redirect: { from: '/a', location: '/start' } },
         { resolve: { [ROUTE_ID]: ['/start', ''], [IS_STATIC_ID]: false } },
@@ -4783,8 +4804,9 @@ describe('Router integration', () => {
       await flush();
       await flush();
     });
-    expect(capture.router!.path).toBe('/start');
-    expect(scrollToSpy).toHaveBeenCalled();
+    expect(view.container.textContent).toContain('/start|');
+    expect(refetch).toHaveBeenCalledTimes(2);
+    expect(scrollToSpy).toHaveBeenCalledTimes(2);
     scrollToSpy.mockRestore();
     view.unmount();
   });
@@ -4932,7 +4954,7 @@ describe('Router integration', () => {
     });
 
     // the second target differs from the first only by its hash
-    expect(view.container.textContent).not.toContain('follow target failed');
+    expect(view.container.textContent).toContain('/next|');
     expect(window.location.hash).toBe('#section');
 
     view.unmount();
@@ -6009,7 +6031,10 @@ describe('Router integration', () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
-    refetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    // the shape checkStatus gives a network failure
+    refetch.mockRejectedValueOnce(
+      createCustomError('Failed to fetch', { unstable_networkError: true }),
+    );
     installRefetch(refetch);
 
     testHoisted.elements = {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -298,12 +298,28 @@ vi.mock('../src/minimal/client.js', async () => {
         rscPath: string,
         ...rest: [rscParams?: unknown, options?: unknown]
       ) => {
-        const overlay = (
-          rest[1] as { unstable_overlay?: Record<string, unknown> } | undefined
-        )?.unstable_overlay;
+        const options = rest[1] as
+          | {
+              unstable_overlay?: Record<string, unknown>;
+              unstable_swr?: unknown;
+            }
+          | undefined;
+        const overlay = options?.unstable_overlay;
         const dataPromise = Promise.resolve(
           testHoisted.inner!(rscPath, ...rest),
         ).then((result) => withRouteMeta(result, rscPath, rest[0]));
+        if (options?.unstable_swr) {
+          // like minimal's swr merge: the overlay lands right away and the
+          // record keeps rendering while the response streams into its holes
+          if (overlay) {
+            store?.applySync(overlay);
+          }
+          dataPromise.then(
+            (result) => store?.applySync({ ...result, ...overlay }),
+            () => {},
+          );
+          return dataPromise;
+        }
         // like minimal's refetch: the overlay merges atomically on success
         store?.applyAsync(
           dataPromise.then(
@@ -2595,6 +2611,47 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('instant nav paints the target and writes the url before the response', async () => {
+    const pending = createDeferred<Record<string, unknown>>();
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(() => pending.promise);
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/next')]: <Probe />,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    let pushed: Promise<void> | undefined;
+    await act(async () => {
+      pushed = capture.router!.push('/next', { unstable_instant: true });
+      await flush();
+    });
+
+    expect(window.location.pathname).toBe('/next');
+    expect(capture.router?.path).toBe('/next');
+
+    await act(async () => {
+      pending.resolve({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: true });
+      await pushed;
+      await flush();
+    });
+
+    expect(window.location.pathname).toBe('/next');
+
+    view.unmount();
+  });
+
   test('instant nav adopts an in-flight prefetch as its data source', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
@@ -4390,6 +4447,51 @@ describe('Router integration', () => {
     // the address bar keeps the requested url as one new entry
     expect(window.location.pathname).toBe('/missing');
     expect(window.history.length).toBe(lengthBefore + 1);
+    view.unmount();
+  });
+
+  test('a follow into a known static route does not fetch it', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockResolvedValueOnce({ [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: false })
+      .mockImplementationOnce(() =>
+        Promise.reject(createCustomError('follow-error', { status: 404 })),
+      );
+    installRefetch(refetch);
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    // starting on a static /404 records it as static, so the follow below can
+    // serve it without a request
+    const view = await renderRouter(
+      { initialRoute: { path: '/404', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/404')]: <Probe />,
+        [unstable_getRouteSlotId('/a')]: <Probe />,
+        [ROUTE_ID]: ['/404', ''],
+        [IS_STATIC_ID]: true,
+        [HAS404_ID]: true,
+      },
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/a');
+      await flush();
+    });
+    await act(async () => {
+      await capture.router!.push('/missing').catch(() => {});
+      for (let i = 0; i < 4; i += 1) {
+        await flush();
+      }
+    });
+
+    // /a and the failed /missing; the follow serves the static /404
+    expect(refetch).toHaveBeenCalledTimes(2);
+    expect(capture.router.path).toBe('/404');
+    expect(window.location.pathname).toBe('/missing');
+
     view.unmount();
   });
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2744,6 +2744,45 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('an instant nav to a static route keeps the query', async () => {
+    // A static payload does not echo the query. The meta the eager pass pins
+    // is the route being left, so without a refresh the record would call this
+    // a server redirect and drop ?x=1 from the address bar.
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
+      [ROUTE_ID]: ['/next', ''],
+      [IS_STATIC_ID]: true,
+    }));
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/next')]: <Probe />,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    await act(async () => {
+      await capture.router!.push('/next?x=1', { unstable_instant: true });
+      await flush();
+      await flush();
+    });
+
+    expect(capture.router.path).toBe('/next');
+    expect(capture.router.query).toBe('x=1');
+    expect(window.location.pathname + window.location.search).toBe('/next?x=1');
+
+    view.unmount();
+  });
+
   test('an instant nav from a static route does not mark the target static', async () => {
     const pending = createDeferred<Record<string, unknown>>();
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -728,7 +728,12 @@ describe('useRouter + Link with context', () => {
     expect(changeRoute).toHaveBeenNthCalledWith(
       3,
       { path: '/start', query: '', hash: '' },
-      { shouldScroll: true, refetch: true, history: 'replace' },
+      {
+        shouldScroll: true,
+        refetch: true,
+        history: 'replace',
+        url: expect.any(URL),
+      },
     );
     const firstUrl = (
       (changeRoute.mock.calls[0] as unknown[] | undefined)?.[1] as
@@ -3344,6 +3349,34 @@ describe('Router integration', () => {
     );
     expect(capture.router?.path).toBe('/intercepted');
     expect(capture.router?.query).toBe('from=interceptor');
+
+    view.unmount();
+  });
+
+  test('reload leaves the url the browser has alone', async () => {
+    // the same round trip that popstate must not suffer: a trailing slash and
+    // a percent encoded space do not survive parseRoute + getRouteUrl
+    window.history.replaceState({}, '', '/start/?q=hello%20world');
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: 'q=hello+world', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [ROUTE_ID]: ['/start', 'q=hello+world'],
+        [IS_STATIC_ID]: false,
+      },
+    );
+
+    await act(async () => {
+      await capture.router!.reload();
+      await flush();
+    });
+
+    expect(window.location.pathname + window.location.search).toBe(
+      '/start/?q=hello%20world',
+    );
 
     view.unmount();
   });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { StrictMode, act, use, useState } from 'react';
+import { StrictMode, Suspense, act, use, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { preloadModule } from 'react-dom';
 import { createRoot } from 'react-dom/client';
@@ -4464,6 +4464,66 @@ describe('Router integration', () => {
       view.unmount();
     }
   }, 20_000);
+
+  test('a redirect cycle that suspends before throwing stays bounded', async () => {
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {
+      const path = rscPath === unstable_encodeRoutePath('/a') ? '/a' : '/b';
+      const next = path === '/a' ? '/b' : '/a';
+      const err = createCustomError('moved', { status: 307, location: next });
+      // the slot commits a fallback first, then throws once the gate resolves
+      let resolveGate: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        resolveGate = resolve;
+      });
+      setTimeout(() => resolveGate(), 0);
+      const Thrower = () => {
+        use(gate);
+        throw err;
+      };
+      return Promise.resolve({
+        [unstable_getRouteSlotId(path)]: (
+          <Suspense fallback={<div>loading</div>}>
+            <Thrower />
+          </Suspense>
+        ),
+        [ROUTE_ID]: [path, ''],
+        [IS_STATIC_ID]: false,
+      });
+    }) as unknown as ReturnType<typeof useRefetch>);
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <ErrorBoundary>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </ErrorBoundary>
+      </Unstable_SearchCodecsProvider>,
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/a').catch(() => {});
+        for (let i = 0; i < 300; i += 1) {
+          await flush();
+        }
+      });
+      // the hop counter resets on a clean commit, and a slot that commits a
+      // fallback before throwing gives it one; the chain must still not run on
+      expect(refetch.mock.calls.length).toBeLessThanOrEqual(22);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  }, 60_000);
 
   test('a committing redirect cycle stops at the hop limit', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2384,6 +2384,10 @@ describe('Router integration', () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
     refetch.mockRejectedValueOnce(new Error('refetch failed'));
     installRefetch(refetch);
+    // the probe finds nothing, so the failure stays in the app
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new TypeError('Failed to fetch'));
     const historyPushSpy = vi.spyOn(window.history, 'pushState');
 
     const elements = {
@@ -2422,6 +2426,7 @@ describe('Router integration', () => {
       );
     } finally {
       consoleErrorSpy.mockRestore();
+      fetchSpy.mockRestore();
       view.unmount();
     }
   });
@@ -5176,6 +5181,31 @@ describe('Router integration', () => {
     expect(assignSpy).toHaveBeenCalledTimes(1);
     expect(assignSpy.mock.calls[0]![0]).toContain('/protected');
     expect(capture.router!.path).toBe('/start');
+    assignSpy.mockRestore();
+    fetchSpy.mockRestore();
+    view.unmount();
+  });
+
+  test('a failure without a waku error also retries as a browser navigation', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(''));
+    const assignSpy = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => {});
+    const { view, refetch, router } = await renderFollowRouter({
+      responses: [],
+    });
+    // a payload the client could not decode carries no server status
+    refetch.mockImplementationOnce(() =>
+      Promise.reject(new Error('could not decode')),
+    );
+    await act(async () => {
+      await router.push('/protected').catch(() => {});
+      await flush();
+    });
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    expect(assignSpy.mock.calls[0]![0]).toContain('/protected');
     assignSpy.mockRestore();
     fetchSpy.mockRestore();
     view.unmount();

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -5227,6 +5227,106 @@ describe('Router integration', () => {
     }
   });
 
+  test('a redirect the client cannot follow surfaces instead of blanking', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const ThrowRedirectErrorObject = createCustomError('redirect', {
+      status: 307,
+      location: 'mailto:someone@example.com',
+    });
+    const ThrowRedirect = () => {
+      throw ThrowRedirectErrorObject;
+    };
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <ThrowRedirect />,
+      [unstable_getRouteSlotId('/next')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      </ErrorBoundary>,
+    );
+    try {
+      await flush();
+      await flush();
+
+      expect(view.container.textContent).toContain(
+        'cannot follow a redirect to mailto:someone@example.com',
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('a session of followed redirects does not exhaust the budget', async () => {
+    // the follow budget bounds one navigation, so a long session of ordinary
+    // redirects must not run it down
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {
+      if (rscPath !== unstable_encodeRoutePath('/moved')) {
+        return Promise.resolve({});
+      }
+      const err = createCustomError('moved', {
+        status: 307,
+        location: '/next',
+      });
+      const Thrower = () => {
+        throw err;
+      };
+      return Promise.resolve({
+        [unstable_getRouteSlotId('/moved')]: <Thrower />,
+        [ROUTE_ID]: ['/moved', ''],
+        [IS_STATIC_ID]: false,
+      });
+    }) as unknown as ReturnType<typeof useRefetch>);
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/next')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <ErrorBoundary>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </ErrorBoundary>
+      </Unstable_SearchCodecsProvider>,
+    );
+    try {
+      for (let i = 0; i < 110; i += 1) {
+        await act(async () => {
+          await capture.router!.push('/moved').catch(() => {});
+          await flush();
+          await flush();
+        });
+        await act(async () => {
+          await capture.router!.push('/start').catch(() => {});
+          await flush();
+        });
+      }
+
+      expect(view.container.textContent).not.toContain('too many redirect');
+      expect(capture.router!.path).toBe('/start');
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  }, 60_000);
+
   test('a redirect that only adds a hash is followed, not a loop', async () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2652,7 +2652,65 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('instant routerState adopts an in-flight prefetch as its data source', async () => {
+  test('an instant nav from a static route does not mark the target static', async () => {
+    const pending = createDeferred<Record<string, unknown>>();
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
+      [ROUTE_ID]: ['/next', ''],
+      [IS_STATIC_ID]: false,
+    }));
+    refetch.mockImplementationOnce(() => pending.promise);
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/next')]: <Probe />,
+      // the route being left is static, the instant target is not
+      [IS_STATIC_ID]: true,
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    if (!capture.router) {
+      throw new Error('router not initialized');
+    }
+
+    // the instant commit lands before the response: /next's route id sits next
+    // to /start's pinned static flag
+    let pushed: Promise<void> | undefined;
+    await act(async () => {
+      pushed = capture.router!.push('/next', { unstable_instant: true });
+      await flush();
+    });
+    await act(async () => {
+      pending.resolve({ [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false });
+      await pushed;
+      await flush();
+    });
+    await act(async () => {
+      await capture.router!.push('/start');
+      await flush();
+    });
+    refetch.mockClear();
+    await act(async () => {
+      await capture.router!.push('/next');
+      await flush();
+    });
+
+    expect(refetch).toHaveBeenCalledWith(
+      unstable_encodeRoutePath('/next'),
+      expect.any(URLSearchParams),
+      expect.anything(),
+    );
+
+    view.unmount();
+  });
+
+  test('instant nav adopts an in-flight prefetch as its data source', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/next', ''],
       [IS_STATIC_ID]: true,

--- a/packages/waku/tests/router-navigator.test.ts
+++ b/packages/waku/tests/router-navigator.test.ts
@@ -25,11 +25,7 @@ const urlOf = (path: string) => new URL(path, window.location.origin);
 const withNav = (
   elements: Record<string, unknown>,
   nav: ReturnType<typeof makeNavState>,
-): Record<string, unknown> => {
-  const next: Record<string, unknown> = { ...elements };
-  (next as Record<symbol, unknown>)[NAV_ID] = nav;
-  return next;
-};
+) => ({ ...elements, [NAV_ID]: nav });
 
 describe('makeNavState', () => {
   test('captures the url, the attempted route and the intents', () => {

--- a/packages/waku/tests/router-navigator.test.ts
+++ b/packages/waku/tests/router-navigator.test.ts
@@ -42,6 +42,7 @@ describe('makeNavState', () => {
     expect(nav.attempted).toEqual(['/a', 'x=1']);
     expect(nav.push).toBe(true);
     expect(nav.scroll).toEqual({ pathChanged: true });
+    expect(nav.scrollIntent).toBe(true);
   });
 
   test('no scroll intent when scrolling is off', () => {
@@ -51,6 +52,7 @@ describe('makeNavState', () => {
       pathChanged: true,
     });
     expect(nav.scroll).toBeNull();
+    expect(nav.scrollIntent).toBe(false);
   });
 });
 

--- a/packages/waku/tests/router-navigator.test.ts
+++ b/packages/waku/tests/router-navigator.test.ts
@@ -1,264 +1,138 @@
 /** @vitest-environment happy-dom */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { createCustomError } from '../src/lib/utils/custom-errors.js';
 import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import {
-  applyServerRedirect,
+  NAV_ID,
   canCommitInstantly,
-  deriveNav,
+  deriveCommitted,
+  getNavState,
+  makeNavState,
   pinForSwr,
-  resolveFollowingErrors,
 } from '../src/router/client-utils/navigate.js';
-import type { ResolveDeps } from '../src/router/client-utils/navigate.js';
-import { ROUTE_ID } from '../src/router/isomorphic-utils/route-path.js';
+import {
+  IS_STATIC_ID,
+  ROUTE_ID,
+} from '../src/router/isomorphic-utils/route-path.js';
 
 beforeEach(() => {
   vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
 });
 
-const route = (path: string, query = '') => ({ path, query, hash: '' });
-
-const makeDeps = (
-  responses: (
-    | { reject: { status: number; location?: string } }
-    | { resolve: Record<string, unknown> }
-  )[],
-  overrides?: Partial<ResolveDeps>,
-) => {
-  const fetchRoute = vi.fn<ResolveDeps['fetchRoute']>();
-  for (const response of responses) {
-    if ('reject' in response) {
-      fetchRoute.mockImplementationOnce(() =>
-        Promise.reject(createCustomError('follow-error', response.reject)),
-      );
-    } else {
-      fetchRoute.mockResolvedValueOnce(response.resolve);
-    }
-  }
-  const leaveApp = vi.fn();
-  const deps: ResolveDeps = {
-    fetchRoute,
-    isKnownStatic: () => false,
-    has404: true,
-    isAborted: () => false,
-    leaveApp,
-    ...overrides,
-  };
-  return { deps, fetchRoute, leaveApp };
-};
+const route = (path: string, query = '', hash = '') => ({ path, query, hash });
 
 const urlOf = (path: string) => new URL(path, window.location.origin);
 
-describe('navigator', () => {
-  test('resolves a redirect chain to its destination', async () => {
-    const { deps, fetchRoute } = makeDeps([
-      { reject: { status: 307, location: '/b' } },
-      { reject: { status: 307, location: '/c' } },
-      { resolve: { data: 'c' } },
-    ]);
-    const destination = await resolveFollowingErrors(
-      deps,
-      route('/a'),
-      urlOf('/a'),
-      route('/start'),
-      undefined,
-    );
-    expect(fetchRoute).toHaveBeenCalledTimes(3);
-    expect(destination?.route.path).toBe('/c');
-    expect(destination?.routeUrl.pathname).toBe('/c');
-  });
+const withNav = (
+  elements: Record<string, unknown>,
+  nav: ReturnType<typeof makeNavState>,
+): Record<string, unknown> => {
+  const next: Record<string, unknown> = { ...elements };
+  (next as Record<symbol, unknown>)[NAV_ID] = nav;
+  return next;
+};
 
-  test('a 404 keeps the attempted url while resolving the 404 route', async () => {
-    const { deps } = makeDeps([
-      { reject: { status: 404 } },
-      { resolve: { data: '404' } },
-    ]);
-    const destination = await resolveFollowingErrors(
-      deps,
-      route('/missing'),
-      urlOf('/missing'),
-      route('/start'),
-      undefined,
-    );
-    expect(destination?.route.path).toBe('/404');
-    expect(destination?.routeUrl.pathname).toBe('/missing');
-  });
-
-  test('a followed redirect back to the current route resolves without fetching', async () => {
-    const { deps, fetchRoute } = makeDeps([]);
-    const destination = await resolveFollowingErrors(
-      deps,
-      route('/foo'),
-      urlOf('/foo'),
-      route('/foo'),
-      createCustomError('redirect', { status: 307, location: '/foo' }),
-    );
-    expect(destination?.route.path).toBe('/foo');
-    expect(destination?.elements).toBeUndefined();
-    expect(fetchRoute).not.toHaveBeenCalled();
-  });
-
-  test('a followed chain returning to the current route resolves after one fetch', async () => {
-    const { deps, fetchRoute } = makeDeps([
-      { reject: { status: 307, location: '/foo' } },
-    ]);
-    const destination = await resolveFollowingErrors(
-      deps,
-      route('/foo'),
-      urlOf('/foo'),
-      route('/foo'),
-      createCustomError('redirect', { status: 307, location: '/bar' }),
-    );
-    expect(destination?.route.path).toBe('/foo');
-    expect(destination?.elements).toBeUndefined();
-    expect(fetchRoute).toHaveBeenCalledTimes(1);
-  });
-
-  test('a plain navigation may still resolve back to the current route', async () => {
-    const { deps, fetchRoute } = makeDeps([
-      { reject: { status: 307, location: '/current' } },
-    ]);
-    const destination = await resolveFollowingErrors(
-      deps,
-      route('/next'),
-      urlOf('/next'),
-      route('/current'),
-      undefined,
-    );
-    expect(destination?.route.path).toBe('/current');
-    expect(destination?.elements).toBeUndefined();
-    expect(fetchRoute).toHaveBeenCalledTimes(1);
-  });
-
-  test('a cycle stops at the hop limit with the cause attached', async () => {
-    const { deps, fetchRoute } = makeDeps([]);
-    fetchRoute.mockImplementation(() =>
-      Promise.reject(
-        createCustomError('follow-error', { status: 307, location: '/a' }),
-      ),
-    );
-    await expect(
-      resolveFollowingErrors(
-        deps,
-        route('/a'),
-        urlOf('/a'),
-        route('/start'),
-        undefined,
-      ),
-    ).rejects.toThrow('too many redirect or 404 follows');
-    expect(fetchRoute).toHaveBeenCalledTimes(21);
-  });
-
-  test('a known static follow target resolves without fetching', async () => {
-    const { deps, fetchRoute } = makeDeps(
-      [{ reject: { status: 307, location: '/static-page' } }],
-      { isKnownStatic: (path: string) => path === '/static-page' },
-    );
-    const destination = await resolveFollowingErrors(
-      deps,
-      route('/a'),
-      urlOf('/a'),
-      route('/start'),
-      undefined,
-    );
-    expect(fetchRoute).toHaveBeenCalledTimes(1);
-    expect(destination?.route.path).toBe('/static-page');
-    expect(destination?.elements).toBeUndefined();
-  });
-
-  test('a cross origin redirect leaves through the app, not directly', async () => {
-    const { deps, fetchRoute, leaveApp } = makeDeps([
-      { reject: { status: 307, location: 'https://auth.example.com/login' } },
-    ]);
-    const destination = await resolveFollowingErrors(
-      deps,
-      route('/protected'),
-      urlOf('/protected'),
-      route('/dashboard'),
-      undefined,
-    );
-    expect(destination).toBeUndefined();
-    expect(fetchRoute).toHaveBeenCalledTimes(1);
-    expect(leaveApp).toHaveBeenCalledWith(
-      new URL('https://auth.example.com/login'),
-    );
-  });
-});
-
-describe('deriveNav', () => {
-  const getServerRedirect = () => undefined;
-
-  test('a plain navigation keeps its history and scroll intent', () => {
-    const { route: derived, nav } = deriveNav({
-      destination: {
-        route: route('/next'),
-        routeUrl: urlOf('/next'),
-      },
-      attempted: route('/next'),
-      routeBefore: route('/start'),
-      history: 'push',
-      historyUrl: urlOf('/next'),
-      shouldScroll: true,
-      getServerRedirect,
+describe('makeNavState', () => {
+  test('captures the url, the attempted route and the intents', () => {
+    const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1#top'), {
+      push: true,
+      scroll: true,
+      pathChanged: true,
     });
-    expect(derived.path).toBe('/next');
-    expect(nav.history).toEqual({
-      mode: 'push',
-      url: urlOf('/next'),
-    });
+    expect(nav.url).toBe('/a?x=1#top');
+    expect(nav.attempted).toEqual(['/a', 'x=1']);
+    expect(nav.push).toBe(true);
     expect(nav.scroll).toEqual({ pathChanged: true });
   });
 
-  test('a followed navigation replaces the history url', () => {
-    const { nav } = deriveNav({
-      destination: {
-        route: route('/login'),
-        routeUrl: urlOf('/login'),
-      },
-      attempted: route('/protected'),
-      routeBefore: route('/start'),
-      history: 'push',
-      historyUrl: urlOf('/protected'),
-      shouldScroll: true,
-      getServerRedirect,
+  test('no scroll intent when scrolling is off', () => {
+    const nav = makeNavState(route('/a'), urlOf('/a'), {
+      push: false,
+      scroll: false,
+      pathChanged: true,
     });
-    expect(nav.history?.url?.pathname).toBe('/login');
-  });
-
-  test('a server side redirect keeps a replace intent', () => {
-    const { nav } = deriveNav({
-      destination: {
-        route: route('/login'),
-        routeUrl: urlOf('/login'),
-        elements: {},
-      },
-      attempted: route('/login'),
-      routeBefore: route('/start'),
-      history: 'replace',
-      historyUrl: urlOf('/login'),
-      shouldScroll: false,
-      getServerRedirect: () => route('/dashboard'),
-    });
-    expect(nav.history?.mode).toBe('replace');
-  });
-
-  test('a server side redirect to the 404 route drops the history write', () => {
-    const { route: derived, nav } = deriveNav({
-      destination: {
-        route: route('/somewhere'),
-        routeUrl: urlOf('/somewhere'),
-        elements: {},
-      },
-      attempted: route('/somewhere'),
-      routeBefore: route('/start'),
-      history: 'push',
-      historyUrl: urlOf('/somewhere'),
-      shouldScroll: false,
-      getServerRedirect: () => route('/404'),
-    });
-    expect(derived.path).toBe('/404');
-    expect(nav.history).toBeNull();
     expect(nav.scroll).toBeNull();
+  });
+});
+
+describe('deriveCommitted', () => {
+  test('falls back to the given route without nav state', () => {
+    const {
+      route: derived,
+      nav,
+      url,
+    } = deriveCommitted({ [ROUTE_ID]: ['/a', ''] }, route('/fallback'));
+    expect(derived).toEqual(route('/fallback'));
+    expect(nav).toBeUndefined();
+    expect(url).toBeUndefined();
+  });
+
+  test('path from the elements, query and hash from the nav url', () => {
+    const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1#top'), {
+      push: false,
+      scroll: false,
+      pathChanged: false,
+    });
+    const elements = withNav({ [ROUTE_ID]: ['/a', 'x=1'] }, nav);
+    const { route: derived, url } = deriveCommitted(elements, route('/f'));
+    expect(derived).toEqual(route('/a', 'x=1', '#top'));
+    expect(url?.pathname).toBe('/a');
+    expect(getNavState(elements)).toBe(nav);
+  });
+
+  test('a static response does not echo the query; the nav url keeps it', () => {
+    const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1'), {
+      push: false,
+      scroll: false,
+      pathChanged: false,
+    });
+    const elements = withNav(
+      { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true },
+      nav,
+    );
+    const { route: derived, url } = deriveCommitted(elements, route('/f'));
+    expect(derived.query).toBe('x=1');
+    expect(url?.search).toBe('?x=1');
+  });
+
+  test('a server redirect moves the route and the url', () => {
+    const nav = makeNavState(route('/a'), urlOf('/a'), {
+      push: true,
+      scroll: false,
+      pathChanged: true,
+    });
+    const elements = withNav({ [ROUTE_ID]: ['/b', 'y=2'] }, nav);
+    const { route: derived, url } = deriveCommitted(elements, route('/f'));
+    expect(derived).toEqual(route('/b', 'y=2'));
+    expect(url?.pathname).toBe('/b');
+    expect(url?.search).toBe('?y=2');
+  });
+
+  test('a server redirect keeps the base path in the url', () => {
+    vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/docs/');
+    try {
+      const nav = makeNavState(route('/a'), urlOf('/docs/a'), {
+        push: false,
+        scroll: false,
+        pathChanged: false,
+      });
+      const elements = withNav({ [ROUTE_ID]: ['/b', ''] }, nav);
+      const { url } = deriveCommitted(elements, route('/f'));
+      expect(url?.pathname).toBe('/docs/b');
+    } finally {
+      vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
+    }
+  });
+
+  test('a server redirect to the 404 route keeps the attempted url', () => {
+    const nav = makeNavState(route('/missing'), urlOf('/missing'), {
+      push: false,
+      scroll: false,
+      pathChanged: true,
+    });
+    const elements = withNav({ [ROUTE_ID]: ['/404', ''] }, nav);
+    const { route: derived, url } = deriveCommitted(elements, route('/f'));
+    expect(derived.path).toBe('/404');
+    expect(url?.pathname).toBe('/missing');
   });
 });
 
@@ -308,27 +182,5 @@ describe('pinForSwr', () => {
     expect(pin('layout:/')).toBe(false);
     resolved = immutable('layout:/');
     expect(pin('layout:/')).toBe(true);
-  });
-});
-
-describe('applyServerRedirect', () => {
-  const prev = {
-    query: '',
-    hash: '',
-    history: { mode: 'push', url: undefined },
-    scroll: { pathChanged: true },
-  } as const;
-
-  test('replaces history with the redirect url and keeps the scroll intent', () => {
-    const next = applyServerRedirect(prev, route('/b', 'x=1'));
-    expect(next.query).toBe('x=1');
-    expect(next.history?.mode).toBe('replace');
-    expect(next.history?.url?.pathname).toBe('/b');
-    expect(next.scroll).toEqual({ pathChanged: true });
-  });
-
-  test('drops the history write for the 404 route', () => {
-    const next = applyServerRedirect(prev, route('/404'));
-    expect(next.history).toBeNull();
   });
 });

--- a/packages/waku/tests/router-navigator.test.ts
+++ b/packages/waku/tests/router-navigator.test.ts
@@ -30,20 +30,20 @@ const withNav = (
 describe('makeNavState', () => {
   test('captures the url, the attempted route and the intents', () => {
     const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1#top'), {
-      push: true,
+      history: 'push',
       scroll: true,
       pathChanged: true,
     });
     expect(nav.url).toBe('/a?x=1#top');
     expect(nav.attempted).toEqual(['/a', 'x=1']);
-    expect(nav.push).toBe(true);
+    expect(nav.history).toBe('push');
     expect(nav.scroll).toEqual({ pathChanged: true });
     expect(nav.scrollIntent).toBe(true);
   });
 
   test('no scroll intent when scrolling is off', () => {
     const nav = makeNavState(route('/a'), urlOf('/a'), {
-      push: false,
+      history: 'replace',
       scroll: false,
       pathChanged: true,
     });
@@ -66,7 +66,7 @@ describe('deriveCommitted', () => {
 
   test('path from the elements, query and hash from the nav url', () => {
     const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1#top'), {
-      push: false,
+      history: 'replace',
       scroll: false,
       pathChanged: false,
     });
@@ -79,7 +79,7 @@ describe('deriveCommitted', () => {
 
   test('a static response does not echo the query; the nav url keeps it', () => {
     const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1'), {
-      push: false,
+      history: 'replace',
       scroll: false,
       pathChanged: false,
     });
@@ -94,7 +94,7 @@ describe('deriveCommitted', () => {
 
   test('a server redirect moves the route and the url', () => {
     const nav = makeNavState(route('/a'), urlOf('/a'), {
-      push: true,
+      history: 'push',
       scroll: false,
       pathChanged: true,
     });
@@ -109,7 +109,7 @@ describe('deriveCommitted', () => {
     vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/docs/');
     try {
       const nav = makeNavState(route('/a'), urlOf('/docs/a'), {
-        push: false,
+        history: 'replace',
         scroll: false,
         pathChanged: false,
       });
@@ -123,7 +123,7 @@ describe('deriveCommitted', () => {
 
   test('a server redirect to the 404 route keeps the attempted url', () => {
     const nav = makeNavState(route('/missing'), urlOf('/missing'), {
-      push: false,
+      history: 'replace',
       scroll: false,
       pathChanged: true,
     });

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -4,7 +4,7 @@ import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import {
   ROUTER_STATE_ID,
   canCommitInstantly,
-  getCommittedRoute,
+  getCommitted,
   getRouterState,
   makeRouterState,
   pinForSwr,
@@ -56,9 +56,9 @@ describe('makeRouterState', () => {
   });
 });
 
-describe('getCommittedRoute', () => {
+describe('getCommitted', () => {
   test('commits nothing until the client has navigated', () => {
-    expect(getCommittedRoute({ [ROUTE_ID]: ['/a', ''] }, '/fallback')).toBe(
+    expect(getCommitted({ [ROUTE_ID]: ['/a', ''] }, '/fallback')).toBe(
       undefined,
     );
   });
@@ -77,7 +77,7 @@ describe('getCommittedRoute', () => {
       { [ROUTE_ID]: ['/a', 'x=1'] },
       routerState,
     );
-    const { route: committedRoute, url } = getCommittedRoute(elements, '/f')!;
+    const { route: committedRoute, url } = getCommitted(elements, '/f')!;
     expect(committedRoute).toEqual(route('/a', 'x=1', '#top'));
     expect(url.pathname).toBe('/a');
     expect(getRouterState(elements)).toBe(routerState);
@@ -93,7 +93,7 @@ describe('getCommittedRoute', () => {
       { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true },
       routerState,
     );
-    const { route: committedRoute, url } = getCommittedRoute(elements, '/f')!;
+    const { route: committedRoute, url } = getCommitted(elements, '/f')!;
     expect(committedRoute.query).toBe('x=1');
     expect(url.search).toBe('?x=1');
   });
@@ -108,7 +108,7 @@ describe('getCommittedRoute', () => {
       { [ROUTE_ID]: ['/b', 'y=2'] },
       routerState,
     );
-    const { route: committedRoute, url } = getCommittedRoute(elements, '/f')!;
+    const { route: committedRoute, url } = getCommitted(elements, '/f')!;
     expect(committedRoute).toEqual(route('/b', 'y=2'));
     expect(url.pathname).toBe('/b');
     expect(url.search).toBe('?y=2');
@@ -123,7 +123,7 @@ describe('getCommittedRoute', () => {
         pathChanged: false,
       });
       const elements = withRouterState({ [ROUTE_ID]: ['/b', ''] }, routerState);
-      const { url } = getCommittedRoute(elements, '/f')!;
+      const { url } = getCommitted(elements, '/f')!;
       expect(url.pathname).toBe('/docs/b');
     } finally {
       vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
@@ -137,7 +137,7 @@ describe('getCommittedRoute', () => {
       pathChanged: true,
     });
     const elements = withRouterState({ [ROUTE_ID]: ['/404', ''] }, routerState);
-    const { route: committedRoute, url } = getCommittedRoute(elements, '/f')!;
+    const { route: committedRoute, url } = getCommitted(elements, '/f')!;
     expect(committedRoute.path).toBe('/404');
     expect(url.pathname).toBe('/missing');
   });

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -67,6 +67,24 @@ describe('getRouterState', () => {
 });
 
 describe('resolveServerRedirect', () => {
+  test('a failed navigation reads no redirect from the stale route id', () => {
+    const attempt = makeRouterState(route('/missing'), urlOf('/missing'), {
+      history: 'push',
+      scroll: true,
+      pathChanged: true,
+    });
+    const elements = { [ROUTE_ID]: ['/a', ''] };
+
+    // the record still holds the route the client came from
+    expect(resolveServerRedirect(elements, attempt, '/f').url.pathname).toBe(
+      '/a',
+    );
+    expect(
+      resolveServerRedirect(elements, { ...attempt, failed: true }, '/f').url
+        .pathname,
+    ).toBe('/missing');
+  });
+
   test('path from the elements, query and hash from the routerState url', () => {
     const routerState = makeRouterState(
       route('/a', 'x=1'),
@@ -189,6 +207,8 @@ describe('pinForSwr', () => {
   test('pins meta keys and immutable slots, not mutable ones', () => {
     const pin = pinForSwr(() => immutable('layout:/'));
     expect(pin(ROUTE_ID)).toBe(true);
+    // the client's own state rides the merge instead of becoming a hole
+    expect(pin(ROUTER_STATE_ID)).toBe(true);
     expect(pin('layout:/')).toBe(true);
     expect(pin('page:/a')).toBe(false);
   });

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -4,10 +4,10 @@ import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import {
   ROUTER_STATE_ID,
   canCommitInstantly,
-  getCommitted,
   getRouterState,
   makeRouterState,
   pinForSwr,
+  resolveCommitted,
 } from '../src/router/client-utils/router-state.js';
 import {
   IS_STATIC_ID,
@@ -56,13 +56,19 @@ describe('makeRouterState', () => {
   });
 });
 
-describe('getCommitted', () => {
-  test('commits nothing until the client has navigated', () => {
-    expect(getCommitted({ [ROUTE_ID]: ['/a', ''] }, '/fallback')).toBe(
-      undefined,
-    );
+describe('getRouterState', () => {
+  test('reads the state the record carries under the symbol', () => {
+    const routerState = makeRouterState(route('/a'), urlOf('/a'), {
+      history: 'push',
+      scroll: false,
+      pathChanged: false,
+    });
+    expect(getRouterState(withRouterState({}, routerState))).toBe(routerState);
+    expect(getRouterState({})).toBeUndefined();
   });
+});
 
+describe('resolveCommitted', () => {
   test('path from the elements, query and hash from the routerState url', () => {
     const routerState = makeRouterState(
       route('/a', 'x=1'),
@@ -73,14 +79,14 @@ describe('getCommitted', () => {
         pathChanged: false,
       },
     );
-    const elements = withRouterState(
-      { [ROUTE_ID]: ['/a', 'x=1'] },
+    const elements = { [ROUTE_ID]: ['/a', 'x=1'] };
+    const { route: committedRoute, url } = resolveCommitted(
+      elements,
       routerState,
+      '/f',
     );
-    const { route: committedRoute, url } = getCommitted(elements, '/f')!;
     expect(committedRoute).toEqual(route('/a', 'x=1', '#top'));
     expect(url.pathname).toBe('/a');
-    expect(getRouterState(elements)).toBe(routerState);
   });
 
   test('a static response does not echo the query; the routerState url keeps it', () => {
@@ -89,11 +95,12 @@ describe('getCommitted', () => {
       scroll: false,
       pathChanged: false,
     });
-    const elements = withRouterState(
-      { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true },
+    const elements = { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true };
+    const { route: committedRoute, url } = resolveCommitted(
+      elements,
       routerState,
+      '/f',
     );
-    const { route: committedRoute, url } = getCommitted(elements, '/f')!;
     expect(committedRoute.query).toBe('x=1');
     expect(url.search).toBe('?x=1');
   });
@@ -104,11 +111,12 @@ describe('getCommitted', () => {
       scroll: false,
       pathChanged: true,
     });
-    const elements = withRouterState(
-      { [ROUTE_ID]: ['/b', 'y=2'] },
+    const elements = { [ROUTE_ID]: ['/b', 'y=2'] };
+    const { route: committedRoute, url } = resolveCommitted(
+      elements,
       routerState,
+      '/f',
     );
-    const { route: committedRoute, url } = getCommitted(elements, '/f')!;
     expect(committedRoute).toEqual(route('/b', 'y=2'));
     expect(url.pathname).toBe('/b');
     expect(url.search).toBe('?y=2');
@@ -122,8 +130,8 @@ describe('getCommitted', () => {
         scroll: false,
         pathChanged: false,
       });
-      const elements = withRouterState({ [ROUTE_ID]: ['/b', ''] }, routerState);
-      const { url } = getCommitted(elements, '/f')!;
+      const elements = { [ROUTE_ID]: ['/b', ''] };
+      const { url } = resolveCommitted(elements, routerState, '/f');
       expect(url.pathname).toBe('/docs/b');
     } finally {
       vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
@@ -136,8 +144,12 @@ describe('getCommitted', () => {
       scroll: false,
       pathChanged: true,
     });
-    const elements = withRouterState({ [ROUTE_ID]: ['/404', ''] }, routerState);
-    const { route: committedRoute, url } = getCommitted(elements, '/f')!;
+    const elements = { [ROUTE_ID]: ['/404', ''] };
+    const { route: committedRoute, url } = resolveCommitted(
+      elements,
+      routerState,
+      '/f',
+    );
     expect(committedRoute.path).toBe('/404');
     expect(url.pathname).toBe('/missing');
   });

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -4,7 +4,7 @@ import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import {
   ROUTER_STATE_ID,
   canCommitInstantly,
-  deriveCommitted,
+  getCommittedRoute,
   getRouterState,
   makeRouterState,
   pinForSwr,
@@ -56,16 +56,11 @@ describe('makeRouterState', () => {
   });
 });
 
-describe('deriveCommitted', () => {
-  test('falls back to the given route without routerState state', () => {
-    const {
-      route: derived,
-      routerState,
-      url,
-    } = deriveCommitted({ [ROUTE_ID]: ['/a', ''] }, route('/fallback'));
-    expect(derived).toEqual(route('/fallback'));
-    expect(routerState).toBeUndefined();
-    expect(url).toBeUndefined();
+describe('getCommittedRoute', () => {
+  test('commits nothing until the client has navigated', () => {
+    expect(getCommittedRoute({ [ROUTE_ID]: ['/a', ''] }, '/fallback')).toBe(
+      undefined,
+    );
   });
 
   test('path from the elements, query and hash from the routerState url', () => {
@@ -82,9 +77,9 @@ describe('deriveCommitted', () => {
       { [ROUTE_ID]: ['/a', 'x=1'] },
       routerState,
     );
-    const { route: derived, url } = deriveCommitted(elements, route('/f'));
-    expect(derived).toEqual(route('/a', 'x=1', '#top'));
-    expect(url?.pathname).toBe('/a');
+    const { route: committedRoute, url } = getCommittedRoute(elements, '/f')!;
+    expect(committedRoute).toEqual(route('/a', 'x=1', '#top'));
+    expect(url.pathname).toBe('/a');
     expect(getRouterState(elements)).toBe(routerState);
   });
 
@@ -98,9 +93,9 @@ describe('deriveCommitted', () => {
       { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true },
       routerState,
     );
-    const { route: derived, url } = deriveCommitted(elements, route('/f'));
-    expect(derived.query).toBe('x=1');
-    expect(url?.search).toBe('?x=1');
+    const { route: committedRoute, url } = getCommittedRoute(elements, '/f')!;
+    expect(committedRoute.query).toBe('x=1');
+    expect(url.search).toBe('?x=1');
   });
 
   test('a server redirect moves the route and the url', () => {
@@ -113,10 +108,10 @@ describe('deriveCommitted', () => {
       { [ROUTE_ID]: ['/b', 'y=2'] },
       routerState,
     );
-    const { route: derived, url } = deriveCommitted(elements, route('/f'));
-    expect(derived).toEqual(route('/b', 'y=2'));
-    expect(url?.pathname).toBe('/b');
-    expect(url?.search).toBe('?y=2');
+    const { route: committedRoute, url } = getCommittedRoute(elements, '/f')!;
+    expect(committedRoute).toEqual(route('/b', 'y=2'));
+    expect(url.pathname).toBe('/b');
+    expect(url.search).toBe('?y=2');
   });
 
   test('a server redirect keeps the base path in the url', () => {
@@ -128,8 +123,8 @@ describe('deriveCommitted', () => {
         pathChanged: false,
       });
       const elements = withRouterState({ [ROUTE_ID]: ['/b', ''] }, routerState);
-      const { url } = deriveCommitted(elements, route('/f'));
-      expect(url?.pathname).toBe('/docs/b');
+      const { url } = getCommittedRoute(elements, '/f')!;
+      expect(url.pathname).toBe('/docs/b');
     } finally {
       vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
     }
@@ -142,9 +137,9 @@ describe('deriveCommitted', () => {
       pathChanged: true,
     });
     const elements = withRouterState({ [ROUTE_ID]: ['/404', ''] }, routerState);
-    const { route: derived, url } = deriveCommitted(elements, route('/f'));
-    expect(derived.path).toBe('/404');
-    expect(url?.pathname).toBe('/missing');
+    const { route: committedRoute, url } = getCommittedRoute(elements, '/f')!;
+    expect(committedRoute.path).toBe('/404');
+    expect(url.pathname).toBe('/missing');
   });
 });
 

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -42,7 +42,6 @@ describe('makeRouterState', () => {
     expect(routerState.attempted).toEqual(['/a', 'x=1']);
     expect(routerState.history).toBe('push');
     expect(routerState.scroll).toEqual({ pathChanged: true });
-    expect(routerState.scrollIntent).toBe(true);
   });
 
   test('no scroll intent when scrolling is off', () => {
@@ -52,7 +51,6 @@ describe('makeRouterState', () => {
       pathChanged: true,
     });
     expect(routerState.scroll).toBeNull();
-    expect(routerState.scrollIntent).toBe(false);
   });
 });
 

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -2,13 +2,13 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import {
-  NAV_ID,
+  ROUTER_STATE_ID,
   canCommitInstantly,
   deriveCommitted,
-  getNavState,
-  makeNavState,
+  getRouterState,
+  makeRouterState,
   pinForSwr,
-} from '../src/router/client-utils/navigate.js';
+} from '../src/router/client-utils/router-state.js';
 import {
   IS_STATIC_ID,
   ROUTE_ID,
@@ -22,70 +22,81 @@ const route = (path: string, query = '', hash = '') => ({ path, query, hash });
 
 const urlOf = (path: string) => new URL(path, window.location.origin);
 
-const withNav = (
+const withRouterState = (
   elements: Record<string, unknown>,
-  nav: ReturnType<typeof makeNavState>,
-) => ({ ...elements, [NAV_ID]: nav });
+  routerState: ReturnType<typeof makeRouterState>,
+) => ({ ...elements, [ROUTER_STATE_ID]: routerState });
 
-describe('makeNavState', () => {
+describe('makeRouterState', () => {
   test('captures the url, the attempted route and the intents', () => {
-    const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1#top'), {
-      history: 'push',
-      scroll: true,
-      pathChanged: true,
-    });
-    expect(nav.url).toBe('/a?x=1#top');
-    expect(nav.attempted).toEqual(['/a', 'x=1']);
-    expect(nav.history).toBe('push');
-    expect(nav.scroll).toEqual({ pathChanged: true });
-    expect(nav.scrollIntent).toBe(true);
+    const routerState = makeRouterState(
+      route('/a', 'x=1'),
+      urlOf('/a?x=1#top'),
+      {
+        history: 'push',
+        scroll: true,
+        pathChanged: true,
+      },
+    );
+    expect(routerState.url).toBe('/a?x=1#top');
+    expect(routerState.attempted).toEqual(['/a', 'x=1']);
+    expect(routerState.history).toBe('push');
+    expect(routerState.scroll).toEqual({ pathChanged: true });
+    expect(routerState.scrollIntent).toBe(true);
   });
 
   test('no scroll intent when scrolling is off', () => {
-    const nav = makeNavState(route('/a'), urlOf('/a'), {
+    const routerState = makeRouterState(route('/a'), urlOf('/a'), {
       history: 'replace',
       scroll: false,
       pathChanged: true,
     });
-    expect(nav.scroll).toBeNull();
-    expect(nav.scrollIntent).toBe(false);
+    expect(routerState.scroll).toBeNull();
+    expect(routerState.scrollIntent).toBe(false);
   });
 });
 
 describe('deriveCommitted', () => {
-  test('falls back to the given route without nav state', () => {
+  test('falls back to the given route without routerState state', () => {
     const {
       route: derived,
-      nav,
+      routerState,
       url,
     } = deriveCommitted({ [ROUTE_ID]: ['/a', ''] }, route('/fallback'));
     expect(derived).toEqual(route('/fallback'));
-    expect(nav).toBeUndefined();
+    expect(routerState).toBeUndefined();
     expect(url).toBeUndefined();
   });
 
-  test('path from the elements, query and hash from the nav url', () => {
-    const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1#top'), {
-      history: 'replace',
-      scroll: false,
-      pathChanged: false,
-    });
-    const elements = withNav({ [ROUTE_ID]: ['/a', 'x=1'] }, nav);
+  test('path from the elements, query and hash from the routerState url', () => {
+    const routerState = makeRouterState(
+      route('/a', 'x=1'),
+      urlOf('/a?x=1#top'),
+      {
+        history: 'replace',
+        scroll: false,
+        pathChanged: false,
+      },
+    );
+    const elements = withRouterState(
+      { [ROUTE_ID]: ['/a', 'x=1'] },
+      routerState,
+    );
     const { route: derived, url } = deriveCommitted(elements, route('/f'));
     expect(derived).toEqual(route('/a', 'x=1', '#top'));
     expect(url?.pathname).toBe('/a');
-    expect(getNavState(elements)).toBe(nav);
+    expect(getRouterState(elements)).toBe(routerState);
   });
 
-  test('a static response does not echo the query; the nav url keeps it', () => {
-    const nav = makeNavState(route('/a', 'x=1'), urlOf('/a?x=1'), {
+  test('a static response does not echo the query; the routerState url keeps it', () => {
+    const routerState = makeRouterState(route('/a', 'x=1'), urlOf('/a?x=1'), {
       history: 'replace',
       scroll: false,
       pathChanged: false,
     });
-    const elements = withNav(
+    const elements = withRouterState(
       { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true },
-      nav,
+      routerState,
     );
     const { route: derived, url } = deriveCommitted(elements, route('/f'));
     expect(derived.query).toBe('x=1');
@@ -93,12 +104,15 @@ describe('deriveCommitted', () => {
   });
 
   test('a server redirect moves the route and the url', () => {
-    const nav = makeNavState(route('/a'), urlOf('/a'), {
+    const routerState = makeRouterState(route('/a'), urlOf('/a'), {
       history: 'push',
       scroll: false,
       pathChanged: true,
     });
-    const elements = withNav({ [ROUTE_ID]: ['/b', 'y=2'] }, nav);
+    const elements = withRouterState(
+      { [ROUTE_ID]: ['/b', 'y=2'] },
+      routerState,
+    );
     const { route: derived, url } = deriveCommitted(elements, route('/f'));
     expect(derived).toEqual(route('/b', 'y=2'));
     expect(url?.pathname).toBe('/b');
@@ -108,12 +122,12 @@ describe('deriveCommitted', () => {
   test('a server redirect keeps the base path in the url', () => {
     vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/docs/');
     try {
-      const nav = makeNavState(route('/a'), urlOf('/docs/a'), {
+      const routerState = makeRouterState(route('/a'), urlOf('/docs/a'), {
         history: 'replace',
         scroll: false,
         pathChanged: false,
       });
-      const elements = withNav({ [ROUTE_ID]: ['/b', ''] }, nav);
+      const elements = withRouterState({ [ROUTE_ID]: ['/b', ''] }, routerState);
       const { url } = deriveCommitted(elements, route('/f'));
       expect(url?.pathname).toBe('/docs/b');
     } finally {
@@ -122,12 +136,12 @@ describe('deriveCommitted', () => {
   });
 
   test('a server redirect to the 404 route keeps the attempted url', () => {
-    const nav = makeNavState(route('/missing'), urlOf('/missing'), {
+    const routerState = makeRouterState(route('/missing'), urlOf('/missing'), {
       history: 'replace',
       scroll: false,
       pathChanged: true,
     });
-    const elements = withNav({ [ROUTE_ID]: ['/404', ''] }, nav);
+    const elements = withRouterState({ [ROUTE_ID]: ['/404', ''] }, routerState);
     const { route: derived, url } = deriveCommitted(elements, route('/f'));
     expect(derived.path).toBe('/404');
     expect(url?.pathname).toBe('/missing');

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -7,7 +7,7 @@ import {
   getRouterState,
   makeRouterState,
   pinForSwr,
-  resolveCommitted,
+  resolveServerRedirect,
 } from '../src/router/client-utils/router-state.js';
 import {
   IS_STATIC_ID,
@@ -68,7 +68,7 @@ describe('getRouterState', () => {
   });
 });
 
-describe('resolveCommitted', () => {
+describe('resolveServerRedirect', () => {
   test('path from the elements, query and hash from the routerState url', () => {
     const routerState = makeRouterState(
       route('/a', 'x=1'),
@@ -80,12 +80,12 @@ describe('resolveCommitted', () => {
       },
     );
     const elements = { [ROUTE_ID]: ['/a', 'x=1'] };
-    const { route: committedRoute, url } = resolveCommitted(
+    const { route: resolvedRoute, url } = resolveServerRedirect(
       elements,
       routerState,
       '/f',
     );
-    expect(committedRoute).toEqual(route('/a', 'x=1', '#top'));
+    expect(resolvedRoute).toEqual(route('/a', 'x=1', '#top'));
     expect(url.pathname).toBe('/a');
   });
 
@@ -96,12 +96,12 @@ describe('resolveCommitted', () => {
       pathChanged: false,
     });
     const elements = { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true };
-    const { route: committedRoute, url } = resolveCommitted(
+    const { route: resolvedRoute, url } = resolveServerRedirect(
       elements,
       routerState,
       '/f',
     );
-    expect(committedRoute.query).toBe('x=1');
+    expect(resolvedRoute.query).toBe('x=1');
     expect(url.search).toBe('?x=1');
   });
 
@@ -112,12 +112,12 @@ describe('resolveCommitted', () => {
       pathChanged: true,
     });
     const elements = { [ROUTE_ID]: ['/b', 'y=2'] };
-    const { route: committedRoute, url } = resolveCommitted(
+    const { route: resolvedRoute, url } = resolveServerRedirect(
       elements,
       routerState,
       '/f',
     );
-    expect(committedRoute).toEqual(route('/b', 'y=2'));
+    expect(resolvedRoute).toEqual(route('/b', 'y=2'));
     expect(url.pathname).toBe('/b');
     expect(url.search).toBe('?y=2');
   });
@@ -131,7 +131,7 @@ describe('resolveCommitted', () => {
         pathChanged: false,
       });
       const elements = { [ROUTE_ID]: ['/b', ''] };
-      const { url } = resolveCommitted(elements, routerState, '/f');
+      const { url } = resolveServerRedirect(elements, routerState, '/f');
       expect(url.pathname).toBe('/docs/b');
     } finally {
       vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
@@ -145,12 +145,12 @@ describe('resolveCommitted', () => {
       pathChanged: true,
     });
     const elements = { [ROUTE_ID]: ['/404', ''] };
-    const { route: committedRoute, url } = resolveCommitted(
+    const { route: resolvedRoute, url } = resolveServerRedirect(
       elements,
       routerState,
       '/f',
     );
-    expect(committedRoute.path).toBe('/404');
+    expect(resolvedRoute.path).toBe('/404');
     expect(url.pathname).toBe('/missing');
   });
 });


### PR DESCRIPTION
The elements record now holds all committed state. The client's own router state lives in it under a symbol key, next to the server's `ROUTE_ID`. One navigation is one merge, and one layout effect writes the URL and the scroll position. Redirects and 404s are now errors that the error boundary follows, so the old `Nav` state and the `resolveFollowingErrors` resolver are gone.

Bugs fixed along the way: a back navigation that landed on another route left the old URL in the address bar, `router.reload()` rewrote the URL (a trailing slash was dropped, `%20` became `+`), an instant navigation to a static route dropped the query string, and a second 404 whose URL had a query crashed the app.

### Notes for users
  
- `unstable_RouterContext` now has `routerState` instead of `nav`.
- `unstable_events`: a redirect reports both navigations, so you get `start` and `complete` for the route you asked for and another pair for the route you land on. `complete` fires when the response arrives, not after React renders it.
- While a server redirect is loading, the target route is empty. Before, the old page stayed on screen until the redirect finished.
- If an RSC request fails with a network error, you still get the in-app error. The error now carries `unstable_networkError`, so your app can choose to do a full page navigation instead.
- If an RSC request is redirected away from the RSC endpoint, the browser takes over the navigation. For redirects inside your app, keep using `unstable_redirect`.                                     
