### PR TITLE
fix(router): unstable events

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -245,7 +245,7 @@ export const NavigationLogger = () => {
 
 Unless the browser takes over the page, every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
 
-`complete` carries the route the response landed on, which is not always the one you asked for, because the server can redirect or send the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded. A listener that throws is reported to the console and does not affect the navigation or the other listeners.
+`complete` carries the route the response landed on, which is not always the one you asked for, because the server can redirect or send the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded. A superseded one reports the route it announced; a failed one reports the route it was fetching, which is the 404 page when the follow to it failed. A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates is served immediately, so listeners registered after it see the new navigation before the rest of the current one.
 
 A redirect carried by the response is the case where the browser takes over: it emits no closing event, because a full page load is already under way.
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -243,7 +243,7 @@ export const NavigationLogger = () => {
 };
 ```
 
-Unless the browser takes over the page, every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
+Unless the browser takes over the page, every `start` is followed by exactly one `complete` or `error`, and unless a listener itself navigates they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
 
 `complete` carries the route the response landed on, which is not always the one you asked for, because the server can redirect or send the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded. A superseded one reports the route it announced; a failed one reports the route it was fetching, which is the 404 page when the follow to it failed. A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates is served immediately, so listeners registered after it see the new navigation before the rest of the current one.
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -210,6 +210,37 @@ export const NavLink = () => (
 
 `useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>`, which means the indicator lives inside the `<a>`. Keep it non-interactive and `aria-hidden` (as above), since it becomes part of the link's accessible name and click target; to render pending UI outside the anchor, drive it from route-change events instead. Called outside any `<Link>`, the hook returns an empty object (not `{ pending: false }`).
 
+## Route Change Events
+
+To drive pending UI from outside a `<Link>`, subscribe to route change events:
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'waku';
+
+export const ProgressBar = () => {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  useEffect(() => {
+    const start = () => setBusy(true);
+    const stop = () => setBusy(false);
+    router.unstable_events.on('start', start);
+    router.unstable_events.on('complete', stop);
+    router.unstable_events.on('error', stop);
+    return () => {
+      router.unstable_events.off('start', start);
+      router.unstable_events.off('complete', stop);
+      router.unstable_events.off('error', stop);
+    };
+  }, [router]);
+  return busy ? <span>Loading...</span> : null;
+};
+```
+
+Every `start` is followed by exactly one `complete` or `error`, so a spinner started on `start` always stops. `complete` carries the route that ended up showing, which is not always the one you asked for: a server redirect or a missing page reports where it landed. `error` fires when the navigation fails, and also when a newer navigation supersedes it. A redirect that leaves the app is the one case with no closing event, because the browser is already loading the next page.
+
 ## Custom Transitions
 
 For advanced navigation effects, pass `unstable_startTransition` to control how Waku starts the route transition. One common use case is integrating the browser View Transitions API:

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -208,7 +208,7 @@ export const NavLink = () => (
 );
 ```
 
-`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>`, which means the indicator lives inside the `<a>`. Keep it non-interactive and `aria-hidden` (as above), since it becomes part of the link's accessible name and click target; to render pending UI outside the anchor, put a `<Suspense>` boundary around the part of the page that changes. Called outside any `<Link>`, the hook returns an empty object (not `{ pending: false }`).
+`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>`, which means the indicator lives inside the `<a>`. Keep it non-interactive and `aria-hidden` (as above), since it becomes part of the link's accessible name and click target; there is no supported way yet to render it outside the anchor, because a navigation runs in a transition that deliberately keeps the current page on screen until the destination is ready. Called outside any `<Link>`, the hook returns an empty object (not `{ pending: false }`).
 
 ## Route Change Events
 
@@ -219,13 +219,17 @@ Subscribe to route change events to observe navigations, for example to log them
 
 import { useEffect } from 'react';
 import { useRouter } from 'waku';
+import type { Unstable_RouteProps } from 'waku/router/client';
 
 export const NavigationLogger = () => {
   const { unstable_events } = useRouter();
   useEffect(() => {
-    const started = (route) => console.log('navigating to', route.path);
-    const landed = (route) => console.log('landed on', route.path);
-    const gaveUp = (route) => console.log('gave up on', route.path);
+    const started = (route: Unstable_RouteProps) =>
+      console.log('navigating to', route.path);
+    const landed = (route: Unstable_RouteProps) =>
+      console.log('landed on', route.path);
+    const gaveUp = (route: Unstable_RouteProps) =>
+      console.log('gave up on', route.path);
     unstable_events.on('start', started);
     unstable_events.on('complete', landed);
     unstable_events.on('error', gaveUp);
@@ -239,13 +243,13 @@ export const NavigationLogger = () => {
 };
 ```
 
-Every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
+Unless the browser takes over the page, every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
 
 `complete` carries the route the response landed on, which is not always the one you asked for, because the server can redirect or send the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded. A listener that throws is reported to the console and does not affect the navigation or the other listeners.
 
-Two things end a navigation without any closing event, because the browser is taking over the page: a redirect carried by the response, and a reload after a new build is deployed.
+A redirect carried by the response is the case where the browser takes over: it emits no closing event, because a full page load is already under way.
 
-For a spinner, prefer `useNavigationStatus_UNSTABLE()` above. These events fire while React is inside the navigation's transition, so state you set from a listener is batched with the navigation itself and may not paint on its own.
+For a spinner, prefer `useNavigationStatus_UNSTABLE()` above. A `start` listener runs inside the navigation's transition, so state you set there is batched with the navigation itself and may not paint on its own.
 
 ## Custom Transitions
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -175,7 +175,7 @@ The `<Suspense>` boundary decides how localized the loading state is. Wrapping t
 
 Because an instant navigation commits before the server responds, it reconciles afterward: a server redirect updates the URL to the redirect target, while a not-found (404) response keeps the attempted URL, so the 404 page shows at the address the user tried.
 
-Instant navigation commits urgently rather than inside a React transition, since a transition would suppress the immediate skeleton. A custom `unstable_startTransition` therefore does not run for instant links, and `useNavigationStatus_UNSTABLE()` does not report `pending` for them; drive pending UI from route-change events instead.
+Instant navigation commits urgently rather than inside a React transition, since a transition would suppress the immediate skeleton. A custom `unstable_startTransition` therefore does not run for instant links, and `useNavigationStatus_UNSTABLE()` does not report `pending` for them. An instant navigation paints its cached shell immediately, so the shell itself is the pending state.
 
 ## Pending UI
 
@@ -208,38 +208,44 @@ export const NavLink = () => (
 );
 ```
 
-`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>`, which means the indicator lives inside the `<a>`. Keep it non-interactive and `aria-hidden` (as above), since it becomes part of the link's accessible name and click target; to render pending UI outside the anchor, drive it from route-change events instead. Called outside any `<Link>`, the hook returns an empty object (not `{ pending: false }`).
+`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>`, which means the indicator lives inside the `<a>`. Keep it non-interactive and `aria-hidden` (as above), since it becomes part of the link's accessible name and click target; to render pending UI outside the anchor, put a `<Suspense>` boundary around the part of the page that changes. Called outside any `<Link>`, the hook returns an empty object (not `{ pending: false }`).
 
 ## Route Change Events
 
-To drive pending UI from outside a `<Link>`, subscribe to route change events:
+Subscribe to route change events to observe navigations, for example to log them or to report them to analytics:
 
 ```tsx
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'waku';
 
-export const ProgressBar = () => {
-  const router = useRouter();
-  const [busy, setBusy] = useState(false);
+export const NavigationLogger = () => {
+  const { unstable_events } = useRouter();
   useEffect(() => {
-    const start = () => setBusy(true);
-    const stop = () => setBusy(false);
-    router.unstable_events.on('start', start);
-    router.unstable_events.on('complete', stop);
-    router.unstable_events.on('error', stop);
+    const started = (route) => console.log('navigating to', route.path);
+    const landed = (route) => console.log('landed on', route.path);
+    const gaveUp = (route) => console.log('gave up on', route.path);
+    unstable_events.on('start', started);
+    unstable_events.on('complete', landed);
+    unstable_events.on('error', gaveUp);
     return () => {
-      router.unstable_events.off('start', start);
-      router.unstable_events.off('complete', stop);
-      router.unstable_events.off('error', stop);
+      unstable_events.off('start', started);
+      unstable_events.off('complete', landed);
+      unstable_events.off('error', gaveUp);
     };
-  }, [router]);
-  return busy ? <span>Loading...</span> : null;
+  }, [unstable_events]);
+  return null;
 };
 ```
 
-Every `start` is followed by exactly one `complete` or `error`, so a spinner started on `start` always stops. `complete` carries the route that ended up showing, which is not always the one you asked for: a server redirect or a missing page reports where it landed. `error` fires when the navigation fails, and also when a newer navigation supersedes it. A redirect that leaves the app is the one case with no closing event, because the browser is already loading the next page.
+Every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
+
+`complete` carries the route the response landed on, which is not always the one you asked for, because the server can redirect or send the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded. A listener that throws is reported to the console and does not affect the navigation or the other listeners.
+
+Two things end a navigation without any closing event, because the browser is taking over the page: a redirect carried by the response, and a reload after a new build is deployed.
+
+For a spinner, prefer `useNavigationStatus_UNSTABLE()` above. These events fire while React is inside the navigation's transition, so state you set from a listener is batched with the navigation itself and may not paint on its own.
 
 ## Custom Transitions
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -243,9 +243,9 @@ export const NavigationLogger = () => {
 };
 ```
 
-Unless the browser takes over the page, every `start` is followed by exactly one `complete` or `error`, and unless a listener itself navigates they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
+Unless the browser takes over the page, every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
 
-`complete` carries the route the response landed on, which is not always the one you asked for, because the server can redirect or send the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded. A superseded one reports the route it announced; a failed one reports the route it was fetching, which is the 404 page when the follow to it failed. A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates is served immediately, so listeners registered after it see the new navigation before the rest of the current one.
+`complete` carries the route the response landed on, which is not always the one you asked for, because the server can redirect or send the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded. A superseded one reports the route it announced; a failed one reports the route it was fetching, which is the 404 page when the follow to it failed. A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates gets a navigation right away, and its events queue behind the one being delivered, so every listener sees the same order whenever it subscribed.
 
 A redirect carried by the response is the case where the browser takes over: it emits no closing event, because a full page load is already under way.
 

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -216,7 +216,7 @@ const createRouteChangeListeners = (): [
       try {
         listener(route);
       } catch (e) {
-        console.error('Error in a route change listener:', e);
+        console.error(`Error in a route change '${event}' listener:`, e);
       }
     }
   };

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -184,7 +184,7 @@ type ChangeRoute = (
   options: ChangeRouteOptions,
 ) => Promise<void>;
 
-type ChangeRouteEvent = 'start' | 'complete';
+type ChangeRouteEvent = 'start' | 'complete' | 'error';
 
 type ChangeRouteCallback = (route: RouteProps) => void;
 
@@ -202,6 +202,7 @@ const createRouteChangeListeners = (): [
   const listeners: Record<ChangeRouteEvent, Set<ChangeRouteCallback>> = {
     start: new Set(),
     complete: new Set(),
+    error: new Set(),
   };
   const emit = (event: ChangeRouteEvent, route: RouteProps) => {
     const eventListenersSet = listeners[event];
@@ -1204,6 +1205,7 @@ const InnerRouter = ({
       }
       // a start listener can navigate synchronously, which aborts this one
       if (isAborted()) {
+        emitRouteChangeEvent('error', nextRoute);
         return;
       }
       if (!options.follow) {
@@ -1266,6 +1268,7 @@ const InnerRouter = ({
       try {
         const resolved = await dataPromise;
         if (isAborted()) {
+          emitRouteChangeEvent('error', nextRoute);
           return;
         }
         abortRef.current = null;
@@ -1276,6 +1279,7 @@ const InnerRouter = ({
         );
       } catch (e) {
         if (isAborted()) {
+          emitRouteChangeEvent('error', nextRoute);
           return;
         }
         const info = getErrorInfo(e);
@@ -1331,6 +1335,7 @@ const InnerRouter = ({
           },
         });
         setErr(failure);
+        emitRouteChangeEvent('error', nextRoute);
         throw failure;
       }
     },

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -209,8 +209,12 @@ const createRouteChangeListeners = (): [
     if (!eventListenersSet.size) {
       return;
     }
-    for (const listener of eventListenersSet) {
-      listener(route);
+    for (const listener of [...eventListenersSet]) {
+      try {
+        listener(route);
+      } catch (e) {
+        console.error('Error in a route change listener:', e);
+      }
     }
   };
   return [
@@ -1193,19 +1197,24 @@ const InnerRouter = ({
   const fetchingSlices = useRef(new Set<SliceId>()).current;
   const followBudget = useRef<FollowBudget>({ spent: 0 }).current;
   const abortRef = useRef<AbortController | null>(null);
+  const announcedRef = useRef<RouteProps | null>(null);
 
   const changeRoute: ChangeRoute = useCallback(
     async function changeRoute(nextRoute, options) {
+      const superseded = abortRef.current ? announcedRef.current : null;
       abortRef.current?.abort();
       const abortController = new AbortController();
       abortRef.current = abortController;
       const isAborted = () => abortController.signal.aborted;
+      if (superseded) {
+        emitRouteChangeEvent('error', superseded);
+      }
       if (options.follow !== 'inline') {
+        announcedRef.current = nextRoute;
         emitRouteChangeEvent('start', nextRoute);
       }
       // a start listener can navigate synchronously, which aborts this one
       if (isAborted()) {
-        emitRouteChangeEvent('error', nextRoute);
         return;
       }
       if (!options.follow) {
@@ -1268,7 +1277,6 @@ const InnerRouter = ({
       try {
         const resolved = await dataPromise;
         if (isAborted()) {
-          emitRouteChangeEvent('error', nextRoute);
           return;
         }
         abortRef.current = null;
@@ -1279,7 +1287,6 @@ const InnerRouter = ({
         );
       } catch (e) {
         if (isAborted()) {
-          emitRouteChangeEvent('error', nextRoute);
           return;
         }
         const info = getErrorInfo(e);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -176,7 +176,7 @@ type ChangeRouteOptions = {
   history: 'push' | 'replace' | null;
   url?: URL | undefined;
   instant?: boolean | undefined;
-  follow?: 'inline' | 'boundary' | undefined;
+  follow?: 'continues' | 'announces' | undefined;
 };
 
 type ChangeRoute = (
@@ -885,7 +885,7 @@ const FollowError = ({
             : target.path !== caught.path,
           history: 'replace',
           url,
-          follow: 'boundary',
+          follow: 'announces',
           refetch: true,
         }).then(
           () => {
@@ -1217,7 +1217,7 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      if (options.follow !== 'inline') {
+      if (options.follow !== 'continues') {
         announcedRef.current = nextRoute;
         emitRouteChangeEvent('start', nextRoute);
       }
@@ -1333,7 +1333,7 @@ const InnerRouter = ({
             shouldScroll: options.shouldScroll,
             history: null,
             url: errorRoute.url,
-            follow: 'inline',
+            follow: 'continues',
             refetch: true,
           });
         }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -213,10 +213,13 @@ const createRouteChangeListeners = (): [
       if (!eventListenersSet.has(listener)) {
         continue;
       }
-      try {
-        listener(route);
-      } catch (e) {
+      const report = (e: unknown) => {
         console.error(`Error in a route change '${event}' listener:`, e);
+      };
+      try {
+        Promise.resolve(listener(route)).catch(report);
+      } catch (e) {
+        report(e);
       }
     }
   };

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -210,6 +210,9 @@ const createRouteChangeListeners = (): [
       return;
     }
     for (const listener of [...eventListenersSet]) {
+      if (!eventListenersSet.has(listener)) {
+        continue;
+      }
       try {
         listener(route);
       } catch (e) {
@@ -1207,13 +1210,17 @@ const InnerRouter = ({
       abortRef.current = abortController;
       const isAborted = () => abortController.signal.aborted;
       if (superseded) {
+        announcedRef.current = null;
         emitRouteChangeEvent('error', superseded);
+      }
+      // a listener can navigate synchronously, which aborts this one
+      if (isAborted()) {
+        return;
       }
       if (options.follow !== 'inline') {
         announcedRef.current = nextRoute;
         emitRouteChangeEvent('start', nextRoute);
       }
-      // a start listener can navigate synchronously, which aborts this one
       if (isAborted()) {
         return;
       }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -176,7 +176,7 @@ type ChangeRouteOptions = {
   history: 'push' | 'replace' | null;
   url?: URL | undefined;
   instant?: boolean | undefined;
-  follow?: boolean | undefined;
+  follow?: 'inline' | 'boundary' | undefined;
 };
 
 type ChangeRoute = (
@@ -877,7 +877,7 @@ const FollowError = ({
             : target.path !== caught.path,
           history: 'replace',
           url,
-          follow: true,
+          follow: 'boundary',
           refetch: true,
         }).then(
           () => {
@@ -1199,7 +1199,9 @@ const InnerRouter = ({
       const abortController = new AbortController();
       abortRef.current = abortController;
       const isAborted = () => abortController.signal.aborted;
-      emitRouteChangeEvent('start', nextRoute);
+      if (options.follow !== 'inline') {
+        emitRouteChangeEvent('start', nextRoute);
+      }
       // a start listener can navigate synchronously, which aborts this one
       if (isAborted()) {
         return;
@@ -1313,7 +1315,7 @@ const InnerRouter = ({
             shouldScroll: options.shouldScroll,
             history: null,
             url: errorRoute.url,
-            follow: true,
+            follow: 'inline',
             refetch: true,
           });
         }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -204,23 +204,39 @@ const createRouteChangeListeners = (): [
     complete: new Set(),
     error: new Set(),
   };
+  const queued: [ChangeRouteEvent, RouteProps][] = [];
+  let dispatching = false;
   const emit = (event: ChangeRouteEvent, route: RouteProps) => {
-    const eventListenersSet = listeners[event];
-    if (!eventListenersSet.size) {
+    queued.push([event, route]);
+    if (dispatching) {
       return;
     }
-    for (const listener of [...eventListenersSet]) {
-      if (!eventListenersSet.has(listener)) {
-        continue;
+    dispatching = true;
+    try {
+      let next = queued.shift();
+      while (next) {
+        const [queuedEvent, queuedRoute] = next;
+        const eventListenersSet = listeners[queuedEvent];
+        const report = (e: unknown) => {
+          console.error(
+            `Error in a route change '${queuedEvent}' listener:`,
+            e,
+          );
+        };
+        for (const listener of [...eventListenersSet]) {
+          if (!eventListenersSet.has(listener)) {
+            continue;
+          }
+          try {
+            Promise.resolve(listener(queuedRoute)).catch(report);
+          } catch (e) {
+            report(e);
+          }
+        }
+        next = queued.shift();
       }
-      const report = (e: unknown) => {
-        console.error(`Error in a route change '${event}' listener:`, e);
-      };
-      try {
-        Promise.resolve(listener(route)).catch(report);
-      } catch (e) {
-        report(e);
-      }
+    } finally {
+      dispatching = false;
     }
   };
   return [

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1807,6 +1807,78 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a failed navigation ends with an error event', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>((() =>
+      Promise.reject(
+        createCustomError('boom', { status: 500 }),
+      )) as unknown as ReturnType<typeof useRefetch>);
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+      </ErrorBoundary>,
+    );
+    try {
+      const events: string[] = [];
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
+
+      await act(async () => {
+        await capture.router!.push('/next' as never).catch(() => {});
+        await flushUntil(() => events.length >= 2);
+      });
+
+      expect(events).toEqual(['start /next', 'error /next']);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('a superseded navigation ends with an error event', async () => {
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { resolve: { [ROUTE_ID]: ['/slow', ''], [IS_STATIC_ID]: false } },
+        { resolve: { [ROUTE_ID]: ['/fast', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/slow', '/fast'],
+    });
+    const events: string[] = [];
+    for (const name of ['start', 'complete', 'error'] as const) {
+      capture.router!.unstable_events.on(name, (route) =>
+        events.push(`${name} ${route.path}`),
+      );
+    }
+
+    await act(async () => {
+      const slow = router.push('/slow').catch(() => {});
+      await router.push('/fast').catch(() => {});
+      await slow;
+      await flushUntil(() => events.length >= 4);
+    });
+
+    // every start reaches a terminal event, whichever order they interleave in
+    expect(events.filter((e) => e.startsWith('start')).length).toBe(2);
+    expect(events).toContain('error /slow');
+    expect(events).toContain('complete /fast');
+
+    view.unmount();
+  });
+
   test('a 404 follow reports one navigation that landed on the 404 route', async () => {
     const { view, capture, router } = await renderFollowRouter({
       responses: [

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1871,12 +1871,52 @@ describe('Router integration', () => {
       await flushUntil(() => events.length >= 4);
     });
 
-    // every start reaches a terminal event, whichever order they interleave in
-    expect(events.filter((e) => e.startsWith('start')).length).toBe(2);
-    expect(events).toContain('error /slow');
-    expect(events).toContain('complete /fast');
+    // the superseded one closes before the winner announces itself, so a
+    // listener that flips a boolean is never left showing the wrong state
+    expect(events).toEqual([
+      'start /slow',
+      'error /slow',
+      'start /fast',
+      'complete /fast',
+    ]);
 
     view.unmount();
+  });
+
+  test('a listener that throws does not break the navigation', async () => {
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/next'],
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      const events: string[] = [];
+      capture.router!.unstable_events.on('start', () => {
+        throw new Error('listener blew up');
+      });
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
+
+      await act(async () => {
+        await router.push('/next').catch(() => {});
+        await flushUntil(() => events.length >= 2);
+      });
+
+      // the thrower is reported and the other listeners still see the whole run
+      expect(events).toEqual(['start /next', 'complete /next']);
+      expect(capture.router!.path).toBe('/next');
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
   });
 
   test('a 404 follow reports one navigation that landed on the 404 route', async () => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2021,7 +2021,7 @@ describe('Router integration', () => {
     }
   });
 
-  test('a listener registered after a navigating one sees it out of order', async () => {
+  test('a listener that navigates does not reorder events for others', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {
@@ -2062,12 +2062,12 @@ describe('Router integration', () => {
         await flushUntil(() => events.includes('complete /b'));
       });
 
-      // documented caveat: the nested navigation is served before the rest of
-      // the emit reaches listeners registered after the one that navigated
+      // the nested navigation's events queue behind the emit that caused them,
+      // so this listener sees the same order as one registered first
       expect(events).toEqual([
+        'start /a',
         'error /a',
         'start /b',
-        'start /a',
         'complete /b',
       ]);
     } finally {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2021,6 +2021,92 @@ describe('Router integration', () => {
     }
   });
 
+  test('a listener registered after a navigating one sees it out of order', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {
+      const path = rscPath === unstable_encodeRoutePath('/b') ? '/b' : '/a';
+      return Promise.resolve({
+        [unstable_getRouteSlotId(path)]: <Probe />,
+        [ROUTE_ID]: [path, ''],
+        [IS_STATIC_ID]: false,
+      });
+    }) as unknown as ReturnType<typeof useRefetch>);
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const view = await renderApp(
+      <Router initialRoute={{ path: '/start', query: '', hash: '' }} />,
+    );
+    try {
+      const events: string[] = [];
+      let redirected = false;
+      capture.router!.unstable_events.on('start', (route) => {
+        if (route.path === '/a' && !redirected) {
+          redirected = true;
+          void capture.router!.push('/b' as never).catch(() => {});
+        }
+      });
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
+
+      await act(async () => {
+        await capture.router!.push('/a' as never).catch(() => {});
+        await flushUntil(() => events.includes('complete /b'));
+      });
+
+      // documented caveat: the nested navigation is served before the rest of
+      // the emit reaches listeners registered after the one that navigated
+      expect(events).toEqual([
+        'error /a',
+        'start /b',
+        'start /a',
+        'complete /b',
+      ]);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test('an async listener that rejects is reported like a sync one', async () => {
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/next'],
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      const events: string[] = [];
+      capture.router!.unstable_events.on('start', async () => {
+        throw new Error('async listener blew up');
+      });
+      capture.router!.unstable_events.on('complete', (route) =>
+        events.push(`complete ${route.path}`),
+      );
+
+      await act(async () => {
+        await router.push('/next').catch(() => {});
+        await flushUntil(() => events.length > 0);
+      });
+
+      expect(events).toEqual(['complete /next']);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('a listener removed during an emit is not called', async () => {
     const { view, capture, router } = await renderFollowRouter({
       responses: [

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1857,28 +1857,142 @@ describe('Router integration', () => {
       ],
       slots: ['/slow', '/fast'],
     });
-    const events: string[] = [];
-    for (const name of ['start', 'complete', 'error'] as const) {
-      capture.router!.unstable_events.on(name, (route) =>
-        events.push(`${name} ${route.path}`),
-      );
+    try {
+      const events: string[] = [];
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
+
+      await act(async () => {
+        const slow = router.push('/slow').catch(() => {});
+        await router.push('/fast').catch(() => {});
+        await slow;
+        await flushUntil(() => events.length >= 4);
+      });
+
+      // the superseded one closes before the winner announces itself, so a
+      // listener that flips a boolean is never left showing the wrong state
+      expect(events).toEqual([
+        'start /slow',
+        'error /slow',
+        'start /fast',
+        'complete /fast',
+      ]);
+    } finally {
+      view.unmount();
     }
+  });
+
+  test('an error listener that navigates does not double the terminal', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(((rscPath: string) => {
+      const path = ['/a', '/b', '/c'].find(
+        (p) => rscPath === unstable_encodeRoutePath(p),
+      );
+      return Promise.resolve({
+        [unstable_getRouteSlotId(path!)]: <Probe />,
+        [ROUTE_ID]: [path, ''],
+        [IS_STATIC_ID]: false,
+      });
+    }) as unknown as ReturnType<typeof useRefetch>);
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const view = await renderApp(
+      <Router initialRoute={{ path: '/start', query: '', hash: '' }} />,
+    );
+    try {
+      const events: string[] = [];
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
+      capture.router!.unstable_events.on('error', () => {
+        void capture.router!.push('/c' as never).catch(() => {});
+      });
+
+      await act(async () => {
+        const a = capture.router!.push('/a' as never).catch(() => {});
+        await capture.router!.push('/b' as never).catch(() => {});
+        await a;
+        await flushUntil(() => events.some((e) => e.startsWith('complete')));
+      });
+
+      // /a closes once, and /b never announces itself because /c replaced it
+      expect(events.filter((e) => e === 'error /a')).toHaveLength(1);
+      expect(events).not.toContain('start /b');
+      expect(events.filter((e) => e.startsWith('complete'))).toEqual([
+        'complete /c',
+      ]);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test('a navigation after a finished one reports no error', async () => {
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { resolve: { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: false } },
+        { resolve: { [ROUTE_ID]: ['/b', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/a', '/b'],
+    });
+    try {
+      const events: string[] = [];
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
+
+      await act(async () => {
+        await router.push('/a').catch(() => {});
+        await flushUntil(() => events.includes('complete /a'));
+        await router.push('/b').catch(() => {});
+        await flushUntil(() => events.includes('complete /b'));
+      });
+
+      // the first one already closed, so the second must not supersede it
+      expect(events).toEqual([
+        'start /a',
+        'complete /a',
+        'start /b',
+        'complete /b',
+      ]);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test('a listener removed during an emit is not called', async () => {
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { resolve: { [ROUTE_ID]: ['/next', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/next'],
+    });
+    const called: string[] = [];
+    const doomed = () => called.push('doomed');
+    capture.router!.unstable_events.on('start', () => {
+      called.push('first');
+      capture.router!.unstable_events.off('start', doomed);
+    });
+    capture.router!.unstable_events.on('start', doomed);
 
     await act(async () => {
-      const slow = router.push('/slow').catch(() => {});
-      await router.push('/fast').catch(() => {});
-      await slow;
-      await flushUntil(() => events.length >= 4);
+      await router.push('/next').catch(() => {});
+      await flushUntil(() => called.length > 0);
     });
 
-    // the superseded one closes before the winner announces itself, so a
-    // listener that flips a boolean is never left showing the wrong state
-    expect(events).toEqual([
-      'start /slow',
-      'error /slow',
-      'start /fast',
-      'complete /fast',
-    ]);
+    expect(called).toEqual(['first']);
 
     view.unmount();
   });
@@ -1928,23 +2042,25 @@ describe('Router integration', () => {
       slots: ['/404'],
       meta: { [HAS404_ID]: true },
     });
-    const events: string[] = [];
-    capture.router!.unstable_events.on('start', (route) =>
-      events.push(`start ${route.path}`),
-    );
-    capture.router!.unstable_events.on('complete', (route) =>
-      events.push(`complete ${route.path}`),
-    );
+    try {
+      const events: string[] = [];
+      capture.router!.unstable_events.on('start', (route) =>
+        events.push(`start ${route.path}`),
+      );
+      capture.router!.unstable_events.on('complete', (route) =>
+        events.push(`complete ${route.path}`),
+      );
 
-    await act(async () => {
-      await router.push('/missing').catch(() => {});
-      await flushUntil(() => events.length >= 2);
-    });
+      await act(async () => {
+        await router.push('/missing').catch(() => {});
+        await flushUntil(() => events.length >= 2);
+      });
 
-    // the follow finishes the navigation the user asked for, it is not a new one
-    expect(events).toEqual(['start /missing', 'complete /404']);
-
-    view.unmount();
+      // the follow finishes the navigation it was asked for, not a new one
+      expect(events).toEqual(['start /missing', 'complete /404']);
+    } finally {
+      view.unmount();
+    }
   });
 
   test('a followed redirect emits events for the attempt and the follow', async () => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1937,6 +1937,55 @@ describe('Router integration', () => {
     }
   });
 
+  test('a 404 follow that fails closes with the route it was fetching', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>();
+    refetch
+      .mockImplementationOnce(() =>
+        Promise.reject(createCustomError('nf', { status: 404 })),
+      )
+      .mockImplementationOnce(() =>
+        Promise.reject(createCustomError('boom', { status: 500 })),
+      );
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/404')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+      [HAS404_ID]: true,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+      </ErrorBoundary>,
+    );
+    try {
+      const events: string[] = [];
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
+
+      await act(async () => {
+        await capture.router!.push('/missing' as never).catch(() => {});
+        await flushUntil(() => events.length >= 2);
+      });
+
+      // the start still closes, carrying the route the follow was fetching
+      expect(events).toEqual(['start /missing', 'error /404']);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('a navigation after a finished one reports no error', async () => {
     const { view, capture, router } = await renderFollowRouter({
       responses: [

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1807,6 +1807,34 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a 404 follow reports one navigation that landed on the 404 route', async () => {
+    const { view, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 404 } },
+        { resolve: { [ROUTE_ID]: ['/404', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/404'],
+      meta: { [HAS404_ID]: true },
+    });
+    const events: string[] = [];
+    capture.router!.unstable_events.on('start', (route) =>
+      events.push(`start ${route.path}`),
+    );
+    capture.router!.unstable_events.on('complete', (route) =>
+      events.push(`complete ${route.path}`),
+    );
+
+    await act(async () => {
+      await router.push('/missing').catch(() => {});
+      await flushUntil(() => events.length >= 2);
+    });
+
+    // the follow finishes the navigation the user asked for, it is not a new one
+    expect(events).toEqual(['start /missing', 'complete /404']);
+
+    view.unmount();
+  });
+
   test('a followed redirect emits events for the attempt and the follow', async () => {
     const { view, capture, router } = await renderFollowRouter({
       responses: [


### PR DESCRIPTION
Route change events now describe one navigation from start to finish.

A navigation landing on the 404 page used to announce itself twice, as start /missing, start /404, complete /404. It now reports start /missing, complete /404.

A navigation that failed or was superseded emitted nothing after its start. There is a new error event, so every start is closed by exactly one complete or error, and a superseded navigation closes before the next one starts. A listener that throws is logged instead of breaking the navigation.
