### PR TITLE
fix(router): answer a missing route in one request

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -165,9 +165,11 @@ export const PostButton = () => {
 
 Both return a promise that resolves once the navigation you asked for has been handled: after the response when the route needs one, right away when it does not, such as a static route already loaded once or the route you are already on, and also when a newer navigation supersedes it.
 
-It does not wait for a follow. A response that comes back 404, and anything your page throws while rendering such as a late `unstable_notFound()` or `unstable_redirect()`, is followed by a navigation of its own that starts after this promise has settled. A redirect carried by the response leaves the app with a full page load.
+It does not wait for a follow. Anything your page throws while rendering, such as a late `unstable_notFound()` or `unstable_redirect()`, is followed by a navigation of its own that starts after this promise has settled.
 
-The promise rejects when the navigation fails, including when the response came back 404, so catch it if you await it. It also does not wait for React to finish rendering the destination, so the address bar may still show the previous URL when it resolves.
+A missing route depends on who answers the request. A Waku server sends the 404 page as the response, so the promise resolves and the route you land on is `/404`. Where no Waku server answers, such as a static export or a CDN serving its own 404, the request fails and the client fetches the 404 page itself: there the promise **rejects** and the 404 page arrives from a second navigation.
+
+The promise also rejects when the navigation fails outright, and when a redirect carried by the response hands the page to the browser. Catch it if you call these programmatically, or an auth redirect at the fetch layer will surface as an unhandled rejection. It does not wait for React to finish rendering the destination, so the address bar may still show the previous URL when it resolves.
 
 When the shell is cached, the layout and the `Loading...` fallback appear with no round trip, and the post's content streams into the fallback once the server responds. When the shell is **not** cached, the navigation falls back to normal behavior: the current page stays put until the response arrives, so there is no blank flash.
 
@@ -245,7 +247,11 @@ export const NavigationLogger = () => {
 
 Every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
 
-`complete` carries the route the response landed on, which is not always the one you asked for, because the server can answer with the destination of a redirect or with the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded, and reports the route it announced. A navigation that fails and is then followed, such as a 404 response or a late `unstable_redirect()`, reports its own `error` first and the follow opens a `start` of its own. A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates gets a navigation right away, and its events queue behind the one being delivered, so every listener sees the same order whenever it subscribed.
+`complete` carries the route the response landed on, which is not always the one you asked for, because the server can answer with the destination of a redirect or with the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded, and reports the route it announced.
+
+A follow is a navigation of its own, so it opens its own `start`. A late `unstable_redirect()` reports `complete` for the page that threw it and then a second pair for the destination. A navigation that fails first, such as a 404 with no Waku server to answer it, reports `error` and then the follow's own pair.
+
+A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates gets a navigation right away, and its events queue behind the one being delivered, so every listener sees the same order whenever it subscribed.
 
 A redirect carried by the response hands the page to the browser. It still reports `error` for the navigation it was asked to make, and the full page load follows.
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -243,11 +243,11 @@ export const NavigationLogger = () => {
 };
 ```
 
-Unless the browser takes over the page, every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
+Every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
 
 `complete` carries the route the response landed on, which is not always the one you asked for, because the server can answer with the destination of a redirect or with the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded, and reports the route it announced. A navigation that fails and is then followed, such as a 404 response or a late `unstable_redirect()`, reports its own `error` first and the follow opens a `start` of its own. A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates gets a navigation right away, and its events queue behind the one being delivered, so every listener sees the same order whenever it subscribed.
 
-A redirect carried by the response is the case where the browser takes over: it emits no closing event, because a full page load is already under way.
+A redirect carried by the response hands the page to the browser. It still reports `error` for the navigation it was asked to make, and the full page load follows.
 
 For a spinner, prefer `useNavigationStatus_UNSTABLE()` above. A `start` listener runs inside the navigation's transition, so state you set there is batched with the navigation itself and may not paint on its own.
 

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -165,9 +165,9 @@ export const PostButton = () => {
 
 Both return a promise that resolves once the navigation you asked for has been handled: after the response when the route needs one, right away when it does not, such as a static route already loaded once or the route you are already on, and also when a newer navigation supersedes it.
 
-It waits for the 404 page when the response itself came back 404. It does not wait for anything your page throws while rendering, such as a late `unstable_notFound()` or `unstable_redirect()`, which are followed after the promise has already resolved. A redirect carried by the response leaves the app with a full page load.
+It does not wait for a follow. A response that comes back 404, and anything your page throws while rendering such as a late `unstable_notFound()` or `unstable_redirect()`, is followed by a navigation of its own that starts after this promise has settled. A redirect carried by the response leaves the app with a full page load.
 
-The promise rejects when the navigation fails, so catch it if you await it. It also does not wait for React to finish rendering the destination, so the address bar may still show the previous URL when it resolves.
+The promise rejects when the navigation fails, including when the response came back 404, so catch it if you await it. It also does not wait for React to finish rendering the destination, so the address bar may still show the previous URL when it resolves.
 
 When the shell is cached, the layout and the `Loading...` fallback appear with no round trip, and the post's content streams into the fallback once the server responds. When the shell is **not** cached, the navigation falls back to normal behavior: the current page stays put until the response arrives, so there is no blank flash.
 
@@ -245,7 +245,7 @@ export const NavigationLogger = () => {
 
 Unless the browser takes over the page, every `start` is followed by exactly one `complete` or `error`, and they never interleave: when a second navigation supersedes one that is still running, the first one's `error` arrives before the second one's `start`.
 
-`complete` carries the route the response landed on, which is not always the one you asked for, because the server can redirect or send the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded. A superseded one reports the route it announced; a failed one reports the route it was fetching, which is the 404 page when the follow to it failed. A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates gets a navigation right away, and its events queue behind the one being delivered, so every listener sees the same order whenever it subscribed.
+`complete` carries the route the response landed on, which is not always the one you asked for, because the server can answer with the destination of a redirect or with the 404 page. It fires when the response has been handled, not when React has finished rendering it. `error` means the navigation failed or was superseded, and reports the route it announced. A navigation that fails and is then followed, such as a 404 response or a late `unstable_redirect()`, reports its own `error` first and the follow opens a `start` of its own. A listener that throws is reported to the console and does not affect the navigation or the other listeners. A listener that navigates gets a navigation right away, and its events queue behind the one being delivered, so every listener sees the same order whenever it subscribed.
 
 A redirect carried by the response is the case where the browser takes over: it emits no closing event, because a full page load is already under way.
 

--- a/docs/guides/redirects-and-not-found.mdx
+++ b/docs/guides/redirects-and-not-found.mdx
@@ -83,6 +83,8 @@ export default function NewPostPage() {
 }
 ```
 
+Waku renders the destination into the same response, so the client does not make a second request. That only works for a target it can render: a path on this site, without a hash. Anything else, including a target that is not a route at all, is sent back as a real HTTP redirect for the browser to follow, which costs a full page load.
+
 ## Render Not Found for Missing Data
 
 Use `unstable_notFound` when a route matches but the backing data does not exist:
@@ -127,6 +129,8 @@ export const getConfig = async () => {
 ```
 
 If a `/404` page exists, Waku uses it for unmatched routes and `notFound()` results. If it does not exist, Waku falls back to a minimal not-found response.
+
+A client-side navigation to a missing route is answered the same way: the server sends the 404 page in the response, so the client does not need a second request. That response carries status 200, because it carries a page rather than an error. A direct page load of the same URL is still a 404. Where no Waku server answers, such as a static export, the request 404s and the client fetches the 404 page itself.
 
 ## Status and Streaming Notes
 

--- a/docs/guides/redirects-and-not-found.mdx
+++ b/docs/guides/redirects-and-not-found.mdx
@@ -83,7 +83,7 @@ export default function NewPostPage() {
 }
 ```
 
-Waku renders the destination into the same response, so the client does not make a second request. That only works for a target it can render: a path on this site, without a hash. Anything else, including a target that is not a route at all, is sent back as a real HTTP redirect for the browser to follow, which costs a full page load.
+Waku renders the destination into the same response, so the client does not make a second request. That only works for a target it can render: a path on this site, without a hash. Anything else, including a target that is not a route at all, is handed to the browser, which costs a full page load.
 
 ## Render Not Found for Missing Data
 

--- a/docs/guides/redirects-and-not-found.mdx
+++ b/docs/guides/redirects-and-not-found.mdx
@@ -83,7 +83,7 @@ export default function NewPostPage() {
 }
 ```
 
-Waku renders the destination into the same response, so the client does not make a second request. That only works for a target it can render: a path on this site, without a hash. Anything else, including a target that is not a route at all, is handed to the browser, which costs a full page load.
+Waku renders the destination into the same response, so the client does not make a second request. That only works for a target it can render: a path on this site, without a hash. Anything else, including a target that is not a route at all, is handed to the browser as a 303, which costs a full page load. The 303 is what keeps the form submission from being sent again to the destination.
 
 ## Render Not Found for Missing Data
 

--- a/docs/guides/redirects-and-not-found.mdx
+++ b/docs/guides/redirects-and-not-found.mdx
@@ -83,7 +83,7 @@ export default function NewPostPage() {
 }
 ```
 
-Waku renders the destination into the same response, so the client does not make a second request. That only works for a target it can render: a path on this site, without a hash. Anything else, including a target that is not a route at all, is handed to the browser as a 303, which costs a full page load. The 303 is what keeps the form submission from being sent again to the destination.
+Waku renders the destination into the same response, so the client does not make a second request. That only works for a target it can render: a path on this site, without a hash. Anything else, including a target that is not a route at all or one that renders not found, is handed to the browser as a 303, which costs a full page load. The 303 is what keeps the form submission from being sent again to the destination.
 
 ## Render Not Found for Missing Data
 

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -1,10 +1,9 @@
 type ErrorInfo = {
   status?: number;
   location?: string;
+  unstable_offRscEndpoint?: boolean;
   // set by the client, read by no one in waku: an app decides its own recovery
   unstable_networkError?: boolean;
-  // the rsc fetch landed outside the rsc endpoint, so its location is a url
-  unstable_offEndpoint?: boolean;
 };
 
 const isErrorInfo = (x: unknown): x is ErrorInfo => {
@@ -24,8 +23,8 @@ const isErrorInfo = (x: unknown): x is ErrorInfo => {
     return false;
   }
   if (
-    'unstable_offEndpoint' in x &&
-    typeof (x as ErrorInfo).unstable_offEndpoint !== 'boolean'
+    'unstable_offRscEndpoint' in x &&
+    typeof (x as ErrorInfo).unstable_offRscEndpoint !== 'boolean'
   ) {
     return false;
   }

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -3,6 +3,8 @@ type ErrorInfo = {
   location?: string;
   // set by the client, read by no one in waku: an app decides its own recovery
   unstable_networkError?: boolean;
+  // the rsc fetch landed outside the rsc endpoint, so its location is a url
+  unstable_offEndpoint?: boolean;
 };
 
 const isErrorInfo = (x: unknown): x is ErrorInfo => {
@@ -18,6 +20,12 @@ const isErrorInfo = (x: unknown): x is ErrorInfo => {
   if (
     'unstable_networkError' in x &&
     typeof (x as ErrorInfo).unstable_networkError !== 'boolean'
+  ) {
+    return false;
+  }
+  if (
+    'unstable_offEndpoint' in x &&
+    typeof (x as ErrorInfo).unstable_offEndpoint !== 'boolean'
   ) {
     return false;
   }

--- a/packages/waku/src/lib/utils/custom-errors.ts
+++ b/packages/waku/src/lib/utils/custom-errors.ts
@@ -1,7 +1,7 @@
 type ErrorInfo = {
   status?: number;
   location?: string;
-  unstable_offRscEndpoint?: boolean;
+  unstable_redirected?: boolean;
   // set by the client, read by no one in waku: an app decides its own recovery
   unstable_networkError?: boolean;
 };
@@ -23,8 +23,8 @@ const isErrorInfo = (x: unknown): x is ErrorInfo => {
     return false;
   }
   if (
-    'unstable_offRscEndpoint' in x &&
-    typeof (x as ErrorInfo).unstable_offRscEndpoint !== 'boolean'
+    'unstable_redirected' in x &&
+    typeof (x as ErrorInfo).unstable_redirected !== 'boolean'
   ) {
     return false;
   }

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -77,7 +77,7 @@ const checkStatus = async (
     throw createCustomError('redirected rsc request', {
       status: 307,
       location: response.url,
-      unstable_offRscEndpoint: true,
+      unstable_redirected: true,
     });
   }
   if (!response.ok) {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -77,7 +77,7 @@ const checkStatus = async (
     throw createCustomError('redirected rsc request', {
       status: 307,
       location: response.url,
-      unstable_offEndpoint: true,
+      unstable_offRscEndpoint: true,
     });
   }
   if (!response.ok) {

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -74,10 +74,10 @@ const checkStatus = async (
     (redirectedTo.origin !== window.location.origin ||
       !redirectedTo.pathname.startsWith(BASE_RSC_PATH))
   ) {
-    // redirected off the rsc endpoint; the navigation layer follows it
     throw createCustomError('redirected rsc request', {
       status: 307,
       location: response.url,
+      unstable_offEndpoint: true,
     });
   }
   if (!response.ok) {

--- a/packages/waku/src/router/client-utils/error-route.ts
+++ b/packages/waku/src/router/client-utils/error-route.ts
@@ -22,7 +22,7 @@ export const resolveErrorRoute = (
     if (!parsed) {
       return { type: 'unfollowable', location: info.location };
     }
-    if (parsed.origin !== window.location.origin) {
+    if (info.unstable_offEndpoint || parsed.origin !== window.location.origin) {
       return { type: 'leave', url: parsed };
     }
     if (info.location.startsWith('/') && !info.location.startsWith('//')) {

--- a/packages/waku/src/router/client-utils/error-route.ts
+++ b/packages/waku/src/router/client-utils/error-route.ts
@@ -22,10 +22,7 @@ export const resolveErrorRoute = (
     if (!parsed) {
       return { type: 'unfollowable', location: info.location };
     }
-    if (
-      info.unstable_offRscEndpoint ||
-      parsed.origin !== window.location.origin
-    ) {
+    if (info.unstable_redirected || parsed.origin !== window.location.origin) {
       return { type: 'leave', url: parsed };
     }
     if (info.location.startsWith('/') && !info.location.startsWith('//')) {

--- a/packages/waku/src/router/client-utils/error-route.ts
+++ b/packages/waku/src/router/client-utils/error-route.ts
@@ -22,7 +22,10 @@ export const resolveErrorRoute = (
     if (!parsed) {
       return { type: 'unfollowable', location: info.location };
     }
-    if (info.unstable_offEndpoint || parsed.origin !== window.location.origin) {
+    if (
+      info.unstable_offRscEndpoint ||
+      parsed.origin !== window.location.origin
+    ) {
       return { type: 'leave', url: parsed };
     }
     if (info.location.startsWith('/') && !info.location.startsWith('//')) {

--- a/packages/waku/src/router/client-utils/route-url.ts
+++ b/packages/waku/src/router/client-utils/route-url.ts
@@ -32,7 +32,9 @@ export const isSameRoute = (next: RouteProps, prev: RouteProps) =>
   next.query === prev.query &&
   next.hash === prev.hash;
 
-export const isSameRscRoute = (next: RouteProps, prev: RouteProps) =>
+type RscRoute = Pick<RouteProps, 'path' | 'query'>;
+
+export const isSameRscRoute = (next: RscRoute, prev: RscRoute) =>
   next.path === prev.path && next.query === prev.query;
 
 export const parseRedirectUrl = (location: string, base: string | URL) => {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -784,9 +784,6 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOW_HOPS = 20;
 
-// followHops resets when a hop commits, so it alone cannot bound a chain
-const MAX_FOLLOWS_PER_NAVIGATION = 100;
-
 type FollowBudget = { spent: number };
 
 const FollowError = ({
@@ -795,14 +792,12 @@ const FollowError = ({
   reset,
   fail,
   countHop,
-  followPromiseMap,
 }: {
   error: unknown;
   has404: boolean;
   reset: () => void;
   fail: (original: unknown, error: unknown) => void;
   countHop: () => boolean;
-  followPromiseMap: WeakMap<object, Promise<unknown>>;
 }) => {
   const { route, routerState, changeRoute } = useRouterOrThrow();
   const { path: routePath, query: routeQuery, hash: routeHash } = route;
@@ -816,6 +811,7 @@ const FollowError = ({
     undefined,
   );
   const stateAtDispatchRef = useRef<RouterState | undefined>(undefined);
+  const followedRef = useRef<unknown>(null);
   const routerStateRef = useRef(routerState);
   useEffect(() => {
     routerStateRef.current = routerState;
@@ -874,7 +870,7 @@ const FollowError = ({
       return;
     }
     const { target, url } = errorRoute;
-    if (followPromiseMap.has(error as object)) {
+    if (followedRef.current === error) {
       return;
     }
     const attempted = routerStateRef.current?.attempted;
@@ -897,30 +893,28 @@ const FollowError = ({
       url: url.pathname + url.search + url.hash,
     };
     stateAtDispatchRef.current = routerStateRef.current;
+    // the same error object can be thrown again, so this clears when it settles
+    followedRef.current = error;
     startTransition(() => {
-      followPromiseMap.set(
-        error as object,
-        changeRoute(target, {
-          shouldScroll: routerStateRef.current
-            ? routerStateRef.current.scroll !== null
-            : target.path !== caught.path,
-          history: 'replace',
-          url,
-          follow: true,
-          refetch: true,
-        }).then(
-          () => {
-            // a module scoped error is thrown again, so let it follow again
-            followPromiseMap.delete(error as object);
-          },
-          (err) => {
-            followPromiseMap.delete(error as object);
-            fail(error, err);
-          },
-        ),
+      changeRoute(target, {
+        shouldScroll: routerStateRef.current
+          ? routerStateRef.current.scroll !== null
+          : target.path !== caught.path,
+        history: 'replace',
+        url,
+        follow: true,
+        refetch: true,
+      }).then(
+        () => {
+          followedRef.current = null;
+        },
+        (err) => {
+          followedRef.current = null;
+          fail(error, err);
+        },
       );
     });
-  }, [error, has404, fail, countHop, changeRoute, followPromiseMap]);
+  }, [error, has404, fail, countHop, changeRoute]);
   const info = getErrorInfo(error);
   return info?.status === 404 && !has404 ? <h1>Not Found</h1> : null;
 };
@@ -929,8 +923,6 @@ class CustomErrorHandler extends Component<
   { has404: boolean; budget: FollowBudget; children?: ReactNode },
   { error: unknown | null }
 > {
-  private followPromiseMap = new WeakMap<object, Promise<unknown>>();
-  private followHops = 0;
   constructor(props: {
     has404: boolean;
     budget: FollowBudget;
@@ -949,18 +941,8 @@ class CustomErrorHandler extends Component<
     this.setState({ error: null });
   }
   countHop() {
-    this.followHops += 1;
     this.props.budget.spent += 1;
-    return (
-      this.followHops <= MAX_FOLLOW_HOPS &&
-      this.props.budget.spent <= MAX_FOLLOWS_PER_NAVIGATION
-    );
-  }
-  componentDidUpdate() {
-    // clearing in reset() would let a chain that redirects on render run free
-    if (this.state.error === null) {
-      this.followHops = 0;
-    }
+    return this.props.budget.spent <= MAX_FOLLOW_HOPS;
   }
   // error is a wrapper: the original still carries a location and would follow
   fail(original: unknown, error: unknown) {
@@ -978,7 +960,6 @@ class CustomErrorHandler extends Component<
             reset={this.reset}
             fail={this.fail}
             countHop={this.countHop}
-            followPromiseMap={this.followPromiseMap}
           />
         );
       }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -784,8 +784,6 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOWS_PER_NAVIGATION = 20;
 
-type FollowCount = { current: number };
-
 const isFollowable = (error: unknown) => {
   const info = getErrorInfo(error);
   return info?.status === 404 || !!info?.location;
@@ -921,12 +919,16 @@ const FollowError = ({
 };
 
 class CustomErrorHandler extends Component<
-  { has404: boolean; follows: FollowCount; children?: ReactNode },
+  {
+    has404: boolean;
+    followCount: RefObject<number>;
+    children?: ReactNode;
+  },
   { error: unknown | null }
 > {
   constructor(props: {
     has404: boolean;
-    follows: FollowCount;
+    followCount: RefObject<number>;
     children?: ReactNode;
   }) {
     super(props);
@@ -942,8 +944,8 @@ class CustomErrorHandler extends Component<
     this.setState({ error: null });
   }
   countFollow() {
-    this.props.follows.current += 1;
-    return this.props.follows.current <= MAX_FOLLOWS_PER_NAVIGATION;
+    this.props.followCount.current += 1;
+    return this.props.followCount.current <= MAX_FOLLOWS_PER_NAVIGATION;
   }
   // error is a wrapper: the original still carries a location and would follow
   fail(original: unknown, error: unknown) {
@@ -1200,7 +1202,7 @@ const InnerRouter = ({
 
   // FIXME this "fetchingSlices" hack feels suboptimal.
   const fetchingSlices = useRef(new Set<SliceId>()).current;
-  const followCount = useRef<FollowCount>({ current: 0 }).current;
+  const followCountRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
   const announcedRef = useRef<RouteProps | null>(null);
 
@@ -1225,7 +1227,7 @@ const InnerRouter = ({
         return;
       }
       if (!options.isFollow) {
-        followCount.current = 0;
+        followCountRef.current = 0;
       }
       const routeBefore = routeRef.current;
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
@@ -1323,7 +1325,7 @@ const InnerRouter = ({
       emitRouteChangeEvent,
       staticPathSet,
       learnStaticPath,
-      followCount,
+      followCountRef,
       resolvedElementsRef,
       prefetchManager,
     ],
@@ -1423,7 +1425,7 @@ const InnerRouter = ({
     );
   const rootElement = (
     <Slot id="root">
-      <CustomErrorHandler has404={has404} follows={followCount}>
+      <CustomErrorHandler has404={has404} followCount={followCountRef}>
         {routeElement}
       </CustomErrorHandler>
     </Slot>

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1325,8 +1325,6 @@ const InnerRouter = ({
       emitRouteChangeEvent,
       staticPathSet,
       learnStaticPath,
-      followCountRef,
-      resolvedElementsRef,
       prefetchManager,
     ],
   );

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1415,7 +1415,7 @@ const InnerRouter = ({
       learnStaticPath(elements);
       const { [ROUTE_ID]: routeData, [IS_STATIC_ID]: isStatic } = elements;
       applyChangeRouteData(routeData, isStatic).catch((err) => {
-        console.log('Error while handling route updates:', err);
+        console.error('Error while handling route updates:', err);
       });
     };
     return registerCallServerElementsListener(listener);
@@ -1457,7 +1457,7 @@ const InnerRouter = ({
             ? new URL(window.location.href)
             : getRouteUrl(nextRoute),
         }).catch((err) => {
-          console.log('Error while navigating back:', err);
+          console.error('Error while navigating back:', err);
         });
       });
     };

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -110,11 +110,11 @@ type NavigateOptions = {
 /**
  * Resolves once the requested navigation has been handled: after its response
  * when the route needs one, right away when it does not, and when a newer
- * navigation supersedes it. It rejects when the navigation fails, including a
- * response that came back 404, and it never waits for a follow: a 404 or
- * anything the destination throws while rendering is followed by a navigation
- * of its own. It does not wait for React to render either, so the address bar
- * may still show the previous url.
+ * navigation supersedes it. It rejects when the navigation fails, when a
+ * redirect hands the page to the browser, and when a missing route gets no
+ * answer from a waku server (a waku server sends the 404 page instead, which
+ * resolves). It never waits for a follow, and it does not wait for React to
+ * render, so the address bar may still show the previous url.
  */
 type Navigate = {
   (to: RouteHref, options?: NavigateOptions): Promise<void>;
@@ -175,7 +175,7 @@ type ChangeRouteOptions = {
   history: 'push' | 'replace' | null;
   url?: URL | undefined;
   instant?: boolean | undefined;
-  follow?: boolean | undefined;
+  keepFollowBudget?: boolean | undefined;
 };
 
 type ChangeRoute = (
@@ -782,9 +782,14 @@ export class ErrorBoundary extends Component<
   }
 }
 
-const MAX_FOLLOW_HOPS = 20;
+const MAX_FOLLOWS_PER_NAVIGATION = 20;
 
 type FollowBudget = { spent: number };
+
+const isFollowable = (error: unknown) => {
+  const info = getErrorInfo(error);
+  return info?.status === 404 || !!info?.location;
+};
 
 const FollowError = ({
   error,
@@ -811,7 +816,7 @@ const FollowError = ({
     undefined,
   );
   const stateAtDispatchRef = useRef<RouterState | undefined>(undefined);
-  const followedRef = useRef<unknown>(null);
+  const followingRef = useRef<unknown>(null);
   const routerStateRef = useRef(routerState);
   useEffect(() => {
     routerStateRef.current = routerState;
@@ -853,9 +858,10 @@ const FollowError = ({
       ? new URL(routerStateRef.current.url, window.location.href)
       : new URL(window.location.href);
     const errorRoute = resolveErrorRoute(error, attemptedUrl, has404);
-    if (errorRoute.type === 'none') {
+    if (errorRoute.type === 'none' || followingRef.current === error) {
       return;
     }
+    followingRef.current = error;
     if (errorRoute.type === 'unfollowable') {
       fail(
         error,
@@ -870,9 +876,6 @@ const FollowError = ({
       return;
     }
     const { target, url } = errorRoute;
-    if (followedRef.current === error) {
-      return;
-    }
     const attempted = routerStateRef.current?.attempted;
     const caught = attempted
       ? { path: attempted[0], query: attempted[1], hash: '' }
@@ -893,8 +896,6 @@ const FollowError = ({
       url: url.pathname + url.search + url.hash,
     };
     stateAtDispatchRef.current = routerStateRef.current;
-    // the same error object can be thrown again, so this clears when it settles
-    followedRef.current = error;
     startTransition(() => {
       changeRoute(target, {
         shouldScroll: routerStateRef.current
@@ -902,14 +903,14 @@ const FollowError = ({
           : target.path !== caught.path,
         history: 'replace',
         url,
-        follow: true,
+        keepFollowBudget: true,
         refetch: true,
       }).then(
         () => {
-          followedRef.current = null;
+          followingRef.current = null;
         },
         (err) => {
-          followedRef.current = null;
+          followingRef.current = null;
           fail(error, err);
         },
       );
@@ -942,7 +943,7 @@ class CustomErrorHandler extends Component<
   }
   countHop() {
     this.props.budget.spent += 1;
-    return this.props.budget.spent <= MAX_FOLLOW_HOPS;
+    return this.props.budget.spent <= MAX_FOLLOWS_PER_NAVIGATION;
   }
   // error is a wrapper: the original still carries a location and would follow
   fail(original: unknown, error: unknown) {
@@ -951,8 +952,7 @@ class CustomErrorHandler extends Component<
   render() {
     const { error } = this.state;
     if (error !== null) {
-      const info = getErrorInfo(error);
-      if (info?.status === 404 || info?.location) {
+      if (isFollowable(error)) {
         return (
           <FollowError
             error={error}
@@ -1224,8 +1224,8 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      if (!options.follow) {
-        followBudget.spent = 0; // a navigation of its own starts a fresh budget
+      if (!options.keepFollowBudget) {
+        followBudget.spent = 0;
       }
       const routeBefore = routeRef.current;
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
@@ -1359,7 +1359,9 @@ const InnerRouter = ({
       learnStaticPath(elements);
       const { [ROUTE_ID]: routeData, [IS_STATIC_ID]: isStatic } = elements;
       applyChangeRouteData(routeData, isStatic).catch((err) => {
-        console.error('Error while handling route updates:', err);
+        if (!isFollowable(err)) {
+          console.error('Error while handling route updates:', err);
+        }
       });
     };
     return registerCallServerElementsListener(listener);
@@ -1401,7 +1403,9 @@ const InnerRouter = ({
             ? new URL(window.location.href)
             : getRouteUrl(nextRoute),
         }).catch((err) => {
-          console.error('Error while navigating back:', err);
+          if (!isFollowable(err)) {
+            console.error('Error while navigating back:', err);
+          }
         });
       });
     };

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -53,7 +53,6 @@ import {
   getRouteUrl,
   isSameRoute,
   isSameRscRoute,
-  parseRedirectUrl,
   parseRoute,
   pathnameToCurrentRoutePath,
 } from './client-utils/route-url.js';
@@ -111,11 +110,11 @@ type NavigateOptions = {
 /**
  * Resolves once the requested navigation has been handled: after its response
  * when the route needs one, right away when it does not, and when a newer
- * navigation supersedes it. A response that came back 404 is covered, because
- * the 404 page is fetched first; anything the destination throws while
- * rendering is followed after it resolves. It rejects when the navigation
- * fails, and it does not wait for React to render, so the address bar may still
- * show the previous url.
+ * navigation supersedes it. It rejects when the navigation fails, including a
+ * response that came back 404, and it never waits for a follow: a 404 or
+ * anything the destination throws while rendering is followed by a navigation
+ * of its own. It does not wait for React to render either, so the address bar
+ * may still show the previous url.
  */
 type Navigate = {
   (to: RouteHref, options?: NavigateOptions): Promise<void>;
@@ -176,7 +175,7 @@ type ChangeRouteOptions = {
   history: 'push' | 'replace' | null;
   url?: URL | undefined;
   instant?: boolean | undefined;
-  follow?: 'continues' | 'announces' | undefined;
+  follow?: boolean | undefined;
 };
 
 type ChangeRoute = (
@@ -878,8 +877,11 @@ const FollowError = ({
     if (followPromiseMap.has(error as object)) {
       return;
     }
-    const caught = parseRoute(attemptedUrl);
-    if (isSameRoute(target, caught)) {
+    const attempted = routerStateRef.current?.attempted;
+    const caught = attempted
+      ? { path: attempted[0], query: attempted[1], hash: '' }
+      : parseRoute(attemptedUrl);
+    if (isSameRscRoute(target, caught) && url.href === attemptedUrl.href) {
       fail(error, new Error('detected a navigation loop', { cause: error }));
       return;
     }
@@ -904,7 +906,7 @@ const FollowError = ({
             : target.path !== caught.path,
           history: 'replace',
           url,
-          follow: 'announces',
+          follow: true,
           refetch: true,
         }).then(
           () => {
@@ -1236,10 +1238,8 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      if (options.follow !== 'continues') {
-        announcedRef.current = nextRoute;
-        emitRouteChangeEvent('start', nextRoute);
-      }
+      announcedRef.current = nextRoute;
+      emitRouteChangeEvent('start', nextRoute);
       if (isAborted()) {
         return;
       }
@@ -1315,25 +1315,6 @@ const InnerRouter = ({
         if (isAborted()) {
           return;
         }
-        const info = getErrorInfo(e);
-        // a fetch level redirect may leave waku, so the browser takes it on
-        const redirectUrl = info?.location
-          ? parseRedirectUrl(info.location, targetUrl)
-          : undefined;
-        if (redirectUrl) {
-          abortRef.current = null;
-          // an instant commit already pushed the attempted url, so pushing
-          // again would cost the navigation a second entry
-          if (
-            routerState.history === 'push' &&
-            window.location.href !== targetUrl.href
-          ) {
-            window.location.assign(redirectUrl.href);
-          } else {
-            window.location.replace(redirectUrl.href);
-          }
-          return;
-        }
         abortRef.current = null;
         // write the url now; an unrecoverable rethrow discards the commit
         if (window.location.href !== targetUrl.href) {
@@ -1343,23 +1324,6 @@ const InnerRouter = ({
             window.history.replaceState(window.history.state, '', targetUrl);
           }
         }
-        const errorRoute = resolveErrorRoute(e, targetUrl, has404);
-        if (
-          errorRoute.type === 'route' &&
-          !isSameRscRoute(errorRoute.target, nextRoute)
-        ) {
-          return dispatchChangeRoute(changeRoute, errorRoute.target, {
-            shouldScroll: options.shouldScroll,
-            history: null,
-            url: errorRoute.url,
-            follow: 'continues',
-            refetch: true,
-          });
-        }
-        const failure =
-          errorRoute.type === 'route'
-            ? new Error('detected a navigation loop', { cause: e })
-            : e;
         mergeElements({
           [ROUTER_STATE_ID]: {
             ...routerState,
@@ -1367,15 +1331,14 @@ const InnerRouter = ({
             failed: true,
           },
         });
-        setErr(failure);
+        setErr(e);
         emitRouteChangeEvent('error', nextRoute);
-        throw failure;
+        throw e;
       }
     },
     [
       refetch,
       mergeElements,
-      has404,
       emitRouteChangeEvent,
       staticPathSet,
       learnStaticPath,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -175,7 +175,7 @@ type ChangeRouteOptions = {
   history: 'push' | 'replace' | null;
   url?: URL | undefined;
   instant?: boolean | undefined;
-  keepFollowBudget?: boolean | undefined;
+  isFollow?: boolean | undefined;
 };
 
 type ChangeRoute = (
@@ -784,7 +784,7 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOWS_PER_NAVIGATION = 20;
 
-type FollowBudget = { spent: number };
+type FollowCount = { current: number };
 
 const isFollowable = (error: unknown) => {
   const info = getErrorInfo(error);
@@ -796,13 +796,13 @@ const FollowError = ({
   has404,
   reset,
   fail,
-  countHop,
+  countFollow,
 }: {
   error: unknown;
   has404: boolean;
   reset: () => void;
   fail: (original: unknown, error: unknown) => void;
-  countHop: () => boolean;
+  countFollow: () => boolean;
 }) => {
   const { route, routerState, changeRoute } = useRouterOrThrow();
   const { path: routePath, query: routeQuery, hash: routeHash } = route;
@@ -884,7 +884,7 @@ const FollowError = ({
       fail(error, new Error('detected a navigation loop', { cause: error }));
       return;
     }
-    if (!countHop()) {
+    if (!countFollow()) {
       fail(
         error,
         new Error('too many redirect or 404 follows', { cause: error }),
@@ -903,7 +903,7 @@ const FollowError = ({
           : target.path !== caught.path,
         history: 'replace',
         url,
-        keepFollowBudget: true,
+        isFollow: true,
         refetch: true,
       }).then(
         () => {
@@ -915,25 +915,25 @@ const FollowError = ({
         },
       );
     });
-  }, [error, has404, fail, countHop, changeRoute]);
+  }, [error, has404, fail, countFollow, changeRoute]);
   const info = getErrorInfo(error);
   return info?.status === 404 && !has404 ? <h1>Not Found</h1> : null;
 };
 
 class CustomErrorHandler extends Component<
-  { has404: boolean; budget: FollowBudget; children?: ReactNode },
+  { has404: boolean; follows: FollowCount; children?: ReactNode },
   { error: unknown | null }
 > {
   constructor(props: {
     has404: boolean;
-    budget: FollowBudget;
+    follows: FollowCount;
     children?: ReactNode;
   }) {
     super(props);
     this.state = { error: null };
     this.reset = this.reset.bind(this);
     this.fail = this.fail.bind(this);
-    this.countHop = this.countHop.bind(this);
+    this.countFollow = this.countFollow.bind(this);
   }
   static getDerivedStateFromError(error: unknown) {
     return { error };
@@ -941,9 +941,9 @@ class CustomErrorHandler extends Component<
   reset() {
     this.setState({ error: null });
   }
-  countHop() {
-    this.props.budget.spent += 1;
-    return this.props.budget.spent <= MAX_FOLLOWS_PER_NAVIGATION;
+  countFollow() {
+    this.props.follows.current += 1;
+    return this.props.follows.current <= MAX_FOLLOWS_PER_NAVIGATION;
   }
   // error is a wrapper: the original still carries a location and would follow
   fail(original: unknown, error: unknown) {
@@ -959,7 +959,7 @@ class CustomErrorHandler extends Component<
             has404={this.props.has404}
             reset={this.reset}
             fail={this.fail}
-            countHop={this.countHop}
+            countFollow={this.countFollow}
           />
         );
       }
@@ -1200,7 +1200,7 @@ const InnerRouter = ({
 
   // FIXME this "fetchingSlices" hack feels suboptimal.
   const fetchingSlices = useRef(new Set<SliceId>()).current;
-  const followBudget = useRef<FollowBudget>({ spent: 0 }).current;
+  const followCount = useRef<FollowCount>({ current: 0 }).current;
   const abortRef = useRef<AbortController | null>(null);
   const announcedRef = useRef<RouteProps | null>(null);
 
@@ -1224,8 +1224,8 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      if (!options.keepFollowBudget) {
-        followBudget.spent = 0;
+      if (!options.isFollow) {
+        followCount.current = 0;
       }
       const routeBefore = routeRef.current;
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
@@ -1323,7 +1323,7 @@ const InnerRouter = ({
       emitRouteChangeEvent,
       staticPathSet,
       learnStaticPath,
-      followBudget,
+      followCount,
       resolvedElementsRef,
       prefetchManager,
     ],
@@ -1423,7 +1423,7 @@ const InnerRouter = ({
     );
   const rootElement = (
     <Slot id="root">
-      <CustomErrorHandler has404={has404} budget={followBudget}>
+      <CustomErrorHandler has404={has404} follows={followCount}>
         {routeElement}
       </CustomErrorHandler>
     </Slot>

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -878,7 +878,7 @@ const FollowError = ({
     const { target, url } = errorRoute;
     const attempted = routerStateRef.current?.attempted;
     const caught = attempted
-      ? { path: attempted[0], query: attempted[1], hash: '' }
+      ? { path: attempted[0], query: attempted[1] }
       : parseRoute(attemptedUrl);
     if (isSameRscRoute(target, caught) && url.href === attemptedUrl.href) {
       fail(error, new Error('detected a navigation loop', { cause: error }));

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -182,22 +182,22 @@ export const createRequestHandler = ({
             throw e;
           }
           const redirectRoute = resolveInternalRoute(location, input.req.url);
-          const entries = !redirectRoute
-            ? null
-            : await routeEntries
-                .getEntriesForRoute(
-                  encodeRoutePath(redirectRoute.path),
-                  new URLSearchParams({ query: redirectRoute.query }),
-                  clientEtags,
-                  requestElementCache,
-                )
-                .catch((e: unknown) => {
-                  const info = getErrorInfo(e);
-                  if (info?.location || info?.status === 404) {
-                    return null;
-                  }
-                  throw e;
-                });
+          const entries =
+            redirectRoute &&
+            (await routeEntries
+              .getEntriesForRoute(
+                encodeRoutePath(redirectRoute.path),
+                new URLSearchParams({ query: redirectRoute.query }),
+                clientEtags,
+                requestElementCache,
+              )
+              .catch((e: unknown) => {
+                const info = getErrorInfo(e);
+                if (info?.location || info?.status === 404) {
+                  return null;
+                }
+                throw e;
+              }));
           if (!entries) {
             // 303 keeps the browser from sending the action body along
             throw createCustomError('Redirect', { status: 303, location });

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -23,15 +23,16 @@ import type { RouteEntries, createRouteEntries } from './route-entries.js';
 type HandleRequest = Parameters<typeof defineHandlers>[0]['handleRequest'];
 type HandlerInput = Parameters<HandleRequest>[0];
 
-const parseInternalRedirect = (location: string) => {
+const parseInternalRedirect = (location: string, base: string) => {
   if (
     !location.startsWith('/') ||
     location.startsWith('//') ||
-    location.includes('#')
+    location.includes('#') ||
+    location.includes('\\')
   ) {
     return undefined;
   }
-  const url = new URL(location, 'http://localhost:3000');
+  const url = new URL(location, base);
   return {
     path: pathnameToRoutePath(url.pathname),
     query: url.searchParams.toString(),
@@ -171,7 +172,9 @@ export const createRequestHandler = ({
           return renderRsc(entries.elements, { value, etags: entries.etags });
         } catch (e) {
           const location = getErrorInfo(e)?.location;
-          const target = location ? parseInternalRedirect(location) : undefined;
+          const target = location
+            ? parseInternalRedirect(location, input.req.url)
+            : undefined;
           if (!target) {
             throw e;
           }

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -1,6 +1,5 @@
 import {
   unstable_base64ToBytes as base64ToBytes,
-  unstable_createCustomError as createCustomError,
   unstable_getErrorInfo as getErrorInfo,
 } from '../../minimal/server.js';
 import type { unstable_defineHandlers as defineHandlers } from '../../minimal/server.js';
@@ -183,7 +182,7 @@ export const createRequestHandler = ({
             requestElementCache,
           );
           if (!entries) {
-            throw createCustomError('Not Found', { status: 404 });
+            throw e;
           }
           return renderRsc(entries.elements, { etags: entries.etags });
         }

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -24,7 +24,7 @@ import type { RouteEntries, createRouteEntries } from './route-entries.js';
 type HandleRequest = Parameters<typeof defineHandlers>[0]['handleRequest'];
 type HandlerInput = Parameters<HandleRequest>[0];
 
-const parseInternalRedirect = (location: string, base: string) => {
+const resolveInternalRoute = (location: string, base: string) => {
   if (!location.startsWith('/') || location.includes('#')) {
     return undefined;
   }
@@ -181,7 +181,7 @@ export const createRequestHandler = ({
           if (!location) {
             throw e;
           }
-          const target = parseInternalRedirect(location, input.req.url);
+          const target = resolveInternalRoute(location, input.req.url);
           const entries = !target
             ? null
             : await routeEntries

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -24,6 +24,21 @@ import type { RouteEntries, createRouteEntries } from './route-entries.js';
 type HandleRequest = Parameters<typeof defineHandlers>[0]['handleRequest'];
 type HandlerInput = Parameters<HandleRequest>[0];
 
+const parseInternalRedirect = (location: string) => {
+  if (
+    !location.startsWith('/') ||
+    location.startsWith('//') ||
+    location.includes('#')
+  ) {
+    return undefined;
+  }
+  const url = new URL(location, 'http://localhost:3000');
+  return {
+    path: pathnameToRoutePath(url.pathname),
+    query: url.searchParams.toString(),
+  };
+};
+
 export const createRequestHandler = ({
   configRegistry,
   routeEntries,
@@ -156,22 +171,21 @@ export const createRequestHandler = ({
           const { value, entries } = await withRerender(() => fn(...args));
           return renderRsc(entries.elements, { value, etags: entries.etags });
         } catch (e) {
-          const info = getErrorInfo(e);
-          if (info?.location) {
-            const routePath = pathnameToRoutePath(info.location);
-            const rscPath = encodeRoutePath(routePath);
-            const entries = await routeEntries.getEntriesForRoute(
-              rscPath,
-              undefined,
-              clientEtags,
-              requestElementCache,
-            );
-            if (!entries) {
-              throw createCustomError('Not Found', { status: 404 });
-            }
-            return renderRsc(entries.elements, { etags: entries.etags });
+          const location = getErrorInfo(e)?.location;
+          const target = location ? parseInternalRedirect(location) : undefined;
+          if (!target) {
+            throw e;
           }
-          throw e;
+          const entries = await routeEntries.getEntriesForRoute(
+            encodeRoutePath(target.path),
+            new URLSearchParams({ query: target.query }),
+            clientEtags,
+            requestElementCache,
+          );
+          if (!entries) {
+            throw createCustomError('Not Found', { status: 404 });
+          }
+          return renderRsc(entries.elements, { etags: entries.etags });
         }
       };
 

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -1,5 +1,6 @@
 import {
   unstable_base64ToBytes as base64ToBytes,
+  unstable_createCustomError as createCustomError,
   unstable_getErrorInfo as getErrorInfo,
 } from '../../minimal/server.js';
 import type { unstable_defineHandlers as defineHandlers } from '../../minimal/server.js';
@@ -24,15 +25,13 @@ type HandleRequest = Parameters<typeof defineHandlers>[0]['handleRequest'];
 type HandlerInput = Parameters<HandleRequest>[0];
 
 const parseInternalRedirect = (location: string, base: string) => {
-  if (
-    !location.startsWith('/') ||
-    location.startsWith('//') ||
-    location.includes('#') ||
-    location.includes('\\')
-  ) {
+  if (!location.startsWith('/') || location.includes('#')) {
     return undefined;
   }
   const url = new URL(location, base);
+  if (url.origin !== new URL(base).origin) {
+    return undefined;
+  }
   return {
     path: pathnameToRoutePath(url.pathname),
     query: url.searchParams.toString(),
@@ -150,12 +149,14 @@ export const createRequestHandler = ({
           }
         }
         if (!entries && configRegistry.has404()) {
-          entries = await routeEntries.getEntriesForRoute(
-            encodeRoutePath('/404'),
-            rscParams,
-            clientEtags,
-            requestElementCache,
-          );
+          entries = await routeEntries
+            .getEntriesForRoute(
+              encodeRoutePath('/404'),
+              rscParams,
+              clientEtags,
+              requestElementCache,
+            )
+            .catch(() => null);
         }
         if (!entries) {
           return null;
@@ -172,11 +173,15 @@ export const createRequestHandler = ({
           return renderRsc(entries.elements, { value, etags: entries.etags });
         } catch (e) {
           const location = getErrorInfo(e)?.location;
-          const target = location
-            ? parseInternalRedirect(location, input.req.url)
-            : undefined;
-          if (!target) {
+          if (!location) {
             throw e;
+          }
+          // the action arguments must not be replayed onto the destination
+          const handOff = () =>
+            createCustomError('Redirect', { status: 303, location });
+          const target = parseInternalRedirect(location, input.req.url);
+          if (!target) {
+            throw handOff();
           }
           const entries = await routeEntries.getEntriesForRoute(
             encodeRoutePath(target.path),
@@ -185,7 +190,7 @@ export const createRequestHandler = ({
             requestElementCache,
           );
           if (!entries) {
-            throw e;
+            throw handOff();
           }
           return renderRsc(entries.elements, { etags: entries.etags });
         }

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -156,7 +156,12 @@ export const createRequestHandler = ({
               clientEtags,
               requestElementCache,
             )
-            .catch(() => null);
+            .catch((e) => {
+              if (getErrorInfo(e)?.status !== 404) {
+                throw e;
+              }
+              return null;
+            });
         }
         if (!entries) {
           return null;
@@ -183,12 +188,19 @@ export const createRequestHandler = ({
           if (!target) {
             throw handOff();
           }
-          const entries = await routeEntries.getEntriesForRoute(
-            encodeRoutePath(target.path),
-            new URLSearchParams({ query: target.query }),
-            clientEtags,
-            requestElementCache,
-          );
+          const entries = await routeEntries
+            .getEntriesForRoute(
+              encodeRoutePath(target.path),
+              new URLSearchParams({ query: target.query }),
+              clientEtags,
+              requestElementCache,
+            )
+            .catch((e: unknown) => {
+              if (getErrorInfo(e)?.location) {
+                throw handOff();
+              }
+              throw e;
+            });
           if (!entries) {
             throw handOff();
           }

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -181,28 +181,25 @@ export const createRequestHandler = ({
           if (!location) {
             throw e;
           }
-          // the action arguments must not be replayed onto the destination
-          const handOff = () =>
-            createCustomError('Redirect', { status: 303, location });
           const target = parseInternalRedirect(location, input.req.url);
-          if (!target) {
-            throw handOff();
-          }
-          const entries = await routeEntries
-            .getEntriesForRoute(
-              encodeRoutePath(target.path),
-              new URLSearchParams({ query: target.query }),
-              clientEtags,
-              requestElementCache,
-            )
-            .catch((e: unknown) => {
-              if (getErrorInfo(e)?.location) {
-                throw handOff();
-              }
-              throw e;
-            });
+          const entries = !target
+            ? null
+            : await routeEntries
+                .getEntriesForRoute(
+                  encodeRoutePath(target.path),
+                  new URLSearchParams({ query: target.query }),
+                  clientEtags,
+                  requestElementCache,
+                )
+                .catch((e: unknown) => {
+                  if (getErrorInfo(e)?.location) {
+                    return null;
+                  }
+                  throw e;
+                });
           if (!entries) {
-            throw handOff();
+            // 303 keeps the browser from sending the action body along
+            throw createCustomError('Redirect', { status: 303, location });
           }
           return renderRsc(entries.elements, { etags: entries.etags });
         }

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -181,13 +181,13 @@ export const createRequestHandler = ({
           if (!location) {
             throw e;
           }
-          const target = resolveInternalRoute(location, input.req.url);
-          const entries = !target
+          const redirectRoute = resolveInternalRoute(location, input.req.url);
+          const entries = !redirectRoute
             ? null
             : await routeEntries
                 .getEntriesForRoute(
-                  encodeRoutePath(target.path),
-                  new URLSearchParams({ query: target.query }),
+                  encodeRoutePath(redirectRoute.path),
+                  new URLSearchParams({ query: redirectRoute.query }),
                   clientEtags,
                   requestElementCache,
                 )

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -121,12 +121,27 @@ export const createRequestHandler = ({
           }
           return renderRsc(entries.elements, { etags: entries.etags });
         }
-        const entries = await routeEntries.getEntriesForRoute(
-          rscPath,
-          rscParams,
-          clientEtags,
-          requestElementCache,
-        );
+        let entries: RouteEntries | null = null;
+        try {
+          entries = await routeEntries.getEntriesForRoute(
+            rscPath,
+            rscParams,
+            clientEtags,
+            requestElementCache,
+          );
+        } catch (e) {
+          if (getErrorInfo(e)?.status !== 404) {
+            throw e;
+          }
+        }
+        if (!entries && configRegistry.has404()) {
+          entries = await routeEntries.getEntriesForRoute(
+            encodeRoutePath('/404'),
+            rscParams,
+            clientEtags,
+            requestElementCache,
+          );
+        }
         if (!entries) {
           return null;
         }

--- a/packages/waku/src/router/define-router-utils/request-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/request-handler.tsx
@@ -192,7 +192,8 @@ export const createRequestHandler = ({
                   requestElementCache,
                 )
                 .catch((e: unknown) => {
-                  if (getErrorInfo(e)?.location) {
+                  const info = getErrorInfo(e);
+                  if (info?.location || info?.status === 404) {
                     return null;
                   }
                   throw e;

--- a/packages/waku/tests/define-router-request-handler.test.ts
+++ b/packages/waku/tests/define-router-request-handler.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { unstable_createCustomError } from '../src/minimal/server.js';
+import {
+  unstable_createCustomError,
+  unstable_getErrorInfo,
+} from '../src/minimal/server.js';
 import { unstable_defineRouter } from '../src/router/define-router.js';
 import {
   ROUTE_ID,
@@ -8,6 +11,7 @@ import {
 } from '../src/router/isomorphic-utils/route-path.js';
 import {
   unstable_getRequest,
+  unstable_notFound,
   unstable_redirect,
   unstable_rerenderRoute,
   unstable_setNonce,
@@ -140,24 +144,29 @@ describe('request dispatch', () => {
     expect(utils.renderRsc).not.toHaveBeenCalled();
   });
 
-  it.each(['https://example.com/x', '//example.com/x', '/dest#frag'])(
+  it.each([
+    'https://example.com/dest',
+    '//example.com/dest',
+    '/dest#frag',
+    '/\\example.com/dest',
+  ])(
     'leaves a server-function redirect to %s for the browser to follow',
     async (location) => {
       const { handleRequest } = unstable_defineRouter({
         getConfigs: async () => [dynamicRoute('/dest')],
       });
       const utils = makeUtils();
-      await expect(
-        handleRequest(
-          callInput(async () => {
-            throw unstable_createCustomError('Redirect', {
-              status: 307,
-              location,
-            });
-          }),
-          utils,
-        ),
-      ).rejects.toThrow('Redirect');
+      const err = await handleRequest(
+        callInput(async () => {
+          throw unstable_createCustomError('Redirect', {
+            status: 307,
+            location,
+          });
+        }),
+        utils,
+      ).catch((e: unknown) => e);
+      // the browser can only follow it if the response keeps both of these
+      expect(unstable_getErrorInfo(err)).toEqual({ status: 307, location });
       expect(utils.renderRsc).not.toHaveBeenCalled();
     },
   );
@@ -225,6 +234,47 @@ describe('request dispatch', () => {
       expect.objectContaining({ [ROUTE_ID]: ['/404', 'foo=bar'] }),
       expect.anything(),
     );
+  });
+
+  it('answers a route that renders not found with the 404 payload', async () => {
+    const notFound = {
+      ...dynamicRoute('/gone'),
+      routeElement: {
+        isStatic: false,
+        renderer: () => {
+          unstable_notFound();
+        },
+      },
+    };
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [notFound, dynamicRoute('/404')],
+    });
+    const utils = makeUtils();
+    await handleRequest(rscInput(encodeRoutePath('/gone')), utils);
+    expect(utils.renderRsc).toHaveBeenCalledWith(
+      expect.objectContaining({ [ROUTE_ID]: ['/404', ''] }),
+      expect.anything(),
+    );
+  });
+
+  it('propagates a non-404 failure from a route render', async () => {
+    const boom = {
+      ...dynamicRoute('/boom'),
+      routeElement: {
+        isStatic: false,
+        renderer: () => {
+          throw new Error('kaboom');
+        },
+      },
+    };
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [boom, dynamicRoute('/404')],
+    });
+    const utils = makeUtils();
+    await expect(
+      handleRequest(rscInput(encodeRoutePath('/boom')), utils),
+    ).rejects.toThrow('kaboom');
+    expect(utils.renderRsc).not.toHaveBeenCalled();
   });
 
   it('renders the 404 route with the query that was asked for', async () => {

--- a/packages/waku/tests/define-router-request-handler.test.ts
+++ b/packages/waku/tests/define-router-request-handler.test.ts
@@ -318,6 +318,33 @@ describe('request dispatch', () => {
     ).rejects.toThrow('the 404 page is broken');
   });
 
+  it('hands off a server-function redirect whose destination is not found', async () => {
+    const gone = {
+      ...dynamicRoute('/dest'),
+      routeElement: {
+        isStatic: false,
+        renderer: () => {
+          unstable_notFound();
+        },
+      },
+    };
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [gone, dynamicRoute('/404')],
+    });
+    const utils = makeUtils();
+    const err = await handleRequest(
+      callInput(async () => {
+        unstable_redirect('/dest');
+      }),
+      utils,
+    ).catch((e: unknown) => e);
+    // the browser still lands on /dest, which renders its own 404 there
+    expect(unstable_getErrorInfo(err)).toEqual({
+      status: 303,
+      location: '/dest',
+    });
+  });
+
   it('hands off a server-function redirect whose destination redirects', async () => {
     const onward = {
       ...dynamicRoute('/dest'),

--- a/packages/waku/tests/define-router-request-handler.test.ts
+++ b/packages/waku/tests/define-router-request-handler.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { unstable_createCustomError } from '../src/minimal/server.js';
 import { unstable_defineRouter } from '../src/router/define-router.js';
 import {
   ROUTE_ID,
@@ -38,6 +39,14 @@ const rscInput = (rscPath: string, rscParams?: unknown) => ({
   rscPath,
   rscParams,
   req: new Request('http://localhost/RSC/' + rscPath),
+});
+
+const callInput = (fn: () => Promise<unknown>) => ({
+  type: 'call' as const,
+  pathname: '/RSC/F/x.txt',
+  fn,
+  args: [],
+  req: new Request('http://localhost/RSC/F/x.txt', { method: 'POST' }),
 });
 
 const dynamicRoute = (name: string) => ({
@@ -86,16 +95,10 @@ describe('request dispatch', () => {
     });
     const utils = makeUtils();
     await handleRequest(
-      {
-        type: 'call',
-        pathname: '/RSC/F/x.txt',
-        fn: async () => {
-          unstable_rerenderRoute('/');
-          return 'fn-value';
-        },
-        args: [],
-        req: new Request('http://localhost/RSC/F/x.txt', { method: 'POST' }),
-      },
+      callInput(async () => {
+        unstable_rerenderRoute('/');
+        return 'fn-value';
+      }),
       utils,
     );
     expect(utils.renderRsc).toHaveBeenCalledWith(
@@ -104,21 +107,54 @@ describe('request dispatch', () => {
     );
   });
 
+  it('keeps the query of a server-function redirect', async () => {
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [dynamicRoute('/dest')],
+    });
+    const utils = makeUtils();
+    await handleRequest(
+      callInput(async () => {
+        unstable_redirect('/dest?a=1' as never);
+      }),
+      utils,
+    );
+    expect(utils.renderRsc).toHaveBeenCalledWith(
+      expect.objectContaining({ [ROUTE_ID]: ['/dest', 'a=1'] }),
+      { etags: {} },
+    );
+  });
+
+  it.each(['https://example.com/x', '//example.com/x', '/dest#frag'])(
+    'leaves a server-function redirect to %s for the browser to follow',
+    async (location) => {
+      const { handleRequest } = unstable_defineRouter({
+        getConfigs: async () => [dynamicRoute('/dest')],
+      });
+      const utils = makeUtils();
+      await expect(
+        handleRequest(
+          callInput(async () => {
+            throw unstable_createCustomError('Redirect', {
+              status: 307,
+              location,
+            });
+          }),
+          utils,
+        ),
+      ).rejects.toThrow('Redirect');
+      expect(utils.renderRsc).not.toHaveBeenCalled();
+    },
+  );
+
   it('responds to a server-function redirect with the destination route', async () => {
     const { handleRequest } = unstable_defineRouter({
       getConfigs: async () => [dynamicRoute('/dest')],
     });
     const utils = makeUtils();
     await handleRequest(
-      {
-        type: 'call',
-        pathname: '/RSC/F/x.txt',
-        fn: async () => {
-          unstable_redirect('/dest', 303);
-        },
-        args: [],
-        req: new Request('http://localhost/RSC/F/x.txt', { method: 'POST' }),
-      },
+      callInput(async () => {
+        unstable_redirect('/dest', 303);
+      }),
       utils,
     );
     expect(utils.renderRsc).toHaveBeenCalledWith(

--- a/packages/waku/tests/define-router-request-handler.test.ts
+++ b/packages/waku/tests/define-router-request-handler.test.ts
@@ -278,6 +278,73 @@ describe('request dispatch', () => {
     expect(utils.renderRsc).not.toHaveBeenCalled();
   });
 
+  it('gives up quietly when the 404 route renders not found', async () => {
+    const recursive = {
+      ...dynamicRoute('/404'),
+      routeElement: {
+        isStatic: false,
+        renderer: () => {
+          unstable_notFound();
+        },
+      },
+    };
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [recursive],
+    });
+    const utils = makeUtils();
+    const res = await handleRequest(
+      rscInput(encodeRoutePath('/missing')),
+      utils,
+    );
+    expect(res).toBeNull();
+    expect(utils.renderRsc).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a broken 404 route instead of reporting no route', async () => {
+    const broken = {
+      ...dynamicRoute('/404'),
+      routeElement: {
+        isStatic: false,
+        renderer: () => {
+          throw new Error('the 404 page is broken');
+        },
+      },
+    };
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [broken],
+    });
+    await expect(
+      handleRequest(rscInput(encodeRoutePath('/missing')), makeUtils()),
+    ).rejects.toThrow('the 404 page is broken');
+  });
+
+  it('hands off a server-function redirect whose destination redirects', async () => {
+    const onward = {
+      ...dynamicRoute('/dest'),
+      routeElement: {
+        isStatic: false,
+        renderer: () => {
+          unstable_redirect('/onward' as never);
+        },
+      },
+    };
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [onward],
+    });
+    const utils = makeUtils();
+    const err = await handleRequest(
+      callInput(async () => {
+        unstable_redirect('/dest');
+      }),
+      utils,
+    ).catch((e: unknown) => e);
+    // still 303, so the action body is not replayed onto the next hop either
+    expect(unstable_getErrorInfo(err)).toEqual({
+      status: 303,
+      location: '/dest',
+    });
+  });
+
   it('renders the 404 route with the query that was asked for', async () => {
     const { handleRequest } = unstable_defineRouter({
       getConfigs: async () => [dynamicRoute('/404')],

--- a/packages/waku/tests/define-router-request-handler.test.ts
+++ b/packages/waku/tests/define-router-request-handler.test.ts
@@ -149,6 +149,7 @@ describe('request dispatch', () => {
     '//example.com/dest',
     '/dest#frag',
     '/\\example.com/dest',
+    '/\t/evil.com/dest',
   ])(
     'leaves a server-function redirect to %s for the browser to follow',
     async (location) => {
@@ -165,8 +166,8 @@ describe('request dispatch', () => {
         }),
         utils,
       ).catch((e: unknown) => e);
-      // the browser can only follow it if the response keeps both of these
-      expect(unstable_getErrorInfo(err)).toEqual({ status: 307, location });
+      // 303 so the follow is a GET and the action body is not replayed
+      expect(unstable_getErrorInfo(err)).toEqual({ status: 303, location });
       expect(utils.renderRsc).not.toHaveBeenCalled();
     },
   );

--- a/packages/waku/tests/define-router-request-handler.test.ts
+++ b/packages/waku/tests/define-router-request-handler.test.ts
@@ -32,6 +32,14 @@ const makeUtils = (loadBuildMetadata = vi.fn()) => ({
   loadBuildMetadata,
 });
 
+const rscInput = (rscPath: string, rscParams?: unknown) => ({
+  type: 'rsc' as const,
+  pathname: '/RSC/' + rscPath,
+  rscPath,
+  rscParams,
+  req: new Request('http://localhost/RSC/' + rscPath),
+});
+
 const dynamicRoute = (name: string) => ({
   type: 'route' as const,
   path: name === '/' ? [] : [{ type: 'literal' as const, name: name.slice(1) }],
@@ -47,13 +55,7 @@ describe('request dispatch', () => {
       getConfigs: async () => [dynamicRoute('/about')],
     });
     const res = await handleRequest(
-      {
-        type: 'rsc',
-        pathname: '/RSC/R/missing',
-        rscPath: encodeRoutePath('/missing'),
-        rscParams: undefined,
-        req: new Request('http://localhost/RSC/R/missing'),
-      },
+      rscInput(encodeRoutePath('/missing')),
       makeUtils(),
     );
     expect(res).toBeNull();
@@ -71,16 +73,7 @@ describe('request dispatch', () => {
       ],
     });
     const utils = makeUtils();
-    await handleRequest(
-      {
-        type: 'rsc',
-        pathname: '/RSC/S/sidebar',
-        rscPath: encodeSliceId('sidebar'),
-        rscParams: undefined,
-        req: new Request('http://localhost/RSC/S/sidebar'),
-      },
-      utils,
-    );
+    await handleRequest(rscInput(encodeSliceId('sidebar')), utils);
     expect(utils.renderRsc).toHaveBeenCalledWith(
       expect.objectContaining({ 'slice:sidebar': 'SIDEBAR' }),
       expect.anything(),
@@ -161,6 +154,25 @@ describe('request dispatch', () => {
     const [apiReq, apiContext] = apiHandler.mock.calls[0]!;
     expect(new URL(apiReq.url).pathname).toBe('/api/hello');
     expect(apiContext).toEqual({ params: { slug: 'hello' } });
+  });
+
+  it('answers an rsc request for a missing route with the 404 payload', async () => {
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [dynamicRoute('/404')],
+    });
+    const utils = makeUtils();
+    const res = await handleRequest(
+      rscInput(
+        encodeRoutePath('/missing'),
+        new URLSearchParams({ query: 'foo=bar' }),
+      ),
+      utils,
+    );
+    expect(res).not.toBeNull();
+    expect(utils.renderRsc).toHaveBeenCalledWith(
+      expect.objectContaining({ [ROUTE_ID]: ['/404', 'foo=bar'] }),
+      expect.anything(),
+    );
   });
 
   it('renders the 404 route with the query that was asked for', async () => {

--- a/packages/waku/tests/define-router-request-handler.test.ts
+++ b/packages/waku/tests/define-router-request-handler.test.ts
@@ -124,6 +124,22 @@ describe('request dispatch', () => {
     );
   });
 
+  it('leaves a server-function redirect to a non-route for the browser', async () => {
+    const { handleRequest } = unstable_defineRouter({
+      getConfigs: async () => [dynamicRoute('/dest'), dynamicRoute('/404')],
+    });
+    const utils = makeUtils();
+    await expect(
+      handleRequest(
+        callInput(async () => {
+          unstable_redirect('/nowhere' as never);
+        }),
+        utils,
+      ),
+    ).rejects.toThrow('Redirect');
+    expect(utils.renderRsc).not.toHaveBeenCalled();
+  });
+
   it.each(['https://example.com/x', '//example.com/x', '/dest#frag'])(
     'leaves a server-function redirect to %s for the browser to follow',
     async (location) => {

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -195,7 +195,7 @@ describe('minimal/client transport failures', () => {
     expect(getErrorInfo(error)).toEqual({
       status: 307,
       location: url,
-      unstable_offEndpoint: true,
+      unstable_offRscEndpoint: true,
     });
   });
 
@@ -212,7 +212,7 @@ describe('minimal/client transport failures', () => {
     expect(getErrorInfo(error)).toEqual({
       status: 307,
       location: url,
-      unstable_offEndpoint: true,
+      unstable_offRscEndpoint: true,
     });
   });
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -195,7 +195,7 @@ describe('minimal/client transport failures', () => {
     expect(getErrorInfo(error)).toEqual({
       status: 307,
       location: url,
-      unstable_offRscEndpoint: true,
+      unstable_redirected: true,
     });
   });
 
@@ -212,7 +212,7 @@ describe('minimal/client transport failures', () => {
     expect(getErrorInfo(error)).toEqual({
       status: 307,
       location: url,
-      unstable_offRscEndpoint: true,
+      unstable_redirected: true,
     });
   });
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -192,7 +192,11 @@ describe('minimal/client transport failures', () => {
       (e: unknown) => e,
     );
 
-    expect(getErrorInfo(error)).toEqual({ status: 307, location: url });
+    expect(getErrorInfo(error)).toEqual({
+      status: 307,
+      location: url,
+      unstable_offEndpoint: true,
+    });
   });
 
   test('a redirect to another origin leaves the rsc endpoint', async () => {
@@ -205,7 +209,11 @@ describe('minimal/client transport failures', () => {
       (e: unknown) => e,
     );
 
-    expect(getErrorInfo(error)).toEqual({ status: 307, location: url });
+    expect(getErrorInfo(error)).toEqual({
+      status: 307,
+      location: url,
+      unstable_offEndpoint: true,
+    });
   });
 
   test('a network error is marked as such', async () => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1937,7 +1937,7 @@ describe('Router integration', () => {
     }
   });
 
-  test('a 404 follow that fails closes with the route it was fetching', async () => {
+  test('a 404 follow that fails closes both navigations', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
@@ -1975,11 +1975,16 @@ describe('Router integration', () => {
 
       await act(async () => {
         await capture.router!.push('/missing' as never).catch(() => {});
-        await flushUntil(() => events.length >= 2);
+        await flushUntil(() => events.length >= 4);
       });
 
-      // the start still closes, carrying the route the follow was fetching
-      expect(events).toEqual(['start /missing', 'error /404']);
+      // the follow is a navigation of its own, so it opens and closes too
+      expect(events).toEqual([
+        'start /missing',
+        'error /missing',
+        'start /404',
+        'error /404',
+      ]);
     } finally {
       consoleErrorSpy.mockRestore();
       view.unmount();
@@ -2168,7 +2173,7 @@ describe('Router integration', () => {
     }
   });
 
-  test('a 404 follow reports one navigation that landed on the 404 route', async () => {
+  test('a 404 follow reports a navigation of its own', async () => {
     const { view, capture, router } = await renderFollowRouter({
       responses: [
         { reject: { status: 404 } },
@@ -2179,20 +2184,23 @@ describe('Router integration', () => {
     });
     try {
       const events: string[] = [];
-      capture.router!.unstable_events.on('start', (route) =>
-        events.push(`start ${route.path}`),
-      );
-      capture.router!.unstable_events.on('complete', (route) =>
-        events.push(`complete ${route.path}`),
-      );
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
 
       await act(async () => {
         await router.push('/missing').catch(() => {});
-        await flushUntil(() => events.length >= 2);
+        await flushUntil(() => events.length >= 4);
       });
 
-      // the follow finishes the navigation it was asked for, not a new one
-      expect(events).toEqual(['start /missing', 'complete /404']);
+      expect(events).toEqual([
+        'start /missing',
+        'error /missing',
+        'start /404',
+        'complete /404',
+      ]);
     } finally {
       view.unmount();
     }
@@ -3337,7 +3345,11 @@ describe('Router integration', () => {
     window.history.replaceState({}, '', '/next?x=1');
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
       Promise.reject(
-        createCustomError('moved', { status: 307, location: '/login' }),
+        createCustomError('moved', {
+          status: 307,
+          location: '/login',
+          unstable_offEndpoint: true,
+        }),
       ),
     );
     installRefetch(refetch);
@@ -4421,8 +4433,12 @@ describe('Router integration', () => {
           [IS_STATIC_ID]: false,
         });
       } else if ('reject' in response) {
+        // the shape checkStatus gives a fetch redirected off the rsc endpoint
+        const info = response.reject.location
+          ? { ...response.reject, unstable_offEndpoint: true }
+          : response.reject;
         refetch.mockImplementationOnce(() =>
-          Promise.reject(createCustomError('follow-error', response.reject)),
+          Promise.reject(createCustomError('follow-error', info)),
         );
       } else {
         refetch.mockResolvedValueOnce(response.resolve);
@@ -4454,8 +4470,8 @@ describe('Router integration', () => {
   };
 
   test('a rejected fetch redirect hard navigates with a new entry', async () => {
-    const assignSpy = vi
-      .spyOn(window.location, 'assign')
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
       .mockImplementation(() => {});
     const { view, refetch, capture, router } = await renderFollowRouter({
       responses: [{ reject: { status: 307, location: '/next' } }],
@@ -4466,11 +4482,12 @@ describe('Router integration', () => {
       await flush();
     });
     expect(refetch).toHaveBeenCalledTimes(1);
-    expect(assignSpy).toHaveBeenCalledTimes(1);
-    expect(assignSpy.mock.calls[0]![0]).toContain('/next');
+    expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
+    expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/next');
     expect(capture.router!.path).toBe('/start');
-    expect(window.location.pathname).toBe('/start');
-    assignSpy.mockRestore();
+    // the attempted entry is written first, so leaving it keeps /start behind
+    expect(window.location.pathname).toBe('/moved');
+    replaceLocationSpy.mockRestore();
     view.unmount();
   });
 
@@ -4539,7 +4556,11 @@ describe('Router integration', () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch.mockImplementationOnce(() =>
       Promise.reject(
-        createCustomError('moved', { status: 307, location: 'login' }),
+        createCustomError('moved', {
+          status: 307,
+          location: 'login',
+          unstable_offEndpoint: true,
+        }),
       ),
     );
     installRefetch(refetch);
@@ -4591,7 +4612,11 @@ describe('Router integration', () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch.mockImplementationOnce(() =>
       Promise.reject(
-        createCustomError('moved', { status: 307, location: 'login' }),
+        createCustomError('moved', {
+          status: 307,
+          location: 'login',
+          unstable_offEndpoint: true,
+        }),
       ),
     );
     installRefetch(refetch);
@@ -5425,7 +5450,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('push settles only once the 404 it follows has landed', async () => {
+  test('push rejects on a 404 response and the follow lands after', async () => {
     const { view, refetch, capture, router } = await renderFollowRouter({
       responses: [
         { reject: { status: 404 } },
@@ -5435,15 +5460,20 @@ describe('Router integration', () => {
       meta: { [HAS404_ID]: true },
     });
     let callsWhenSettled = 0;
+    let rejected = false;
     const record = () => {
       callsWhenSettled = refetch.mock.calls.length;
     };
     await act(async () => {
-      await router.push('/missing').then(record, record);
+      await router.push('/missing').then(record, () => {
+        rejected = true;
+        record();
+      });
       await flush();
       await flush();
     });
-    expect(callsWhenSettled).toBe(2);
+    expect(rejected).toBe(true);
+    expect(callsWhenSettled).toBe(1);
     expect(refetch).toHaveBeenCalledTimes(2);
     expect(capture.router!.path).toBe('/404');
     view.unmount();
@@ -6274,6 +6304,7 @@ describe('Router integration', () => {
             createCustomError('redirect', {
               status: 307,
               location: '/dashboard',
+              unstable_offEndpoint: true,
             }),
           )
         : Promise.resolve({})) as never);
@@ -6824,8 +6855,8 @@ describe('Router integration', () => {
       ],
       slots: [],
     });
-    const assignSpy = vi
-      .spyOn(window.location, 'assign')
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
       .mockImplementation(() => {});
     window.history.replaceState(null, '', '/dashboard');
     const lengthBefore = window.history.length;
@@ -6834,11 +6865,13 @@ describe('Router integration', () => {
       await flush();
       await flush();
     });
-    // the browser follows and records the entry itself
-    expect(window.location.pathname).toBe('/dashboard');
-    expect(window.history.length).toBe(lengthBefore);
-    expect(assignSpy).toHaveBeenCalledWith('http://elsewhere.test/login');
-    assignSpy.mockRestore();
+    // the attempted entry is written, then the browser leaves from it
+    expect(window.location.pathname).toBe('/protected');
+    expect(window.history.length).toBe(lengthBefore + 1);
+    expect(replaceLocationSpy).toHaveBeenCalledWith(
+      'http://elsewhere.test/login',
+    );
+    replaceLocationSpy.mockRestore();
     view.unmount();
   });
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3348,7 +3348,7 @@ describe('Router integration', () => {
         createCustomError('moved', {
           status: 307,
           location: '/login',
-          unstable_offRscEndpoint: true,
+          unstable_redirected: true,
         }),
       ),
     );
@@ -4437,7 +4437,7 @@ describe('Router integration', () => {
       } else if ('reject' in response) {
         // the shape checkStatus gives a fetch redirected off the rsc endpoint
         const info = response.reject.location
-          ? { ...response.reject, unstable_offRscEndpoint: true }
+          ? { ...response.reject, unstable_redirected: true }
           : response.reject;
         refetch.mockImplementationOnce(() =>
           Promise.reject(createCustomError('follow-error', info)),
@@ -4563,7 +4563,7 @@ describe('Router integration', () => {
         createCustomError('moved', {
           status: 307,
           location: 'login',
-          unstable_offRscEndpoint: true,
+          unstable_redirected: true,
         }),
       ),
     );
@@ -4619,7 +4619,7 @@ describe('Router integration', () => {
         createCustomError('moved', {
           status: 307,
           location: 'login',
-          unstable_offRscEndpoint: true,
+          unstable_redirected: true,
         }),
       ),
     );
@@ -6308,7 +6308,7 @@ describe('Router integration', () => {
             createCustomError('redirect', {
               status: 307,
               location: '/dashboard',
-              unstable_offRscEndpoint: true,
+              unstable_redirected: true,
             }),
           )
         : Promise.resolve({})) as never);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -5203,7 +5203,7 @@ describe('Router integration', () => {
       expect(view.container.textContent).toContain(
         'too many redirect or 404 follows',
       );
-      // the per chain cap fires, not the per navigation budget
+      // a follow never resets the budget, so committing each hop still caps
       expect(refetch).toHaveBeenCalledTimes(21);
     } finally {
       consoleErrorSpy.mockRestore();
@@ -5255,7 +5255,7 @@ describe('Router integration', () => {
       expect(view.container.textContent).toContain(
         'too many redirect or 404 follows',
       );
-      // the per chain cap fires, not the per navigation budget
+      // a follow never resets the budget, so committing each hop still caps
       expect(refetch).toHaveBeenCalledTimes(21);
     } finally {
       consoleErrorSpy.mockRestore();
@@ -6849,12 +6849,18 @@ describe('Router integration', () => {
   });
 
   test('a cross origin rejected redirect hard navigates on push', async () => {
-    const { view, router } = await renderFollowRouter({
+    const { view, capture, router } = await renderFollowRouter({
       responses: [
         { reject: { status: 307, location: 'http://elsewhere.test/login' } },
       ],
       slots: [],
     });
+    const events: string[] = [];
+    for (const name of ['start', 'complete', 'error'] as const) {
+      capture.router!.unstable_events.on(name, (route) =>
+        events.push(`${name} ${route.path}`),
+      );
+    }
     const replaceLocationSpy = vi
       .spyOn(window.location, 'replace')
       .mockImplementation(() => {});
@@ -6868,6 +6874,8 @@ describe('Router integration', () => {
     // the attempted entry is written, then the browser leaves from it
     expect(window.location.pathname).toBe('/protected');
     expect(window.history.length).toBe(lengthBefore + 1);
+    // leaving still closes the navigation it was asked for
+    expect(events).toEqual(['start /protected', 'error /protected']);
     expect(replaceLocationSpy).toHaveBeenCalledWith(
       'http://elsewhere.test/login',
     );

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3348,7 +3348,7 @@ describe('Router integration', () => {
         createCustomError('moved', {
           status: 307,
           location: '/login',
-          unstable_offEndpoint: true,
+          unstable_offRscEndpoint: true,
         }),
       ),
     );
@@ -3368,12 +3368,14 @@ describe('Router integration', () => {
       throw new Error('router not initialized');
     }
 
+    const lengthBefore = window.history.length;
     await act(async () => {
       await capture.router!.push('/next?x=1').catch(() => {});
       await flush();
     });
 
     // that entry already exists, so the redirect must not add another
+    expect(window.history.length).toBe(lengthBefore);
     expect(assignSpy).not.toHaveBeenCalled();
     expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
     expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/login');
@@ -4435,7 +4437,7 @@ describe('Router integration', () => {
       } else if ('reject' in response) {
         // the shape checkStatus gives a fetch redirected off the rsc endpoint
         const info = response.reject.location
-          ? { ...response.reject, unstable_offEndpoint: true }
+          ? { ...response.reject, unstable_offRscEndpoint: true }
           : response.reject;
         refetch.mockImplementationOnce(() =>
           Promise.reject(createCustomError('follow-error', info)),
@@ -4476,11 +4478,13 @@ describe('Router integration', () => {
     const { view, refetch, capture, router } = await renderFollowRouter({
       responses: [{ reject: { status: 307, location: '/next' } }],
     });
+    const lengthBefore = window.history.length;
     await act(async () => {
       await router.push('/moved').catch(() => {});
       await flush();
       await flush();
     });
+    expect(window.history.length).toBe(lengthBefore + 1);
     expect(refetch).toHaveBeenCalledTimes(1);
     expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
     expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/next');
@@ -4559,7 +4563,7 @@ describe('Router integration', () => {
         createCustomError('moved', {
           status: 307,
           location: 'login',
-          unstable_offEndpoint: true,
+          unstable_offRscEndpoint: true,
         }),
       ),
     );
@@ -4615,7 +4619,7 @@ describe('Router integration', () => {
         createCustomError('moved', {
           status: 307,
           location: 'login',
-          unstable_offEndpoint: true,
+          unstable_offRscEndpoint: true,
         }),
       ),
     );
@@ -6304,7 +6308,7 @@ describe('Router integration', () => {
             createCustomError('redirect', {
               status: 307,
               location: '/dashboard',
-              unstable_offEndpoint: true,
+              unstable_offRscEndpoint: true,
             }),
           )
         : Promise.resolve({})) as never);
@@ -6884,8 +6888,8 @@ describe('Router integration', () => {
   });
 
   test('a network error stays an error instead of leaving the app', async () => {
-    const assignSpy = vi
-      .spyOn(window.location, 'assign')
+    const replaceLocationSpy = vi
+      .spyOn(window.location, 'replace')
       .mockImplementation(() => {});
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -6921,13 +6925,13 @@ describe('Router integration', () => {
         );
         await flush();
       });
-      expect(assignSpy).not.toHaveBeenCalled();
+      expect(replaceLocationSpy).not.toHaveBeenCalled();
       expect(view.container.textContent).toContain(
         'Caught an unexpected error',
       );
     } finally {
       consoleErrorSpy.mockRestore();
-      assignSpy.mockRestore();
+      replaceLocationSpy.mockRestore();
       view.unmount();
     }
   });

--- a/packages/waku/tests/router-error-route.test.ts
+++ b/packages/waku/tests/router-error-route.test.ts
@@ -54,6 +54,21 @@ describe('resolveErrorRoute', () => {
     expect(errorRoute.type === 'route' && errorRoute.target.path).toBe('/next');
   });
 
+  test('a same origin url left the rsc endpoint, so the browser takes it', () => {
+    const error = createCustomError('redirected rsc request', {
+      status: 307,
+      location: `${window.location.origin}/next`,
+      unstable_offRscEndpoint: true,
+    });
+
+    const errorRoute = resolveErrorRoute(error, attempted('/from'), false);
+
+    expect(errorRoute.type).toBe('leave');
+    expect(errorRoute.type === 'leave' && errorRoute.url.pathname).toBe(
+      '/next',
+    );
+  });
+
   test('another origin leaves the app', () => {
     const error = createCustomError('redirect', {
       status: 307,

--- a/packages/waku/tests/router-error-route.test.ts
+++ b/packages/waku/tests/router-error-route.test.ts
@@ -54,11 +54,11 @@ describe('resolveErrorRoute', () => {
     expect(errorRoute.type === 'route' && errorRoute.target.path).toBe('/next');
   });
 
-  test('a same origin url left the rsc endpoint, so the browser takes it', () => {
+  test('a same origin url from a redirected response is left to the browser', () => {
     const error = createCustomError('redirected rsc request', {
       status: 307,
       location: `${window.location.origin}/next`,
-      unstable_offRscEndpoint: true,
+      unstable_redirected: true,
     });
 
     const errorRoute = resolveErrorRoute(error, attempted('/from'), false);


### PR DESCRIPTION
A missing route used to send nothing back, so the client fetched the 404 page itself. The server now sends it in the same response.

A failed fetch was sorted out inside `changeRoute`, which kept its own copy of the redirect and 404 logic. It now goes to the error boundary that already handles a redirect thrown while rendering, so one place decides where a navigation landed.

Also fixes two server function redirect bugs: `redirect('/dest?a=1')` failed with "Not Found", and a redirect the server cannot render inline now goes back to the browser instead of a 404.

Breaking:
- `push()` now rejects when a redirect leaves the app, and when a missing route gets no answer from a waku server, such as a static export. Catch it if you call it programmatically.
- Landing on a 404, or on a redirect thrown while rendering, now navigates again to get there, so route change events report two navigations instead of one.