### PR TITLE
fix(cloudflare): expose handlers in Vite dev

### DIFF
--- a/e2e/cloudflare-adapter.dev.spec.ts
+++ b/e2e/cloudflare-adapter.dev.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test';
+import { prepareNormalSetup, test } from './utils.js';
+
+const startApp = prepareNormalSetup('cloudflare-adapter');
+
+test.describe('cloudflare adapter', () => {
+  let port: number;
+  let stopApp: () => Promise<void>;
+
+  test.beforeAll(async () => {
+    ({ port, stopApp } = await startApp('DEV'));
+  });
+
+  test.afterAll(async () => {
+    await stopApp();
+  });
+
+  test('runs queue handlers', async ({ request }) => {
+    const url = `http://localhost:${port}/queue`;
+    const response = await request.post(url, { data: 'hello' });
+    expect(response.ok()).toBe(true);
+
+    await expect
+      .poll(async () => (await request.get(url)).text())
+      .toBe('hello');
+  });
+});

--- a/e2e/fixtures/cloudflare-adapter/src/global.d.ts
+++ b/e2e/fixtures/cloudflare-adapter/src/global.d.ts
@@ -1,6 +1,9 @@
 declare module 'cloudflare:workers' {
   export const env: {
     MAX_ITEMS: number;
+    QUEUE: {
+      send(message: string): Promise<void>;
+    };
   };
   export const waitUntil: (promise: Promise<unknown>) => void;
 }

--- a/e2e/fixtures/cloudflare-adapter/src/pages/_api/queue.ts
+++ b/e2e/fixtures/cloudflare-adapter/src/pages/_api/queue.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line import/no-unresolved
+import { env } from 'cloudflare:workers';
+import { queueState } from '../../queue-state.js';
+
+export async function POST(request: Request) {
+  await env.QUEUE.send(await request.text());
+  return new Response('sent');
+}
+
+export function GET() {
+  return new Response(queueState.message);
+}

--- a/e2e/fixtures/cloudflare-adapter/src/queue-state.ts
+++ b/e2e/fixtures/cloudflare-adapter/src/queue-state.ts
@@ -1,0 +1,1 @@
+export const queueState = { message: '' };

--- a/e2e/fixtures/cloudflare-adapter/src/waku.server.tsx
+++ b/e2e/fixtures/cloudflare-adapter/src/waku.server.tsx
@@ -1,4 +1,11 @@
 import { fsRouter } from 'waku';
 import adapter from 'waku/adapters/cloudflare';
+import { queueState } from './queue-state.js';
 
-export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')));
+export default adapter(fsRouter(import.meta.glob('./pages/**/*.{tsx,ts}')), {
+  handlers: {
+    async queue(batch: { messages: { body: unknown }[] }) {
+      queueState.message = String(batch.messages[0]?.body ?? '');
+    },
+  },
+});

--- a/e2e/fixtures/cloudflare-adapter/wrangler.jsonc
+++ b/e2e/fixtures/cloudflare-adapter/wrangler.jsonc
@@ -12,6 +12,20 @@
   "vars": {
     "MAX_ITEMS": 10
   },
+  "queues": {
+    "producers": [
+      {
+        "binding": "QUEUE",
+        "queue": "test-queue"
+      }
+    ],
+    "consumers": [
+      {
+        "queue": "test-queue",
+        "max_batch_timeout": 1
+      }
+    ]
+  },
   "rules": [
     {
       "type": "ESModule",

--- a/e2e/suites.ts
+++ b/e2e/suites.ts
@@ -4,6 +4,7 @@ export const UBUNTU_LTS_ONLY_SPECS = [
   'base-path.spec.ts',
   'broken-links.spec.ts',
   'cache-tag.spec.ts',
+  'cloudflare-adapter.dev.spec.ts',
   'cloudflare-adapter.prd.spec.ts',
   'css-plugin-integrations.spec.ts',
   'custom-library-adapter.prd.spec.ts',
@@ -42,6 +43,7 @@ export const UBUNTU_LTS_ONLY_SPECS = [
 
 export const CHROMIUM_ONLY_SPECS = [
   'cache-tag.spec.ts',
+  'cloudflare-adapter.dev.spec.ts',
   'cloudflare-adapter.prd.spec.ts',
   'css-plugin-integrations.spec.ts',
   'custom-library-adapter.prd.spec.ts',
@@ -85,6 +87,7 @@ export const PRD_ONLY_SPECS = [
 ] as const;
 
 export const DEV_ONLY_SPECS = [
+  'cloudflare-adapter.dev.spec.ts',
   'hot-reload.dev.spec.ts',
   'performance-track.dev.spec.ts',
 ] as const;

--- a/packages/waku/src/adapters/cloudflare.ts
+++ b/packages/waku/src/adapters/cloudflare.ts
@@ -153,6 +153,7 @@ export default createServerEntryAdapter(
     };
 
     return {
+      ...options?.handlers,
       fetch: fetchFn,
       build: async (utils) => {
         const server = await startPreviewServer();


### PR DESCRIPTION
Cloudflare's Vite runner loads src/waku.server directly, so expose custom handlers on the adapter entry too.

Add a dev e2e test for queue handler dispatch.