### PR TITLE
test: cover the hard navigation a redirected rsc request causes

### DIFF
--- a/e2e/define-router.spec.ts
+++ b/e2e/define-router.spec.ts
@@ -172,6 +172,27 @@ test.describe(`define-router`, () => {
     expect(await res.text()).toBe('');
   });
 
+  test('a redirected rsc request hands the page to the browser', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/`);
+    await waitForHydration(page);
+    await page.evaluate(() => {
+      (window as unknown as { __beforeMoved?: true }).__beforeMoved = true;
+    });
+
+    await page.locator("a[href='/moved']").click();
+
+    await expect(page.getByTestId('foo-title')).toHaveText('Foo');
+    expect(page.url()).toBe(`http://localhost:${port}/foo`);
+    // the marker is gone only if the document was replaced, not soft navigated
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __beforeMoved?: true }).__beforeMoved,
+      ),
+    ).toBeUndefined();
+  });
+
   test('api hi with POST', async () => {
     const res = await fetch(`http://localhost:${port}/api/hi`, {
       method: 'POST',

--- a/e2e/fixtures/define-router/src/routes/layout.tsx
+++ b/e2e/fixtures/define-router/src/routes/layout.tsx
@@ -41,6 +41,12 @@ const HomeLayout = ({ children }: { children: ReactNode }) => (
           <Pending />
         </Link>
       </li>
+      <li>
+        <Link to="/moved">
+          Moved
+          <Pending />
+        </Link>
+      </li>
     </ul>
     {children}
   </div>

--- a/e2e/fixtures/define-router/src/waku.server.tsx
+++ b/e2e/fixtures/define-router/src/waku.server.tsx
@@ -3,7 +3,10 @@ import { readFile } from 'node:fs/promises';
 // NOTE: I think we need one spec to use non-default adapter
 import adapter from 'waku/adapters/node';
 import { Children, Slot } from 'waku/minimal/client';
-import { unstable_defineRouter as defineRouter } from 'waku/router/server';
+import {
+  unstable_defineRouter as defineRouter,
+  unstable_redirect as redirect,
+} from 'waku/router/server';
 import { Slice001 } from './components/slice001.js';
 import { Slice002 } from './components/slice002.js';
 import Bar1Page from './routes/bar1/page.js';
@@ -76,6 +79,34 @@ const router: ReturnType<typeof defineRouter> = defineRouter({
         },
       };
     }),
+    {
+      // the renderer throws before anything streams, so the rsc request is
+      // answered with a real redirect that the browser has to follow
+      type: 'route' as const,
+      pattern: '^/moved$',
+      path: [{ type: 'literal', name: 'moved' } as const],
+      isStatic: false,
+      rootElement: {
+        isStatic: true,
+        renderer: () => (
+          <html>
+            <head>
+              <title>Waku example</title>
+            </head>
+            <body>
+              <Children />
+            </body>
+          </html>
+        ),
+      },
+      routeElement: {
+        isStatic: false,
+        renderer: () => {
+          redirect('/foo');
+        },
+      },
+      elements: {},
+    },
     {
       type: 'api',
       path: [

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -182,6 +182,31 @@ describe('minimal/client transport failures', () => {
     });
   });
 
+  test('a redirect the fetch did not follow is reported as a status', async () => {
+    track(
+      unstable_registerFetchEnhancer(
+        () => async () =>
+          ({
+            redirected: false,
+            url: `${window.location.origin}/RSC/R/next.txt`,
+            ok: false,
+            status: 307,
+            statusText: 'Temporary Redirect',
+            headers: new Headers({ location: '/login' }),
+            text: async () => '',
+          }) as unknown as Response,
+      ),
+    );
+
+    const error = await unstable_fetchRsc('R/next.txt').catch(
+      (e: unknown) => e,
+    );
+
+    // waku never reads Location, so a fetch enhancer using redirect: 'manual'
+    // is not supported. Decided 2026-07-30; revisit with a real use case.
+    expect(getErrorInfo(error)).toEqual({ status: 307 });
+  });
+
   test('a redirect off the rsc endpoint leaves it, same origin or not', async () => {
     const url = `${window.location.origin}/login`;
     track(


### PR DESCRIPTION
The client hands the page to the browser when an RSC request gets redirected off the RSC endpoint. That path had no e2e coverage. The define-router fixture gets a `/moved` route whose renderer redirects, which is answered with a real 307, so the fetch lands on an HTML page and the router leaves the app.

The test asserts the document was actually replaced rather than soft navigated. Removing the `unstable_redirected` branch from `resolveErrorRoute` makes it fail.

Also records, as a test, that `checkStatus` does not read the `Location` header on a non-ok response, so a fetch enhancer using `redirect: 'manual'` is not supported.
