### PR TITLE
fix: recover from the entry chunk itself failing to load

### DIFF
--- a/packages/waku/src/lib/utils/ssr.ts
+++ b/packages/waku/src/lib/utils/ssr.ts
@@ -1,5 +1,49 @@
 import { createInitialRscEntryCode } from './initial-rsc.js';
 
+/**
+ * Recovers from the entry chunk itself failing to load — the one dynamic
+ * import in this document (`@vitejs/plugin-rsc`'s bootstrap
+ * `import(entryUrl)`, appended right after this preamble) that Vite's own
+ * `__vitePreload` helper never wraps, since nothing has loaded yet for it to
+ * rewrite. During the version-skew window this build id exists to detect,
+ * that import can 404 (a deploy host hasn't atomically flipped the served
+ * document and its asset manifest together), and a failed `import()` never
+ * throws synchronously — it surfaces only as `unhandledrejection`, never
+ * `vite:preloadError`, so `entry.browser.tsx`'s own listener (which recovers
+ * a *lazy* chunk failing once the entry itself is already running) cannot
+ * fire for this one. Each engine phrases a failed dynamic import
+ * differently, so this matches substrings that hold across Chromium,
+ * Firefox, and Safari rather than one exact string.
+ *
+ * Bounded to one reload per document: this runs ahead of hydration, so
+ * there's nothing yet to hand a budget back to on success the way a mounted
+ * app could. A version-skew window is measured in seconds, so one attempt is
+ * what it needs.
+ *
+ * Unconditional rather than gated on `WAKU_BUILD_ID` the way
+ * `entry.browser.tsx`'s own listener is: that gate is truthy in dev too (the
+ * plugin defines it `'dev'`, not empty, outside a real build), so it already
+ * guards nothing in practice, and this listener is inert unless the exact
+ * failure it matches actually occurs.
+ */
+const ENTRY_IMPORT_RECOVERY = `
+addEventListener("unhandledrejection",function(e){
+  var m=e&&e.reason&&e.reason.message;
+  if(typeof m!=="string")return;
+  m=m.toLowerCase();
+  if(m.indexOf("failed to fetch dynamically imported module")<0&&
+     m.indexOf("error loading dynamically imported module")<0&&
+     m.indexOf("importing a module script failed")<0)return;
+  try{
+    var k="waku:entry-import-reload";
+    if(sessionStorage.getItem(k))return;
+    sessionStorage.setItem(k,"1");
+  }catch(_){return}
+  e.preventDefault();
+  location.reload();
+});
+`.trim();
+
 export function getBootstrapPreamble(options: {
   hydrate: boolean;
   debugId?: string | undefined;
@@ -9,5 +53,6 @@ export function getBootstrapPreamble(options: {
     globalThis.__WAKU_INITIAL_RSC__ = ${createInitialRscEntryCode(
       options.debugId,
     )};
+    ${ENTRY_IMPORT_RECOVERY}
   `;
 }

--- a/packages/waku/tests/ssr-utils.test.ts
+++ b/packages/waku/tests/ssr-utils.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getBootstrapPreamble } from '../src/lib/utils/ssr.js';
 
 describe('getBootstrapPreamble', () => {
@@ -17,5 +18,116 @@ describe('getBootstrapPreamble', () => {
     expect(getBootstrapPreamble({ hydrate: true })).not.toContain(
       'e.debugId =',
     );
+  });
+
+  it('includes the entry-import recovery listener on both the hydrate and SSR-fallback paths', () => {
+    // The bootstrap `import(entryUrl)` this preamble precedes runs on both
+    // paths (see `renderHtmlStream` in `vite-rsc/ssr.tsx`), so both need the
+    // listener that recovers from it failing to load.
+    expect(getBootstrapPreamble({ hydrate: true })).toContain(
+      'addEventListener("unhandledrejection"',
+    );
+    expect(getBootstrapPreamble({ hydrate: false })).toContain(
+      'addEventListener("unhandledrejection"',
+    );
+  });
+});
+
+/**
+ * Runs the emitted preamble's own source rather than a re-typed copy of its
+ * logic — the point of these tests is the exact string that reaches the
+ * document, so a drift between what is tested and what ships would defeat
+ * them.
+ */
+function armEntryImportRecovery(): void {
+  new Function(getBootstrapPreamble({ hydrate: true })).call(window);
+}
+
+/** The event a native `import()` rejection dispatches when nothing catches
+    it. `PromiseRejectionEvent` isn't constructible under happy-dom, so a
+    plain cancelable `Event` stands in with `reason` assigned — the script
+    only ever reads `e.reason.message`. */
+function unhandledRejection(message: string): Event {
+  const event = new Event('unhandledrejection', { cancelable: true });
+  Object.assign(event, { reason: new Error(message) });
+  return event;
+}
+
+describe('entry-import recovery', () => {
+  let reload: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    [
+      'Chromium',
+      'Failed to fetch dynamically imported module: https://example.com/entry.js',
+    ],
+    [
+      'Firefox',
+      'error loading dynamically imported module: https://example.com/entry.js',
+    ],
+    ['Safari', 'Importing a module script failed.'],
+  ])(
+    'reloads once when the entry import rejects (%s wording)',
+    (_engine, message) => {
+      armEntryImportRecovery();
+
+      const event = unhandledRejection(message);
+      window.dispatchEvent(event);
+
+      expect(reload).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
+    },
+  );
+
+  it('ignores a rejection unrelated to a failed module import', () => {
+    armEntryImportRecovery();
+
+    const event = unhandledRejection('Network request failed');
+    window.dispatchEvent(event);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('stops reloading once one attempt is spent', () => {
+    armEntryImportRecovery();
+
+    const message = 'Failed to fetch dynamically imported module: x';
+    window.dispatchEvent(unhandledRejection(message));
+    const second = unhandledRejection(message);
+    window.dispatchEvent(second);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(second.defaultPrevented).toBe(false);
+  });
+
+  it('loads the page even where storage is blocked', () => {
+    const blocked = () => {
+      throw new Error('storage blocked');
+    };
+    vi.stubGlobal('sessionStorage', {
+      getItem: blocked,
+      setItem: blocked,
+      removeItem: blocked,
+    });
+    armEntryImportRecovery();
+
+    const event = unhandledRejection(
+      'Failed to fetch dynamically imported module: x',
+    );
+    expect(() => window.dispatchEvent(event)).not.toThrow();
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #2238.

## Problem

Version-skew recovery (#2072, from discussion #1037) registers its `vite:preloadError` listener inside `entry.browser.tsx`:

```ts
if (import.meta.env.WAKU_BUILD_ID) {
  window.addEventListener('vite:preloadError', () => {
    window.location.reload();
  });
}
```

But the bootstrap script that loads this very file is a bare `import(entryUrl)` written by `@vitejs/plugin-rsc`, never wrapped by Vite's `__vitePreload` helper (the thing that dispatches `vite:preloadError`) — nothing has loaded yet for that helper to rewrite. `import()` never throws synchronously, so a failed fetch of the entry chunk surfaces only as an `unhandledrejection`, which nothing was listening for.

The result is a self-referential hole: the file containing the recovery listener is the one file whose own failure to load needs recovering. During the same version-skew window this feature exists to handle (a deploy host that hasn't atomically flipped the served document and its asset manifest together), if the 404 lands on the entry chunk rather than a chunk loaded later, the page is left permanently blank instead of self-healing.

## Fix

Add an `unhandledrejection` listener to `getBootstrapPreamble` (`packages/waku/src/lib/utils/ssr.ts`), which runs immediately ahead of the bootstrap `import()` on both the hydrate and SSR-fallback paths in `renderHtmlStream` — before that import can fail, rather than inside the file it's trying to load. Each JS engine phrases a failed dynamic import differently, so the listener matches substrings that hold across Chromium, Firefox, and Safari rather than trusting one exact string:

- Chromium: "Failed to fetch dynamically imported module"
- Firefox: "error loading dynamically imported module"
- Safari: "Importing a module script failed."

Bounded to one reload per document via `sessionStorage` — the same reasoning the existing `preloadError` recovery leans on implicitly, made explicit here since this runs ahead of hydration and so has nothing to hand a budget back to on success.

Unconditional rather than gated on `WAKU_BUILD_ID` the way the existing listener is: that gate is truthy in dev too (`buildIdPlugin` defines it `'dev'`, not empty, outside a real build), so it already guards nothing in practice — and this listener is inert unless the exact failure it matches actually occurs, so there's nothing to gain by conditioning it.

## Verification

- Added 7 new unit tests to `tests/ssr-utils.test.ts` (all three engines' wording, an unrelated-rejection is ignored, a malformed reason is ignored, the one-reload budget, storage-blocked graceful degradation) plus one test confirming the listener is present on both the hydrate and SSR-fallback paths — 9/9 pass; confirmed 5 fail against the pre-fix code.
- `pnpm run compile`, `tsc -b`, `eslint`, and `prettier -c` all clean.
- Full unit suite: 648/648 passing.
- Built the `01_basic` template end-to-end, ran it with `waku start`, and confirmed the listener is present verbatim in the actual served HTML, immediately ahead of the bootstrap `import()`.

Prior art: Astro hit the identical shape of bug (an uncaught `import()` bootstrapping island hydration, no recovery) and fixed it upstream as a framework bug — withastro/astro#16341 → withastro/astro#16412.