### PR TITLE
fix(router): unblock a superseded navigation and skip hash-only fetches

### DIFF
--- a/packages/waku/src/lib/react-types.d.ts
+++ b/packages/waku/src/lib/react-types.d.ts
@@ -85,7 +85,7 @@ declare module 'react-server-dom-webpack/client' {
   export function createFromFetch<T>(
     promiseForResponse: Promise<Response>,
     options?: Options<T>,
-  ): Promise<T>;
+  ): PromiseLike<T>;
   export function encodeReply(
     value: ReactServerValue,
     options?: { temporaryReferences?: TemporaryReferenceSet },

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -258,7 +258,6 @@ type Refetch = (
   rscPath: string,
   rscParams?: unknown,
   options?: FetchRscOptions & {
-    // react's decoded payload is a thenable, not a promise
     unstable_prefetched?: PromiseLike<Elements>;
     unstable_overlay?: Elements;
     unstable_swr?: {
@@ -621,8 +620,7 @@ export const Root = ({
     delete fetchRscStore[ENTRY];
     let data: Promise<Elements>;
     if (prefetched) {
-      // without this an aborted navigation keeps the elements chain waiting,
-      // and a stale build arriving late reloads the url it walked away from
+      // an aborted navigation must not hold the chain or reload the url it left
       data = abortable(prefetched, options?.signal);
       reloadOnBuildIdMismatch(data, options?.onBuildIdMismatch);
     } else {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -619,7 +619,6 @@ export const Root = ({
     delete fetchRscStore[ENTRY];
     let data: Promise<Elements>;
     if (prefetched) {
-      // an aborted navigation must not hold the chain or reload the url it left
       data = abortable(prefetched, options?.signal);
       reloadOnBuildIdMismatch(data, options?.onBuildIdMismatch);
     } else {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -349,21 +349,21 @@ const reloadOnBuildIdMismatch = (
 const abortable = (
   elements: Promise<Elements>,
   signal: AbortSignal | undefined,
-): Promise<Elements> =>
-  signal
-    ? Promise.race([
-        elements,
-        new Promise<never>((_resolve, reject) => {
-          if (signal.aborted) {
-            reject(signal.reason);
-          } else {
-            signal.addEventListener('abort', () => reject(signal.reason), {
-              once: true,
-            });
-          }
-        }),
-      ])
-    : elements;
+): Promise<Elements> => {
+  if (!signal) {
+    return elements;
+  }
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise<Elements>((resolve, reject) => {
+    const abort = () => reject(signal.reason);
+    signal.addEventListener('abort', abort, { once: true });
+    elements
+      .then(resolve, reject)
+      .finally(() => signal.removeEventListener('abort', abort));
+  });
+};
 
 const applyInputTransformers = (
   rscPath: string,

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -322,13 +322,16 @@ const decodeRsc = (
   temporaryReferences: ReturnType<typeof createTemporaryReferenceSet>,
   debugChannel:
     ReturnType<typeof setupDebugChannel>['debugChannel'] | undefined,
+  // react's thenable returns nothing from then, so chaining needs a real one
 ): Promise<Elements> =>
-  createFromFetch<Elements>(checkStatus(responsePromise), {
-    callServer: (funcId: string, args: unknown[]) =>
-      unstable_callServerRsc(funcId, args),
-    debugChannel,
-    temporaryReferences,
-  });
+  Promise.resolve(
+    createFromFetch<Elements>(checkStatus(responsePromise), {
+      callServer: (funcId: string, args: unknown[]) =>
+        unstable_callServerRsc(funcId, args),
+      debugChannel,
+      temporaryReferences,
+    }),
+  );
 
 const reloadOnBuildIdMismatch = (
   elements: Promise<Elements>,

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -346,6 +346,25 @@ const reloadOnBuildIdMismatch = (
   );
 };
 
+const abortable = (
+  elements: Promise<Elements>,
+  signal: AbortSignal | undefined,
+): Promise<Elements> =>
+  signal
+    ? Promise.race([
+        elements,
+        new Promise<never>((_resolve, reject) => {
+          if (signal.aborted) {
+            reject(signal.reason);
+          } else {
+            signal.addEventListener('abort', () => reject(signal.reason), {
+              once: true,
+            });
+          }
+        }),
+      ])
+    : elements;
+
 const applyInputTransformers = (
   rscPath: string,
   rscParams: unknown,
@@ -597,8 +616,10 @@ export const Root = ({
     delete fetchRscStore[ENTRY];
     let data: Promise<Elements>;
     if (prefetched) {
-      data = Promise.resolve(prefetched);
-      reloadOnBuildIdMismatch(data, options?.onBuildIdMismatch);
+      const adopted = Promise.resolve(prefetched);
+      reloadOnBuildIdMismatch(adopted, options?.onBuildIdMismatch);
+      // without this an aborted navigation keeps the elements chain waiting
+      data = abortable(adopted, options?.signal);
     } else {
       if (swr?.base) {
         fetchRscStore[CACHED_ETAGS] = {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -258,7 +258,7 @@ type Refetch = (
   rscPath: string,
   rscParams?: unknown,
   options?: FetchRscOptions & {
-    unstable_prefetched?: Elements | Promise<Elements>;
+    unstable_prefetched?: Promise<Elements>;
     unstable_overlay?: Elements;
     unstable_swr?: {
       pin: (key: string | symbol) => boolean;
@@ -616,10 +616,9 @@ export const Root = ({
     delete fetchRscStore[ENTRY];
     let data: Promise<Elements>;
     if (prefetched) {
-      const adopted = Promise.resolve(prefetched);
-      reloadOnBuildIdMismatch(adopted, options?.onBuildIdMismatch);
+      reloadOnBuildIdMismatch(prefetched, options?.onBuildIdMismatch);
       // without this an aborted navigation keeps the elements chain waiting
-      data = abortable(adopted, options?.signal);
+      data = abortable(prefetched, options?.signal);
     } else {
       if (swr?.base) {
         fetchRscStore[CACHED_ETAGS] = {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -321,7 +321,6 @@ const decodeRsc = (
   temporaryReferences: ReturnType<typeof createTemporaryReferenceSet>,
   debugChannel:
     ReturnType<typeof setupDebugChannel>['debugChannel'] | undefined,
-  // react's thenable returns nothing from then, so chaining needs a real one
 ): Promise<Elements> =>
   Promise.resolve(
     createFromFetch<Elements>(checkStatus(responsePromise), {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -258,7 +258,7 @@ type Refetch = (
   rscPath: string,
   rscParams?: unknown,
   options?: FetchRscOptions & {
-    unstable_prefetched?: PromiseLike<Elements>;
+    unstable_prefetched?: Promise<Elements>;
     unstable_overlay?: Elements;
     unstable_swr?: {
       pin: (key: string | symbol) => boolean;
@@ -350,20 +350,19 @@ const reloadOnBuildIdMismatch = (
 };
 
 const abortable = (
-  elements: PromiseLike<Elements>,
+  elements: Promise<Elements>,
   signal: AbortSignal | undefined,
 ): Promise<Elements> => {
   if (!signal) {
-    return Promise.resolve(elements);
+    return elements;
+  }
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
   }
   return new Promise<Elements>((resolve, reject) => {
     const abort = () => reject(signal.reason);
-    if (signal.aborted) {
-      abort();
-    } else {
-      signal.addEventListener('abort', abort, { once: true });
-    }
-    Promise.resolve(elements)
+    signal.addEventListener('abort', abort, { once: true });
+    elements
       .then(resolve, reject)
       .finally(() => signal.removeEventListener('abort', abort));
   });

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -353,13 +353,15 @@ const abortable = (
   if (!signal) {
     return elements;
   }
-  if (signal.aborted) {
-    return Promise.reject(signal.reason);
-  }
   return new Promise<Elements>((resolve, reject) => {
     const abort = () => reject(signal.reason);
-    signal.addEventListener('abort', abort, { once: true });
-    elements
+    if (signal.aborted) {
+      abort();
+    } else {
+      signal.addEventListener('abort', abort, { once: true });
+    }
+    // Promise.resolve, because a decoded payload is a thenable, not a promise
+    Promise.resolve(elements)
       .then(resolve, reject)
       .finally(() => signal.removeEventListener('abort', abort));
   });

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -258,7 +258,8 @@ type Refetch = (
   rscPath: string,
   rscParams?: unknown,
   options?: FetchRscOptions & {
-    unstable_prefetched?: Promise<Elements>;
+    // react's decoded payload is a thenable, not a promise
+    unstable_prefetched?: PromiseLike<Elements>;
     unstable_overlay?: Elements;
     unstable_swr?: {
       pin: (key: string | symbol) => boolean;
@@ -347,11 +348,11 @@ const reloadOnBuildIdMismatch = (
 };
 
 const abortable = (
-  elements: Promise<Elements>,
+  elements: PromiseLike<Elements>,
   signal: AbortSignal | undefined,
 ): Promise<Elements> => {
   if (!signal) {
-    return elements;
+    return Promise.resolve(elements);
   }
   return new Promise<Elements>((resolve, reject) => {
     const abort = () => reject(signal.reason);
@@ -360,7 +361,6 @@ const abortable = (
     } else {
       signal.addEventListener('abort', abort, { once: true });
     }
-    // Promise.resolve, because a decoded payload is a thenable, not a promise
     Promise.resolve(elements)
       .then(resolve, reject)
       .finally(() => signal.removeEventListener('abort', abort));
@@ -618,9 +618,10 @@ export const Root = ({
     delete fetchRscStore[ENTRY];
     let data: Promise<Elements>;
     if (prefetched) {
-      reloadOnBuildIdMismatch(prefetched, options?.onBuildIdMismatch);
-      // without this an aborted navigation keeps the elements chain waiting
+      // without this an aborted navigation keeps the elements chain waiting,
+      // and a stale build arriving late reloads the url it walked away from
       data = abortable(prefetched, options?.signal);
+      reloadOnBuildIdMismatch(data, options?.onBuildIdMismatch);
     } else {
       if (swr?.base) {
         fetchRscStore[CACHED_ETAGS] = {

--- a/packages/waku/src/router/client-utils/route-url.ts
+++ b/packages/waku/src/router/client-utils/route-url.ts
@@ -32,6 +32,10 @@ export const isSameRoute = (next: RouteProps, prev: RouteProps) =>
   next.query === prev.query &&
   next.hash === prev.hash;
 
+// the hash is client only, so it never changes what the server sends
+export const isSameRscRoute = (next: RouteProps, prev: RouteProps) =>
+  next.path === prev.path && next.query === prev.query;
+
 export const parseRedirectUrl = (location: string, base: string | URL) => {
   const url = new URL(location, base);
   return url.protocol === 'http:' || url.protocol === 'https:'

--- a/packages/waku/src/router/client-utils/route-url.ts
+++ b/packages/waku/src/router/client-utils/route-url.ts
@@ -32,7 +32,6 @@ export const isSameRoute = (next: RouteProps, prev: RouteProps) =>
   next.query === prev.query &&
   next.hash === prev.hash;
 
-// the hash is client only, so it never changes what the server sends
 export const isSameRscRoute = (next: RouteProps, prev: RouteProps) =>
   next.path === prev.path && next.query === prev.query;
 

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -540,7 +540,6 @@ const prefetchIfNotCurrent = (
     return;
   }
   const route = parseRoute(new URL(resolvedTo, window.location.href));
-  // the address bar can hold a route the router never committed
   if (!isSameRscRoute(route, router.route)) {
     router.prefetchRoute(route, options);
   }
@@ -894,7 +893,6 @@ const FollowError = ({
           history: 'replace',
           url,
           follow: true,
-          // the elements it holds are the ones that threw
           refetch: true,
         }).then(
           (followable) => {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -884,6 +884,8 @@ const FollowError = ({
           history: 'replace',
           url,
           follow: true,
+          // the elements it holds are the ones that threw
+          refetch: true,
         }).then(
           (followable) => {
             // a module scoped error is thrown again, so let it follow again
@@ -1224,8 +1226,11 @@ const InnerRouter = ({
         scroll: options.shouldScroll,
         pathChanged: nextRoute.path !== routeBefore.path,
       });
+      // the hash is client only, so it never changes what the server sends
       const shouldRefetch =
-        options.refetch ?? !isSameRoute(nextRoute, routeBefore);
+        options.refetch ??
+        (nextRoute.path !== routeBefore.path ||
+          nextRoute.query !== routeBefore.query);
       setErr(null);
       if (staticPathSet.has(nextRoute.path) || !shouldRefetch) {
         mergeElements({

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -123,6 +123,11 @@ type Navigate = {
   ): Promise<void>;
 };
 
+/**
+ * Fetches whatever it is given, including the route already on screen, so it
+ * can warm the cache for a later reload. `<Link>` prefetching is automatic, so
+ * that one skips a target the router is already showing.
+ */
 type Prefetch = {
   (to: RouteHref, options?: PrefetchOptions): void;
   <Path extends RoutePath>(

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -527,19 +527,23 @@ function useSharedRef<T>(
 }
 
 const prefetchIfNotCurrent = (
-  router: { prefetchRoute: PrefetchRoute } | null,
+  router: { route: RouteProps; prefetchRoute: PrefetchRoute } | null,
   resolvedTo: string,
   options: PrefetchOptions | undefined,
 ) => {
+  if (!router) {
+    return;
+  }
   const route = parseRoute(new URL(resolvedTo, window.location.href));
-  if (router && !isSameRscRoute(route, parseRouteFromLocation())) {
+  // the address bar can hold a route the router never committed
+  if (!isSameRscRoute(route, router.route)) {
     router.prefetchRoute(route, options);
   }
 };
 
 const usePrefetchOnView = (
   ref: RefObject<HTMLAnchorElement | null>,
-  router: { prefetchRoute: PrefetchRoute } | null,
+  router: { route: RouteProps; prefetchRoute: PrefetchRoute } | null,
   resolvedTo: string,
   options: PrefetchOptions | undefined,
 ) => {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -51,6 +51,7 @@ import {
 import {
   getRouteUrl,
   isSameRoute,
+  isSameRscRoute,
   parseRedirectUrl,
   parseRoute,
   pathnameToCurrentRoutePath,
@@ -530,9 +531,9 @@ const prefetchIfNotCurrent = (
   resolvedTo: string,
   options: PrefetchOptions | undefined,
 ) => {
-  const url = new URL(resolvedTo, window.location.href);
-  if (router && url.href !== window.location.href) {
-    router.prefetchRoute(parseRoute(url), options);
+  const route = parseRoute(new URL(resolvedTo, window.location.href));
+  if (router && !isSameRscRoute(route, parseRouteFromLocation())) {
+    router.prefetchRoute(route, options);
   }
 };
 
@@ -1226,11 +1227,8 @@ const InnerRouter = ({
         scroll: options.shouldScroll,
         pathChanged: nextRoute.path !== routeBefore.path,
       });
-      // the hash is client only, so it never changes what the server sends
       const shouldRefetch =
-        options.refetch ??
-        (nextRoute.path !== routeBefore.path ||
-          nextRoute.query !== routeBefore.query);
+        options.refetch ?? !isSameRscRoute(nextRoute, routeBefore);
       setErr(null);
       if (staticPathSet.has(nextRoute.path) || !shouldRefetch) {
         mergeElements({

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -1207,7 +1207,7 @@ describe('minimal/client refetch scenarios', () => {
         then(resolve: (v: Record<string, unknown>) => void) {
           resolvers.push(resolve);
         },
-      } as unknown as Promise<Record<string, unknown>>,
+      } as PromiseLike<Record<string, unknown>>,
       settle: () => resolvers.forEach((resolve) => resolve(value)),
     };
   };
@@ -1264,6 +1264,45 @@ describe('minimal/client refetch scenarios', () => {
 
     // the abandoned prefetch never settles, so the chain must not wait on it
     expect(view.container.textContent).toBe('P2');
+    view.unmount();
+  });
+
+  test('an aborted navigation does not act on its prefetch build id', async () => {
+    vi.stubEnv('WAKU_BUILD_ID', 'build-1');
+    const view = await mount(
+      { _value: null, page: 'P1', _buildId: 'build-1' },
+      () => (
+        <Suspense fallback={null}>
+          <Slot id="page" />
+        </Suspense>
+      ),
+    );
+    const onBuildIdMismatch = vi.fn();
+    const controller = new AbortController();
+    const { thenable, settle } = pendingThenable({
+      _value: null,
+      page: 'P2',
+      _buildId: 'build-2',
+    });
+    await act(async () => {
+      view
+        .refetch()('R/done.txt', undefined, {
+          unstable_prefetched: thenable,
+          signal: controller.signal,
+          onBuildIdMismatch,
+        })
+        .catch(() => {});
+      await wait();
+    });
+
+    controller.abort();
+    await act(async () => {
+      // the stale build arrives after the user moved on
+      settle();
+      await wait();
+    });
+
+    expect(onBuildIdMismatch).not.toHaveBeenCalled();
     view.unmount();
   });
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -1198,6 +1198,44 @@ describe('minimal/client refetch scenarios', () => {
     view.unmount();
   });
 
+  // react's createFromFetch hands back a pending thenable whose `then`
+  // returns nothing, so an adopted prefetch is not always a real promise
+  const pendingThenable = (value: Record<string, unknown>) => {
+    const resolvers: ((v: Record<string, unknown>) => void)[] = [];
+    return {
+      thenable: {
+        then(resolve: (v: Record<string, unknown>) => void) {
+          resolvers.push(resolve);
+        },
+      } as unknown as Promise<Record<string, unknown>>,
+      settle: () => resolvers.forEach((resolve) => resolve(value)),
+    };
+  };
+
+  test('an adopted prefetch may be a thenable, not a promise', async () => {
+    const view = await mount({ _value: null, page: 'P1' }, () => (
+      <Suspense fallback={null}>
+        <Slot id="page" />
+      </Suspense>
+    ));
+    const controller = new AbortController();
+    const { thenable, settle } = pendingThenable({ _value: null, page: 'P2' });
+    await act(async () => {
+      view
+        .refetch()('R/next.txt', undefined, {
+          unstable_prefetched: thenable,
+          signal: controller.signal,
+        })
+        .catch(() => {});
+      await wait();
+      settle();
+      await wait();
+    });
+
+    expect(view.container.textContent).toBe('P2');
+    view.unmount();
+  });
+
   test('aborting a navigation releases the prefetch it adopted', async () => {
     const view = await mount({ _value: null, page: 'P1' }, () => (
       <Suspense fallback={null}>

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -1198,8 +1198,8 @@ describe('minimal/client refetch scenarios', () => {
     view.unmount();
   });
 
-  // react's createFromFetch hands back a pending thenable whose `then`
-  // returns nothing, so an adopted prefetch is not always a real promise
+  // createFromFetch says it returns a promise, but hands back a pending
+  // thenable whose `then` returns nothing
   const pendingThenable = (value: Record<string, unknown>) => {
     const resolvers: ((v: Record<string, unknown>) => void)[] = [];
     return {
@@ -1207,33 +1207,24 @@ describe('minimal/client refetch scenarios', () => {
         then(resolve: (v: Record<string, unknown>) => void) {
           resolvers.push(resolve);
         },
-      } as PromiseLike<Record<string, unknown>>,
+      } as unknown as Promise<Record<string, unknown>>,
       settle: () => resolvers.forEach((resolve) => resolve(value)),
     };
   };
 
-  test('an adopted prefetch may be a thenable, not a promise', async () => {
-    const view = await mount({ _value: null, page: 'P1' }, () => (
-      <Suspense fallback={null}>
-        <Slot id="page" />
-      </Suspense>
-    ));
-    const controller = new AbortController();
+  test('a decoded payload comes back chainable, not as react gave it', async () => {
     const { thenable, settle } = pendingThenable({ _value: null, page: 'P2' });
-    await act(async () => {
-      view
-        .refetch()('R/next.txt', undefined, {
-          unstable_prefetched: thenable,
-          signal: controller.signal,
-        })
-        .catch(() => {});
-      await wait();
-      settle();
-      await wait();
-    });
+    mocks.createFromFetch.mockReturnValue(thenable);
+    track(stubFetch());
 
-    expect(view.container.textContent).toBe('P2');
-    view.unmount();
+    // a thenable would return undefined from then, so this would throw
+    const chained = unstable_fetchRsc('R/next.txt')
+      .then((elements) => elements)
+      .finally(() => {});
+    await wait();
+    settle();
+
+    await expect(chained).resolves.toMatchObject({ page: 'P2' });
   });
 
   test('aborting a navigation releases the prefetch it adopted', async () => {
@@ -1279,15 +1270,14 @@ describe('minimal/client refetch scenarios', () => {
     );
     const onBuildIdMismatch = vi.fn();
     const controller = new AbortController();
-    const { thenable, settle } = pendingThenable({
-      _value: null,
-      page: 'P2',
-      _buildId: 'build-2',
+    let settle = () => {};
+    const prefetched = new Promise<Record<string, unknown>>((resolve) => {
+      settle = () => resolve({ _value: null, page: 'P2', _buildId: 'build-2' });
     });
     await act(async () => {
       view
         .refetch()('R/done.txt', undefined, {
-          unstable_prefetched: thenable,
+          unstable_prefetched: prefetched,
           signal: controller.signal,
           onBuildIdMismatch,
         })

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -1198,6 +1198,37 @@ describe('minimal/client refetch scenarios', () => {
     view.unmount();
   });
 
+  test('aborting a navigation releases the prefetch it adopted', async () => {
+    const view = await mount({ _value: null, page: 'P1' }, () => (
+      <Suspense fallback={null}>
+        <Slot id="page" />
+      </Suspense>
+    ));
+    const controller = new AbortController();
+    const pending = new Promise<Record<string, unknown>>(() => {});
+    await act(async () => {
+      view
+        .refetch()('R/pending.txt', undefined, {
+          unstable_prefetched: pending,
+          signal: controller.signal,
+        })
+        .catch(() => {});
+      await wait();
+    });
+
+    controller.abort();
+    await act(async () => {
+      await view.refetch()('R/next.txt', undefined, {
+        unstable_prefetched: { _value: null, page: 'P2' },
+      });
+      await wait();
+    });
+
+    // the abandoned prefetch never settles, so the chain must not wait on it
+    expect(view.container.textContent).toBe('P2');
+    view.unmount();
+  });
+
   test('adopting prefetched elements re-checks the build id', async () => {
     vi.stubEnv('WAKU_BUILD_ID', 'build-1');
     const view = await mount(

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -1189,7 +1189,7 @@ describe('minimal/client refetch scenarios', () => {
     mocks.createFromFetch.mockClear();
     await act(async () => {
       await view.refetch()('R/done.txt', undefined, {
-        unstable_prefetched: { _value: null, page: 'P2' },
+        unstable_prefetched: Promise.resolve({ _value: null, page: 'P2' }),
       });
     });
     expect(view.container.textContent).toBe('P2');
@@ -1219,7 +1219,7 @@ describe('minimal/client refetch scenarios', () => {
     controller.abort();
     await act(async () => {
       await view.refetch()('R/next.txt', undefined, {
-        unstable_prefetched: { _value: null, page: 'P2' },
+        unstable_prefetched: Promise.resolve({ _value: null, page: 'P2' }),
       });
       await wait();
     });
@@ -1242,7 +1242,11 @@ describe('minimal/client refetch scenarios', () => {
     const onBuildIdMismatch = vi.fn();
     await act(async () => {
       await view.refetch()('R/done.txt', undefined, {
-        unstable_prefetched: { _value: null, page: 'P2', _buildId: 'build-2' },
+        unstable_prefetched: Promise.resolve({
+          _value: null,
+          page: 'P2',
+          _buildId: 'build-2',
+        }),
         onBuildIdMismatch,
       });
       await wait();

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2780,6 +2780,42 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a hover prefetch compares with the route on screen, not the address bar', async () => {
+    // an interceptor or a failed navigation leaves the two apart
+    window.history.replaceState({}, '', '/blocked');
+    const prefetchRoute = vi.fn();
+    const view = await renderApp(
+      <RouterContext
+        value={{
+          route: { path: '/start', query: '', hash: '' },
+          changeRoute: vi.fn(async () => {}),
+          prefetchRoute,
+          routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
+        }}
+      >
+        <Link to="/start#target" unstable_prefetchOnEnter={{}}>
+          shown
+        </Link>
+        <Link to="/blocked#target" unstable_prefetchOnEnter={{}}>
+          in the url
+        </Link>
+      </RouterContext>,
+    );
+
+    const links = view.container.querySelectorAll('a');
+    links[0]!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    expect(prefetchRoute).not.toHaveBeenCalled();
+
+    links[1]!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    expect(prefetchRoute).toHaveBeenCalledWith(
+      { path: '/blocked', query: '', hash: '#target' },
+      {},
+    );
+
+    view.unmount();
+  });
+
   // The instant shell: a prefetch for the target is adopted via
   // `unstable_prefetched` as the navigation's data source, while the eager
   // merge paints the static shell and the base.

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3818,6 +3818,8 @@ describe('Router integration', () => {
       expect(capture.router?.path).toBe('/start');
       expect(capture.router?.hash).toBe('#missing');
       expect(scrollToSpy).not.toHaveBeenCalled();
+      // back and forward between hashes stay on the client too
+      expect(getRefetchMock()).not.toHaveBeenCalled();
     } finally {
       view.unmount();
     }

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2750,6 +2750,36 @@ describe('Router integration', () => {
     }
   });
 
+  test('a hover prefetch skips a link that only adds a hash', async () => {
+    const prefetchRoute = vi.fn();
+    const view = await renderApp(
+      <RouterContext
+        value={{
+          route: { path: '/start', query: '', hash: '' },
+          changeRoute: vi.fn(async () => {}),
+          prefetchRoute,
+          routeChangeEvents: { on: vi.fn(), off: vi.fn() },
+          fetchingSlices: new Set<string>(),
+        }}
+      >
+        <Link to="/start#target" unstable_prefetchOnEnter={{}}>
+          target
+        </Link>
+      </RouterContext>,
+    );
+
+    const link = view.container.querySelector('a');
+    if (!link) {
+      throw new Error('expected link');
+    }
+    link.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+    // the hash never reaches the server, so there is nothing to prefetch
+    expect(prefetchRoute).not.toHaveBeenCalled();
+
+    view.unmount();
+  });
+
   // The instant shell: a prefetch for the target is adopted via
   // `unstable_prefetched` as the navigation's data source, while the eager
   // merge paints the static shell and the base.

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2358,6 +2358,8 @@ describe('Router integration', () => {
       });
       expect(window.location.hash).toBe('#target');
       expect(capture.router.hash).toBe('#target');
+      // the hash never reaches the server, so there is nothing to fetch
+      expect(getRefetchMock()).not.toHaveBeenCalled();
     } finally {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();


### PR DESCRIPTION
Two bugs that were there before #2230.

A new navigation could get stuck behind an old prefetch. When a navigation reuses a prefetch that is still in flight, the adopted promise ignored its abort signal, so navigating away left the new page waiting on it. The signalnow rejects the adopted promise, while the prefetch keeps running and fills its cache.

A hash jump made a request. /x to /x#section counted as a different route, so a dynamic page fetched again even though the hash never reaches the server. The refetch decision now uses path and query only. This also drops an incidental revalidation: a same-path hash navigation used to refetch, and is now fully client side.

Along the way: a redirect or 404 follow always refetches its target, hover and viewport prefetch skip hash-only links and compare against the route on screen, an aborted navigation no longer acts on its prefetch's build id, and decodeRsc hands back a real promise instead of React's thenable.
