### PR TITLE
ci: name React override install steps for readability

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,7 +125,7 @@ jobs:
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
       - if: runner.os == 'Windows'
         run: choco install yq -y
-      - name: Override React versions and install
+      - name: Override React versions
         if: ${{ inputs.react_version }}
         env:
           REACT_VERSION: ${{ inputs.react_version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,8 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
-      - if: ${{ inputs.react_version }}
+      - name: Override React versions and install
+        if: ${{ inputs.react_version }}
         env:
           REACT_VERSION: ${{ inputs.react_version }}
         run: |
@@ -124,7 +125,8 @@ jobs:
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
       - if: runner.os == 'Windows'
         run: choco install yq -y
-      - if: ${{ inputs.react_version }}
+      - name: Override React versions and install
+        if: ${{ inputs.react_version }}
         env:
           REACT_VERSION: ${{ inputs.react_version }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,8 @@ jobs:
         with:
           node-version: ${{ matrix.version }}
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
-      - if: ${{ inputs.react_version }}
+      - name: Override React versions and install
+        if: ${{ inputs.react_version }}
         env:
           REACT_VERSION: ${{ inputs.react_version }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           node-version: ${{ matrix.version }}
           cache: ${{ !inputs.react_version && 'pnpm' || '' }}
-      - name: Override React versions and install
+      - name: Override React versions
         if: ${{ inputs.react_version }}
         env:
           REACT_VERSION: ${{ inputs.react_version }}


### PR DESCRIPTION
## Problem

In `.github/workflows/e2e.yml` and `.github/workflows/test.yml`, the optional React-version override `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when `pnpm-workspace.yaml` override / install fails.

## Changes

Semantics are unchanged: same `if:` conditions, same env vars, and the same `yq` / `pnpm install` commands.

- Add `name: Override React versions and install` in `e2e.yml` (`build` and `e2e` jobs)
- Add `name: Override React versions and install` in `test.yml`

## Test plan
- [ ] Confirm the steps still run only when `inputs.react_version` is set
- [ ] Confirm React / react-dom / react-server-dom-webpack overrides are unchanged
- [ ] Confirm the steps show the new names in the Actions UI
