### PR TITLE
refactor(router): drop router client refs into the router state

### DIFF
--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -17,6 +17,7 @@ export type RouterState = {
   // null leaves history alone: the browser already wrote it
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
+  readonly followCount: number; // follows since the last navigation of its own
   readonly failed?: boolean; // the fetch never landed, so the route id is stale
   readonly error?: unknown; // what failed, when failed is set
   // the reconciler writes this back, so a second pass does not repeat itself
@@ -35,12 +36,14 @@ export const makeRouterState = (
     history: 'push' | 'replace' | null;
     scroll: boolean;
     pathChanged: boolean;
+    followCount: number;
   },
 ): RouterState => ({
   url: url.pathname + url.search + url.hash,
   attempted: [route.path, route.query],
   history: options.history,
   scroll: options.scroll ? { pathChanged: options.pathChanged } : null,
+  followCount: options.followCount,
 });
 
 // a redirect to the 404 route keeps the url that was attempted

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -19,6 +19,8 @@ export type RouterState = {
   readonly scroll: { readonly pathChanged: boolean } | null;
   readonly failed?: boolean; // the fetch never landed, so the route id is stale
   readonly error?: unknown; // what failed, when failed is set
+  // the reconciler writes this back, so a second pass does not repeat itself
+  applied?: { href: string; pushed: boolean };
 };
 
 export const getRouterState = (

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -18,9 +18,9 @@ export type RouterState = {
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
   readonly followCount: number; // follows since the last navigation of its own
-  readonly failed?: boolean; // the fetch never landed, so the route id is stale
-  readonly error?: unknown; // what failed, when failed is set
-  // the reconciler writes this back, so a second pass does not repeat itself
+  // set when the fetch never landed, so the route id is stale
+  readonly failure?: { readonly error: unknown };
+  // the reconciler writes this back on the same object, never on a copy
   applied?: { href: string; pushed: boolean };
 };
 
@@ -54,7 +54,7 @@ export const resolveServerRedirect = (
 ): { route: RouteProps; url: URL } => {
   const stateUrl = new URL(routerState.url, window.location.href);
   // nothing landed on a failed navigation, so there is no redirect to read
-  const redirect = routerState.failed
+  const redirect = routerState.failure
     ? undefined
     : getServerRedirect(elements, {
         path: routerState.attempted[0],

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -18,6 +18,7 @@ export type RouterState = {
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
   readonly failed?: boolean; // the fetch never landed, so the route id is stale
+  readonly error?: unknown; // what failed, when failed is set
 };
 
 export const getRouterState = (

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -18,10 +18,9 @@ export type RouterState = {
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
   readonly followCount: number;
-  // set when the fetch never landed, so the route id is stale
-  readonly failure?: { readonly error: unknown };
-  // the reconciler writes this back on the same object, never on a copy
-  applied?: { href: string; pushed: boolean };
+  // set when the fetch never landed: the route id is stale, and hash is the
+  // one still on screen rather than the one it tried
+  readonly failure?: { readonly error: unknown; readonly hash: string };
 };
 
 export const getRouterState = (

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -18,9 +18,11 @@ export type RouterState = {
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
   readonly followCount: number;
-  // set when the fetch never landed: the route id is stale, and hash is the
-  // one still on screen rather than the one it tried
-  readonly failure?: { readonly error: unknown; readonly hash: string };
+  // set when the fetch never landed, so the route id is stale
+  readonly failure?: {
+    readonly error: unknown;
+    readonly committedHash: string;
+  };
 };
 
 export const getRouterState = (

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -17,7 +17,7 @@ export type RouterState = {
   // null leaves history alone: the browser already wrote it
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
-  readonly followCount: number; // follows since the last navigation of its own
+  readonly followCount: number;
   // set when the fetch never landed, so the route id is stale
   readonly failure?: { readonly error: unknown };
   // the reconciler writes this back on the same object, never on a copy

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -808,17 +808,14 @@ const FollowError = ({
 }) => {
   const { route, routerState, changeRoute } = useRouterOrThrow();
   const { path: routePath, query: routeQuery, hash: routeHash } = route;
-  const [caughtAt] = useState<readonly [string, string, string]>(() => [
-    routePath,
-    routeQuery,
-    routeHash,
-  ]);
+  const caughtAtRef = useRef<readonly [string, string, string]>(undefined);
+  caughtAtRef.current ??= [routePath, routeQuery, routeHash];
   const dispatchedRef = useRef<
     | { route: RouteProps; url: string; from: RouterState | undefined }
     | undefined
   >(undefined);
   useEffect(() => {
-    const [caughtPath, caughtQuery, caughtHash] = caughtAt;
+    const [caughtPath, caughtQuery, caughtHash] = caughtAtRef.current!;
     // a route change means the followed slot is committed; safe to reset
     if (
       routePath !== caughtPath ||
@@ -847,16 +844,7 @@ const FollowError = ({
         fail(error, new Error('detected a navigation loop', { cause: error }));
       }
     }
-  }, [
-    routePath,
-    routeQuery,
-    routeHash,
-    routerState,
-    reset,
-    fail,
-    error,
-    caughtAt,
-  ]);
+  }, [routePath, routeQuery, routeHash, routerState, reset, fail, error]);
   const followCaughtError = useEffectEvent(() => {
     // the attempted url may not have reached the address bar yet
     const attemptedUrl = routerState

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -828,7 +828,7 @@ const FollowError = ({
       dispatched &&
       routerState &&
       routerState !== dispatched.from &&
-      !routerState.failed
+      !routerState.failure
     ) {
       const landed =
         routerState.attempted[0] === dispatched.route.path &&
@@ -1122,7 +1122,7 @@ const InnerRouter = ({
     const route = getRouteFromElements(committed) ?? initialRoute;
     const state = getRouterState(committed);
     // a failed state holds the url it tried, which is not where we are
-    const url = state?.failed ? undefined : state?.url;
+    const url = state?.failure ? undefined : state?.url;
     return {
       ...route,
       hash: url ? new URL(url, window.location.href).hash : '',
@@ -1148,7 +1148,7 @@ const InnerRouter = ({
       }
     }
     routerState.applied = { href: url.href, pushed };
-    if (routerState.scroll && !applied && !routerState.failed) {
+    if (routerState.scroll && !applied && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
       scrollToRoute(
         currentRoute,
@@ -1307,8 +1307,7 @@ const InnerRouter = ({
           [ROUTER_STATE_ID]: {
             ...routerState,
             history: null, // the url above is already written
-            failed: true,
-            error: e,
+            failure: { error: e },
           },
         });
         emitRouteChangeEvent('error', nextRoute);
@@ -1412,8 +1411,8 @@ const InnerRouter = ({
     };
   }, [changeRoute, routeInterceptor, committedRoute]);
 
-  const routeElement = routerState?.failed ? (
-    <ThrowError error={routerState.error} />
+  const routeElement = routerState?.failure ? (
+    <ThrowError error={routerState.failure.error} />
   ) : (
     <Slot id={getRouteSlotId(currentRoute.path)} />
   );

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1071,6 +1071,7 @@ const InnerRouter = ({
       : fallbackRoute;
   const initialHashRef = useRef<string>(undefined);
   initialHashRef.current ??= resolvedRoute.hash;
+  // state, not a ref: it is read during render
   const [initialRoute] = useState(() => ({ ...resolvedRoute, hash: '' }));
 
   const has404 = has404FromElements(elements);
@@ -1185,6 +1186,7 @@ const InnerRouter = ({
   );
 
   // FIXME this "fetchingSlices" hack feels suboptimal.
+  // state, not a ref: it is read during render
   const [fetchingSlices] = useState(() => new Set<SliceId>());
   const pendingNavigationRef = useRef<{
     controller: AbortController;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -142,6 +142,19 @@ const parseRouteFromLocation = (): RouteProps => {
   return parseRoute(new URL(window.location.href));
 };
 
+// returns whether it pushed, so a second pass can downgrade to replace
+const commitHistory = (url: URL, mode: 'push' | 'replace' | null): boolean => {
+  if (window.location.href === url.href) {
+    return false;
+  }
+  if (mode === 'push') {
+    window.history.pushState(window.history.state, '', url);
+    return true;
+  }
+  window.history.replaceState(window.history.state, '', url);
+  return false;
+};
+
 const reloadWithUrl = (url: URL) => {
   window.history.pushState(window.history.state, '', url);
   window.location.reload();
@@ -1138,16 +1151,13 @@ const InnerRouter = ({
     if (applied?.href === url.href) {
       return;
     }
-    let pushed = applied?.pushed ?? false;
+    const wasPushed = applied?.pushed ?? false;
     // history null still writes: the state's url is the one that should show
-    if (window.location.href !== url.href) {
-      if (routerState.history === 'push' && !pushed) {
-        pushed = true;
-        window.history.pushState(window.history.state, '', url);
-      } else {
-        window.history.replaceState(window.history.state, '', url);
-      }
-    }
+    const pushed =
+      commitHistory(
+        url,
+        routerState.history === 'push' && !wasPushed ? 'push' : 'replace',
+      ) || wasPushed;
     appliedByState.set(routerState, { href: url.href, pushed });
     if (routerState.scroll && !applied && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
@@ -1291,13 +1301,7 @@ const InnerRouter = ({
         }
         pendingNavigationRef.current = null;
         // write the url now; an unrecoverable rethrow discards the commit
-        if (window.location.href !== targetUrl.href) {
-          if (routerState.history === 'push') {
-            window.history.pushState(window.history.state, '', targetUrl);
-          } else {
-            window.history.replaceState(window.history.state, '', targetUrl);
-          }
-        }
+        commitHistory(targetUrl, routerState.history);
         mergeElements({
           [ROUTER_STATE_ID]: {
             ...routerState,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -814,7 +814,6 @@ const FollowError = ({
     undefined,
   );
   const stateAtDispatchRef = useRef<RouterState | undefined>(undefined);
-  const followingRef = useRef<unknown>(null);
   const routerStateRef = useRef(routerState);
   useEffect(() => {
     routerStateRef.current = routerState;
@@ -856,10 +855,9 @@ const FollowError = ({
       ? new URL(routerStateRef.current.url, window.location.href)
       : new URL(window.location.href);
     const errorRoute = resolveErrorRoute(error, attemptedUrl, has404);
-    if (errorRoute.type === 'none' || followingRef.current === error) {
+    if (errorRoute.type === 'none') {
       return;
     }
-    followingRef.current = error;
     if (errorRoute.type === 'unfollowable') {
       fail(
         error,
@@ -903,15 +901,9 @@ const FollowError = ({
         url,
         isFollow: true,
         refetch: true,
-      }).then(
-        () => {
-          followingRef.current = null;
-        },
-        (err) => {
-          followingRef.current = null;
-          fail(error, err);
-        },
-      );
+      }).catch((err: unknown) => {
+        fail(error, err);
+      });
     });
   }, [error, has404, fail, countFollow, changeRoute]);
   const info = getErrorInfo(error);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1130,7 +1130,7 @@ const InnerRouter = ({
     if (state.failure) {
       return {
         ...(getRouteFromElements(committed) ?? initialRoute),
-        hash: state.failure.hash,
+        hash: state.failure.committedHash,
       };
     }
     return resolveServerRedirect(committed, state, initialRoute.path).route;
@@ -1312,7 +1312,7 @@ const InnerRouter = ({
           [ROUTER_STATE_ID]: {
             ...routerState,
             history: null, // the url above is already written
-            failure: { error: e, hash: routeBefore.hash },
+            failure: { error: e, committedHash: routeBefore.hash },
           },
         });
         emitRouteChangeEvent('error', nextRoute);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1185,25 +1185,32 @@ const InnerRouter = ({
 
   // FIXME this "fetchingSlices" hack feels suboptimal.
   const fetchingSlices = useRef(new Set<SliceId>()).current;
-  const abortRef = useRef<AbortController | null>(null);
-  const announcedRef = useRef<RouteProps | null>(null);
+  // it exists while a terminal event is owed; announced says start went out
+  const pendingNavigationRef = useRef<{
+    controller: AbortController;
+    route: RouteProps;
+    announced: boolean;
+  } | null>(null);
 
   const changeRoute: ChangeRoute = useCallback(
     async function changeRoute(nextRoute, options) {
-      const superseded = abortRef.current ? announcedRef.current : null;
-      abortRef.current?.abort();
-      const abortController = new AbortController();
-      abortRef.current = abortController;
-      const isAborted = () => abortController.signal.aborted;
-      if (superseded) {
-        announcedRef.current = null;
-        emitRouteChangeEvent('error', superseded);
+      const superseded = pendingNavigationRef.current;
+      superseded?.controller.abort();
+      const pending = {
+        controller: new AbortController(),
+        route: nextRoute,
+        announced: false,
+      };
+      pendingNavigationRef.current = pending;
+      const isAborted = () => pending.controller.signal.aborted;
+      if (superseded?.announced) {
+        emitRouteChangeEvent('error', superseded.route);
       }
       // a listener can navigate synchronously, which aborts this one
       if (isAborted()) {
         return;
       }
-      announcedRef.current = nextRoute;
+      pending.announced = true;
       emitRouteChangeEvent('start', nextRoute);
       if (isAborted()) {
         return;
@@ -1225,7 +1232,7 @@ const InnerRouter = ({
           [ROUTE_ID]: [nextRoute.path, nextRoute.query],
           [ROUTER_STATE_ID]: routerState,
         });
-        abortRef.current = null;
+        pendingNavigationRef.current = null;
         emitRouteChangeEvent('complete', nextRoute);
         return;
       }
@@ -1240,7 +1247,7 @@ const InnerRouter = ({
           prefetchedElements,
         );
       const dataPromise = refetch(rscPath, createRscParams(nextRoute.query), {
-        signal: abortController.signal,
+        signal: pending.controller.signal,
         unstable_overlay: {
           [ROUTER_STATE_ID]: routerState,
           // meta is pinned, so an instant nav has to carry it or it goes stale
@@ -1269,7 +1276,7 @@ const InnerRouter = ({
         if (isAborted()) {
           return;
         }
-        abortRef.current = null;
+        pendingNavigationRef.current = null;
         learnStaticPath(resolved);
         emitRouteChangeEvent(
           'complete',
@@ -1279,7 +1286,7 @@ const InnerRouter = ({
         if (isAborted()) {
           return;
         }
-        abortRef.current = null;
+        pendingNavigationRef.current = null;
         // write the url now; an unrecoverable rethrow discards the commit
         if (window.location.href !== targetUrl.href) {
           if (routerState.history === 'push') {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1101,7 +1101,7 @@ const InnerRouter = ({
     learnStaticPath(initialElements);
   }, [initialElements, learnStaticPath]);
   const resolvedElementsRef = useRef(elements);
-  useEffect(() => {
+  useLayoutEffect(() => {
     resolvedElementsRef.current = elements;
   }, [elements]);
   const [prefetchManager] = useState(createPrefetchManager);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -785,6 +785,11 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOWS_PER_NAVIGATION = 20;
 
+const appliedByState = new WeakMap<
+  RouterState,
+  { href: string; pushed: boolean }
+>();
+
 const isFollowable = (error: unknown) => {
   const info = getErrorInfo(error);
   return info?.status === 404 || !!info?.location;
@@ -1118,20 +1123,24 @@ const InnerRouter = ({
     : { ...initialRoute, hash: restoredHash };
   const committedRoute = useCallback((): RouteProps => {
     const committed = resolvedElementsRef.current;
-    const route = getRouteFromElements(committed) ?? initialRoute;
     const state = getRouterState(committed);
-    const landedUrl = state?.failure ? undefined : state?.url;
-    return {
-      ...route,
-      hash: landedUrl ? new URL(landedUrl, window.location.href).hash : '',
-    };
-  }, [initialRoute]);
+    if (!state) {
+      return { ...initialRoute, hash: restoredHash };
+    }
+    if (state.failure) {
+      return {
+        ...(getRouteFromElements(committed) ?? initialRoute),
+        hash: state.failure.hash,
+      };
+    }
+    return resolveServerRedirect(committed, state, initialRoute.path).route;
+  }, [initialRoute, restoredHash]);
   useLayoutEffect(() => {
     if (!routerState || !destination) {
       return;
     }
     const { url } = destination;
-    const { applied } = routerState;
+    const applied = appliedByState.get(routerState);
     if (applied?.href === url.href) {
       return;
     }
@@ -1145,7 +1154,7 @@ const InnerRouter = ({
         window.history.replaceState(window.history.state, '', url);
       }
     }
-    routerState.applied = { href: url.href, pushed };
+    appliedByState.set(routerState, { href: url.href, pushed });
     if (routerState.scroll && !applied && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
       scrollToRoute(
@@ -1156,9 +1165,8 @@ const InnerRouter = ({
     }
   });
 
-  if (import.meta.hot) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
+  useEffect(() => {
+    if (import.meta.hot) {
       const refetchRouteOnHmr = () => {
         prefetchManager.clear();
         staticPathSet.clear();
@@ -1176,14 +1184,14 @@ const InnerRouter = ({
         refetchRouteOnHmr,
       );
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
-    }, [
-      refetch,
-      prefetchManager,
-      staticPathSet,
-      learnStaticPath,
-      committedRoute,
-    ]);
-  }
+    }
+  }, [
+    refetch,
+    prefetchManager,
+    staticPathSet,
+    learnStaticPath,
+    committedRoute,
+  ]);
 
   const [[routeChangeEvents, emitRouteChangeEvent]] = useState(
     createRouteChangeListeners,
@@ -1304,7 +1312,7 @@ const InnerRouter = ({
           [ROUTER_STATE_ID]: {
             ...routerState,
             history: null, // the url above is already written
-            failure: { error: e },
+            failure: { error: e, hash: routeBefore.hash },
           },
         });
         emitRouteChangeEvent('error', nextRoute);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -794,13 +794,11 @@ const FollowError = ({
   has404,
   reset,
   fail,
-  countFollow,
 }: {
   error: unknown;
   has404: boolean;
   reset: () => void;
   fail: (original: unknown, error: unknown) => void;
-  countFollow: () => boolean;
 }) => {
   const { route, routerState, changeRoute } = useRouterOrThrow();
   const { path: routePath, query: routeQuery, hash: routeHash } = route;
@@ -880,7 +878,9 @@ const FollowError = ({
       fail(error, new Error('detected a navigation loop', { cause: error }));
       return;
     }
-    if (!countFollow()) {
+    if (
+      (routerStateRef.current?.followCount ?? 0) >= MAX_FOLLOWS_PER_NAVIGATION
+    ) {
       fail(
         error,
         new Error('too many redirect or 404 follows', { cause: error }),
@@ -905,7 +905,7 @@ const FollowError = ({
         fail(error, err);
       });
     });
-  }, [error, has404, fail, countFollow, changeRoute]);
+  }, [error, has404, fail, changeRoute]);
   const info = getErrorInfo(error);
   return info?.status === 404 && !has404 ? <h1>Not Found</h1> : null;
 };
@@ -913,31 +913,21 @@ const FollowError = ({
 class CustomErrorHandler extends Component<
   {
     has404: boolean;
-    followCount: RefObject<number>;
     children?: ReactNode;
   },
   { error: unknown | null }
 > {
-  constructor(props: {
-    has404: boolean;
-    followCount: RefObject<number>;
-    children?: ReactNode;
-  }) {
+  constructor(props: { has404: boolean; children?: ReactNode }) {
     super(props);
     this.state = { error: null };
     this.reset = this.reset.bind(this);
     this.fail = this.fail.bind(this);
-    this.countFollow = this.countFollow.bind(this);
   }
   static getDerivedStateFromError(error: unknown) {
     return { error };
   }
   reset() {
     this.setState({ error: null });
-  }
-  countFollow() {
-    this.props.followCount.current += 1;
-    return this.props.followCount.current <= MAX_FOLLOWS_PER_NAVIGATION;
   }
   // error is a wrapper: the original still carries a location and would follow
   fail(original: unknown, error: unknown) {
@@ -953,7 +943,6 @@ class CustomErrorHandler extends Component<
             has404={this.props.has404}
             reset={this.reset}
             fail={this.fail}
-            countFollow={this.countFollow}
           />
         );
       }
@@ -1186,7 +1175,6 @@ const InnerRouter = ({
 
   // FIXME this "fetchingSlices" hack feels suboptimal.
   const fetchingSlices = useRef(new Set<SliceId>()).current;
-  const followCountRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
   const announcedRef = useRef<RouteProps | null>(null);
 
@@ -1210,15 +1198,15 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      if (!options.isFollow) {
-        followCountRef.current = 0;
-      }
       const routeBefore = routeRef.current;
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
       const routerState = makeRouterState(nextRoute, targetUrl, {
         history: options.history,
         scroll: options.shouldScroll,
         pathChanged: nextRoute.path !== routeBefore.path,
+        followCount: options.isFollow
+          ? (getRouterState(resolvedElementsRef.current)?.followCount ?? 0) + 1
+          : 0,
       });
       const shouldRefetch =
         options.refetch ?? !isSameRscRoute(nextRoute, routeBefore);
@@ -1405,9 +1393,7 @@ const InnerRouter = ({
   );
   const rootElement = (
     <Slot id="root">
-      <CustomErrorHandler has404={has404} followCount={followCountRef}>
-        {routeElement}
-      </CustomErrorHandler>
+      <CustomErrorHandler has404={has404}>{routeElement}</CustomErrorHandler>
     </Slot>
   );
   return (

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -803,18 +803,17 @@ const FollowError = ({
 }) => {
   const { route, routerState, changeRoute } = useRouterOrThrow();
   const { path: routePath, query: routeQuery, hash: routeHash } = route;
-  const caughtAtRef = useRef<readonly [string, string, string] | undefined>(
-    undefined,
-  );
-  if (caughtAtRef.current === undefined) {
-    caughtAtRef.current = [routePath, routeQuery, routeHash];
-  }
-  const dispatchedRef = useRef<{ route: RouteProps; url: string } | undefined>(
-    undefined,
-  );
-  const stateAtDispatchRef = useRef<RouterState | undefined>(undefined);
+  const [caughtAt] = useState<readonly [string, string, string]>(() => [
+    routePath,
+    routeQuery,
+    routeHash,
+  ]);
+  const dispatchedRef = useRef<
+    | { route: RouteProps; url: string; from: RouterState | undefined }
+    | undefined
+  >(undefined);
   useEffect(() => {
-    const [caughtPath, caughtQuery, caughtHash] = caughtAtRef.current!;
+    const [caughtPath, caughtQuery, caughtHash] = caughtAt;
     // a route change means the followed slot is committed; safe to reset
     if (
       routePath !== caughtPath ||
@@ -828,7 +827,7 @@ const FollowError = ({
     if (
       dispatched &&
       routerState &&
-      routerState !== stateAtDispatchRef.current &&
+      routerState !== dispatched.from &&
       !routerState.failed
     ) {
       const landed =
@@ -843,7 +842,16 @@ const FollowError = ({
         fail(error, new Error('detected a navigation loop', { cause: error }));
       }
     }
-  }, [routePath, routeQuery, routeHash, routerState, reset, fail, error]);
+  }, [
+    routePath,
+    routeQuery,
+    routeHash,
+    routerState,
+    reset,
+    fail,
+    error,
+    caughtAt,
+  ]);
   const followCaughtError = useEffectEvent(() => {
     // the attempted url may not have reached the address bar yet
     const attemptedUrl = routerState
@@ -885,8 +893,8 @@ const FollowError = ({
     dispatchedRef.current = {
       route: target,
       url: url.pathname + url.search + url.hash,
+      from: routerState,
     };
-    stateAtDispatchRef.current = routerState;
     startTransition(() => {
       changeRoute(target, {
         shouldScroll: routerState

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useEffectEvent,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -812,10 +813,6 @@ const FollowError = ({
     undefined,
   );
   const stateAtDispatchRef = useRef<RouterState | undefined>(undefined);
-  const routerStateRef = useRef(routerState);
-  useEffect(() => {
-    routerStateRef.current = routerState;
-  }, [routerState]);
   useEffect(() => {
     const [caughtPath, caughtQuery, caughtHash] = caughtAtRef.current!;
     // a route change means the followed slot is committed; safe to reset
@@ -847,10 +844,10 @@ const FollowError = ({
       }
     }
   }, [routePath, routeQuery, routeHash, routerState, reset, fail, error]);
-  useEffect(() => {
+  const followCaughtError = useEffectEvent(() => {
     // the attempted url may not have reached the address bar yet
-    const attemptedUrl = routerStateRef.current
-      ? new URL(routerStateRef.current.url, window.location.href)
+    const attemptedUrl = routerState
+      ? new URL(routerState.url, window.location.href)
       : new URL(window.location.href);
     const errorRoute = resolveErrorRoute(error, attemptedUrl, has404);
     if (errorRoute.type === 'none') {
@@ -870,7 +867,7 @@ const FollowError = ({
       return;
     }
     const { target, url } = errorRoute;
-    const attempted = routerStateRef.current?.attempted;
+    const attempted = routerState?.attempted;
     const caught = attempted
       ? { path: attempted[0], query: attempted[1] }
       : parseRoute(attemptedUrl);
@@ -878,9 +875,7 @@ const FollowError = ({
       fail(error, new Error('detected a navigation loop', { cause: error }));
       return;
     }
-    if (
-      (routerStateRef.current?.followCount ?? 0) >= MAX_FOLLOWS_PER_NAVIGATION
-    ) {
+    if ((routerState?.followCount ?? 0) >= MAX_FOLLOWS_PER_NAVIGATION) {
       fail(
         error,
         new Error('too many redirect or 404 follows', { cause: error }),
@@ -891,11 +886,11 @@ const FollowError = ({
       route: target,
       url: url.pathname + url.search + url.hash,
     };
-    stateAtDispatchRef.current = routerStateRef.current;
+    stateAtDispatchRef.current = routerState;
     startTransition(() => {
       changeRoute(target, {
-        shouldScroll: routerStateRef.current
-          ? routerStateRef.current.scroll !== null
+        shouldScroll: routerState
+          ? routerState.scroll !== null
           : target.path !== caught.path,
         history: 'replace',
         url,
@@ -905,7 +900,10 @@ const FollowError = ({
         fail(error, err);
       });
     });
-  }, [error, has404, fail, changeRoute]);
+  });
+  useEffect(() => {
+    followCaughtError();
+  }, [error, has404]);
   const info = getErrorInfo(error);
   return info?.status === 404 && !has404 ? <h1>Not Found</h1> : null;
 };

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1068,11 +1068,11 @@ const InnerRouter = ({
     routeFromElements && routeFromElements.path !== fallbackRoute.path
       ? { ...routeFromElements, hash: fallbackRoute.hash }
       : fallbackRoute;
-  const initialHash = useRef(resolvedRoute.hash).current;
-  const initialRoute = useRef({ ...resolvedRoute, hash: '' }).current;
+  const [initialHash] = useState(() => resolvedRoute.hash);
+  const [initialRoute] = useState(() => ({ ...resolvedRoute, hash: '' }));
 
   const has404 = has404FromElements(elements);
-  const staticPathSet = useRef(new Set<string>()).current;
+  const [staticPathSet] = useState(() => new Set<string>());
   // a record mid navigation pairs the new route id with the old static flag
   const learnStaticPath = useCallback(
     (responseElements: Record<string, unknown>) => {
@@ -1083,7 +1083,7 @@ const InnerRouter = ({
     },
     [staticPathSet],
   );
-  const initialElements = useRef(elements).current;
+  const [initialElements] = useState(() => elements);
   useEffect(() => {
     learnStaticPath(initialElements);
   }, [initialElements, learnStaticPath]);
@@ -1091,7 +1091,7 @@ const InnerRouter = ({
   useEffect(() => {
     resolvedElementsRef.current = elements;
   }, [elements]);
-  const prefetchManager = useRef(createPrefetchManager()).current;
+  const [prefetchManager] = useState(createPrefetchManager);
 
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
@@ -1184,7 +1184,7 @@ const InnerRouter = ({
   );
 
   // FIXME this "fetchingSlices" hack feels suboptimal.
-  const fetchingSlices = useRef(new Set<SliceId>()).current;
+  const [fetchingSlices] = useState(() => new Set<SliceId>());
   // it exists while a terminal event is owed; announced says start went out
   const pendingNavigationRef = useRef<{
     controller: AbortController;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1122,10 +1122,6 @@ const InnerRouter = ({
     ? destination.route
     : { ...initialRoute, hash: restoredHash };
   const routeRef = useRef(currentRoute);
-  // what the last reconcile did, so a second pass does not repeat it
-  const reconciledRef = useRef<
-    { routerState: RouterState; href: string; pushed: boolean } | undefined
-  >(undefined);
   useLayoutEffect(() => {
     if (!routerState?.failed) {
       // a failed navigation renders the route it came from with the url it
@@ -1136,14 +1132,11 @@ const InnerRouter = ({
       return;
     }
     const { url } = destination;
-    const reconciled =
-      reconciledRef.current?.routerState === routerState
-        ? reconciledRef.current
-        : undefined;
-    if (reconciled?.href === url.href) {
+    const { applied } = routerState;
+    if (applied?.href === url.href) {
       return;
     }
-    let pushed = reconciled?.pushed ?? false;
+    let pushed = applied?.pushed ?? false;
     // history null still writes: the state's url is the one that should show
     if (window.location.href !== url.href) {
       if (routerState.history === 'push' && !pushed) {
@@ -1153,8 +1146,8 @@ const InnerRouter = ({
         window.history.replaceState(window.history.state, '', url);
       }
     }
-    reconciledRef.current = { routerState, href: url.href, pushed };
-    if (routerState.scroll && !reconciled && !routerState.failed) {
+    routerState.applied = { href: url.href, pushed };
+    if (routerState.scroll && !applied && !routerState.failed) {
       const { pathChanged } = routerState.scroll;
       scrollToRoute(
         currentRoute,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1108,7 +1108,6 @@ const InnerRouter = ({
 
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
-  const [err, setErr] = useState<unknown>(null);
   // starts empty so hydration matches the server, then the effect fills it
   const [restoredHash, setRestoredHash] = useState('');
   useEffect(() => {
@@ -1230,7 +1229,6 @@ const InnerRouter = ({
       });
       const shouldRefetch =
         options.refetch ?? !isSameRscRoute(nextRoute, routeBefore);
-      setErr(null);
       if (staticPathSet.has(nextRoute.path) || !shouldRefetch) {
         mergeElements({
           [ROUTE_ID]: [nextRoute.path, nextRoute.query],
@@ -1304,9 +1302,9 @@ const InnerRouter = ({
             ...routerState,
             history: null, // the url above is already written
             failed: true,
+            error: e,
           },
         });
-        setErr(e);
         emitRouteChangeEvent('error', nextRoute);
         throw e;
       }
@@ -1407,12 +1405,11 @@ const InnerRouter = ({
     };
   }, [changeRoute, routeInterceptor]);
 
-  const routeElement =
-    err !== null ? (
-      <ThrowError error={err} />
-    ) : (
-      <Slot id={getRouteSlotId(currentRoute.path)} />
-    );
+  const routeElement = routerState?.failed ? (
+    <ThrowError error={routerState.error} />
+  ) : (
+    <Slot id={getRouteSlotId(currentRoute.path)} />
+  );
   const rootElement = (
     <Slot id="root">
       <CustomErrorHandler has404={has404} followCount={followCountRef}>

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1110,13 +1110,19 @@ const InnerRouter = ({
   const currentRoute = destination
     ? destination.route
     : { ...initialRoute, hash: restoredHash };
-  const routeRef = useRef(currentRoute);
+  // a failed navigation leaves the route id alone, so this stays committed
+  const committedRoute = useCallback((): RouteProps => {
+    const committed = resolvedElementsRef.current;
+    const route = getRouteFromElements(committed) ?? initialRoute;
+    const state = getRouterState(committed);
+    // a failed state holds the url it tried, which is not where we are
+    const url = state?.failed ? undefined : state?.url;
+    return {
+      ...route,
+      hash: url ? new URL(url, window.location.href).hash : '',
+    };
+  }, [initialRoute]);
   useLayoutEffect(() => {
-    if (!routerState?.failed) {
-      // a failed navigation renders the route it came from with the url it
-      // tried; publishing that pair would make a retry look like a no op
-      routeRef.current = currentRoute;
-    }
     if (!routerState || !destination) {
       return;
     }
@@ -1152,7 +1158,7 @@ const InnerRouter = ({
       const refetchRouteOnHmr = () => {
         prefetchManager.clear();
         staticPathSet.clear();
-        const route = routeRef.current;
+        const route = committedRoute();
         startTransition(() => {
           // the reload clears the set, so the response has to teach it again
           void refetch(
@@ -1166,7 +1172,13 @@ const InnerRouter = ({
         refetchRouteOnHmr,
       );
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
-    }, [refetch, prefetchManager, staticPathSet, learnStaticPath]);
+    }, [
+      refetch,
+      prefetchManager,
+      staticPathSet,
+      learnStaticPath,
+      committedRoute,
+    ]);
   }
 
   const [[routeChangeEvents, emitRouteChangeEvent]] = useState(
@@ -1198,7 +1210,7 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      const routeBefore = routeRef.current;
+      const routeBefore = committedRoute();
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
       const routerState = makeRouterState(nextRoute, targetUrl, {
         history: options.history,
@@ -1291,6 +1303,7 @@ const InnerRouter = ({
       }
     },
     [
+      committedRoute,
       refetch,
       mergeElements,
       emitRouteChangeEvent,
@@ -1306,7 +1319,7 @@ const InnerRouter = ({
         return;
       }
       const [path, query] = routeData as [string, string];
-      const currentRoute = routeRef.current;
+      const currentRoute = committedRoute();
       if (
         currentRoute.path === path &&
         (isStatic || currentRoute.query === query)
@@ -1323,7 +1336,7 @@ const InnerRouter = ({
         url: is404 ? new URL(window.location.href) : getRouteUrl(route),
       });
     },
-    [changeRoute],
+    [changeRoute, committedRoute],
   );
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
@@ -1367,7 +1380,7 @@ const InnerRouter = ({
       }
       startTransition(() => {
         changeRoute(nextRoute, {
-          shouldScroll: shouldScrollForRouteChange(nextRoute, routeRef.current),
+          shouldScroll: shouldScrollForRouteChange(nextRoute, committedRoute()),
           history: null, // the browser already moved the address bar
           // keep the url it moved to; an interceptor rewrite needs a new one
           url: isSameRoute(nextRoute, popped)
@@ -1384,7 +1397,7 @@ const InnerRouter = ({
     return () => {
       window.removeEventListener('popstate', callback);
     };
-  }, [changeRoute, routeInterceptor]);
+  }, [changeRoute, routeInterceptor, committedRoute]);
 
   const routeElement = routerState?.failed ? (
     <ThrowError error={routerState.error} />

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -798,10 +798,7 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOWS_PER_NAVIGATION = 20;
 
-const appliedByState = new WeakMap<
-  RouterState,
-  { href: string; pushed: boolean }
->();
+const appliedByState = new WeakMap<RouterState, { pushed: boolean }>();
 
 const isFollowable = (error: unknown) => {
   const info = getErrorInfo(error);
@@ -1122,12 +1119,17 @@ const InnerRouter = ({
   }, []);
 
   const routerState = getRouterState(elements);
-  const destination =
-    routerState &&
-    resolveServerRedirect(elements, routerState, initialRoute.path);
-  const currentRoute = destination
-    ? destination.route
-    : { ...initialRoute, hash: restoredHash };
+  const destination = useMemo(
+    () =>
+      routerState &&
+      resolveServerRedirect(elements, routerState, initialRoute.path),
+    [elements, routerState, initialRoute],
+  );
+  const currentRoute = useMemo(
+    () =>
+      destination ? destination.route : { ...initialRoute, hash: restoredHash },
+    [destination, initialRoute, restoredHash],
+  );
   const committedRoute = useCallback((): RouteProps => {
     const committed = resolvedElementsRef.current;
     const state = getRouterState(committed);
@@ -1148,9 +1150,6 @@ const InnerRouter = ({
     }
     const { url } = destination;
     const applied = appliedByState.get(routerState);
-    if (applied?.href === url.href) {
-      return;
-    }
     const wasPushed = applied?.pushed ?? false;
     // history null still writes: the state's url is the one that should show
     const pushed =
@@ -1158,7 +1157,7 @@ const InnerRouter = ({
         url,
         routerState.history === 'push' && !wasPushed ? 'push' : 'replace',
       ) || wasPushed;
-    appliedByState.set(routerState, { href: url.href, pushed });
+    appliedByState.set(routerState, { pushed });
     if (routerState.scroll && !applied && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
       scrollToRoute(
@@ -1167,7 +1166,7 @@ const InnerRouter = ({
         pathChanged,
       );
     }
-  });
+  }, [routerState, destination, currentRoute]);
 
   useEffect(() => {
     if (import.meta.hot) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1116,16 +1116,14 @@ const InnerRouter = ({
   const currentRoute = destination
     ? destination.route
     : { ...initialRoute, hash: restoredHash };
-  // a failed navigation leaves the route id alone, so this stays committed
   const committedRoute = useCallback((): RouteProps => {
     const committed = resolvedElementsRef.current;
     const route = getRouteFromElements(committed) ?? initialRoute;
     const state = getRouterState(committed);
-    // a failed state holds the url it tried, which is not where we are
-    const url = state?.failure ? undefined : state?.url;
+    const landedUrl = state?.failure ? undefined : state?.url;
     return {
       ...route,
-      hash: url ? new URL(url, window.location.href).hash : '',
+      hash: landedUrl ? new URL(landedUrl, window.location.href).hash : '',
     };
   }, [initialRoute]);
   useLayoutEffect(() => {
@@ -1193,11 +1191,10 @@ const InnerRouter = ({
 
   // FIXME this "fetchingSlices" hack feels suboptimal.
   const [fetchingSlices] = useState(() => new Set<SliceId>());
-  // it exists while a terminal event is owed; announced says start went out
   const pendingNavigationRef = useRef<{
     controller: AbortController;
     route: RouteProps;
-    announced: boolean;
+    startEmitted: boolean;
   } | null>(null);
 
   const changeRoute: ChangeRoute = useCallback(
@@ -1207,18 +1204,18 @@ const InnerRouter = ({
       const pending = {
         controller: new AbortController(),
         route: nextRoute,
-        announced: false,
+        startEmitted: false,
       };
       pendingNavigationRef.current = pending;
       const isAborted = () => pending.controller.signal.aborted;
-      if (superseded?.announced) {
+      if (superseded?.startEmitted) {
         emitRouteChangeEvent('error', superseded.route);
       }
       // a listener can navigate synchronously, which aborts this one
       if (isAborted()) {
         return;
       }
-      pending.announced = true;
+      pending.startEmitted = true;
       emitRouteChangeEvent('start', nextRoute);
       if (isAborted()) {
         return;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1069,38 +1069,43 @@ const InnerRouter = ({
     routeFromElements && routeFromElements.path !== fallbackRoute.path
       ? { ...routeFromElements, hash: fallbackRoute.hash }
       : fallbackRoute;
-  const [initialHash] = useState(() => resolvedRoute.hash);
+  const initialHashRef = useRef<string>(undefined);
+  initialHashRef.current ??= resolvedRoute.hash;
   const [initialRoute] = useState(() => ({ ...resolvedRoute, hash: '' }));
 
   const has404 = has404FromElements(elements);
-  const [staticPathSet] = useState(() => new Set<string>());
+  const staticPathSetRef = useRef<Set<string>>(undefined);
+  staticPathSetRef.current ??= new Set();
   // a record mid navigation pairs the new route id with the old static flag
   const learnStaticPath = useCallback(
     (responseElements: Record<string, unknown>) => {
       const route = getRouteFromElements(responseElements);
       if (route && isStaticFromElements(responseElements)) {
-        staticPathSet.add(route.path);
+        staticPathSetRef.current!.add(route.path);
       }
     },
-    [staticPathSet],
+    [],
   );
-  const [initialElements] = useState(() => elements);
+  const initialElementsRef = useRef<typeof elements>(undefined);
+  initialElementsRef.current ??= elements;
   useEffect(() => {
-    learnStaticPath(initialElements);
-  }, [initialElements, learnStaticPath]);
+    learnStaticPath(initialElementsRef.current!);
+  }, [learnStaticPath]);
   const resolvedElementsRef = useRef(elements);
   useLayoutEffect(() => {
     resolvedElementsRef.current = elements;
   }, [elements]);
-  const [prefetchManager] = useState(createPrefetchManager);
+  const prefetchManagerRef =
+    useRef<ReturnType<typeof createPrefetchManager>>(undefined);
+  prefetchManagerRef.current ??= createPrefetchManager();
 
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
   // starts empty so hydration matches the server, then the effect fills it
   const [restoredHash, setRestoredHash] = useState('');
   useEffect(() => {
-    setRestoredHash(window.location.hash || initialHash);
-  }, [initialHash]);
+    setRestoredHash(window.location.hash || initialHashRef.current!);
+  }, []);
 
   const routerState = getRouterState(elements);
   const destination =
@@ -1156,8 +1161,8 @@ const InnerRouter = ({
   useEffect(() => {
     if (import.meta.hot) {
       const refetchRouteOnHmr = () => {
-        prefetchManager.clear();
-        staticPathSet.clear();
+        prefetchManagerRef.current!.clear();
+        staticPathSetRef.current!.clear();
         const route = committedRoute();
         startTransition(() => {
           // the reload clears the set, so the response has to teach it again
@@ -1173,13 +1178,7 @@ const InnerRouter = ({
       );
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
     }
-  }, [
-    refetch,
-    prefetchManager,
-    staticPathSet,
-    learnStaticPath,
-    committedRoute,
-  ]);
+  }, [refetch, learnStaticPath, committedRoute]);
 
   const [[routeChangeEvents, emitRouteChangeEvent]] = useState(
     createRouteChangeListeners,
@@ -1228,7 +1227,7 @@ const InnerRouter = ({
       });
       const shouldRefetch =
         options.refetch ?? !isSameRscRoute(nextRoute, routeBefore);
-      if (staticPathSet.has(nextRoute.path) || !shouldRefetch) {
+      if (staticPathSetRef.current!.has(nextRoute.path) || !shouldRefetch) {
         mergeElements({
           [ROUTE_ID]: [nextRoute.path, nextRoute.query],
           [ROUTER_STATE_ID]: routerState,
@@ -1238,8 +1237,9 @@ const InnerRouter = ({
         return;
       }
       const rscPath = encodeRoutePath(nextRoute.path);
-      const cached = prefetchManager.get(rscPath, nextRoute.query);
-      const prefetchedElements = prefetchManager.getElements(rscPath);
+      const cached = prefetchManagerRef.current!.get(rscPath, nextRoute.query);
+      const prefetchedElements =
+        prefetchManagerRef.current!.getElements(rscPath);
       const instant =
         options.instant &&
         canCommitInstantly(
@@ -1312,9 +1312,7 @@ const InnerRouter = ({
       refetch,
       mergeElements,
       emitRouteChangeEvent,
-      staticPathSet,
       learnStaticPath,
-      prefetchManager,
     ],
   );
 
@@ -1356,25 +1354,22 @@ const InnerRouter = ({
     return registerCallServerElementsListener(listener);
   }, [applyChangeRouteData, learnStaticPath]);
 
-  const prefetchRoute: PrefetchRoute = useCallback(
-    (route, options) => {
-      preloadRouteModules(route.path);
-      if (staticPathSet.has(route.path)) {
-        return;
-      }
-      const rscPath = encodeRoutePath(route.path);
-      prefetchManager.prefetch(
-        rscPath,
-        route.query,
-        (base) =>
-          prefetchRsc(rscPath, createRscParams(route.query), {
-            ...(base ? { unstable_base: base } : {}),
-          }),
-        options,
-      );
-    },
-    [staticPathSet, prefetchManager],
-  );
+  const prefetchRoute: PrefetchRoute = useCallback((route, options) => {
+    preloadRouteModules(route.path);
+    if (staticPathSetRef.current!.has(route.path)) {
+      return;
+    }
+    const rscPath = encodeRoutePath(route.path);
+    prefetchManagerRef.current!.prefetch(
+      rscPath,
+      route.query,
+      (base) =>
+        prefetchRsc(rscPath, createRscParams(route.query), {
+          ...(base ? { unstable_base: base } : {}),
+        }),
+      options,
+    );
+  }, []);
 
   useEffect(() => {
     const callback = () => {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4048,6 +4048,51 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a server rewrite drops the attempted hash from the committed route', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
+      [ROUTE_ID]: ['/z', ''],
+      [IS_STATIC_ID]: false,
+    }));
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/z')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      elements,
+    );
+    try {
+      // asked for a hash, but the server answered with a different route
+      await act(async () => {
+        await capture.router!.push('/y#frag');
+        await flush();
+      });
+      expect(capture.router?.path).toBe('/z');
+      expect(window.location.hash).toBe('');
+      scrollToSpy.mockClear();
+
+      window.history.pushState({}, '', '/z');
+      await act(async () => {
+        window.dispatchEvent(new PopStateEvent('popstate'));
+        await flush();
+      });
+
+      // nothing moved, so the attempted '#frag' must not still count as committed
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    } finally {
+      scrollToSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('popstate that lands on another route moves the url with it', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -6250,8 +6250,12 @@ describe('Router integration', () => {
     expect(
       (view.container.textContent?.match(/found-page/g) ?? []).length,
     ).toBe(2);
-    // exactly one navigation per router, even under strict-mode replay
-    expect(getRefetchMock()).toHaveBeenCalledTimes(2);
+    // both fetched the 404 route; strict mode may replay the dispatch
+    expect(getRefetchMock()).toHaveBeenCalledWith(
+      unstable_encodeRoutePath('/404'),
+      expect.anything(),
+      expect.anything(),
+    );
 
     view.unmount();
   });
@@ -6292,7 +6296,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('custom 404 handling with a /404 page avoids strict-mode refetching race', async () => {
+  test('custom 404 handling with a /404 page recovers under strict mode', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const ThrowNotFoundErrorObject = createCustomError('not-found', {
@@ -6320,7 +6324,6 @@ describe('Router integration', () => {
 
     await flush();
     try {
-      expect(getRefetchMock()).toHaveBeenCalledTimes(1);
       expect(getRefetchMock()).toHaveBeenCalledWith(
         unstable_encodeRoutePath('/404'),
         expect.any(URLSearchParams),

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -5897,6 +5897,98 @@ describe('Router integration', () => {
     }
   });
 
+  test('a retry from a still mounted nav after a failure fetches again', async () => {
+    const capture = { router: null as RouterApi | null };
+    const navCapture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const NavProbe = makeProbe(navCapture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+    refetch.mockRejectedValueOnce(new Error('boom'));
+    installRefetch(refetch);
+
+    testHoisted.elements = {
+      root: (
+        <>
+          <NavProbe />
+          <ErrorBoundary>
+            <Children />
+          </ErrorBoundary>
+        </>
+      ),
+      [unstable_getRouteSlotId('/list')]: <Probe />,
+      [ROUTE_ID]: ['/list', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <Router initialRoute={{ path: '/list', query: '', hash: '' }} />
+      </Unstable_SearchCodecsProvider>,
+    );
+    try {
+      await act(async () => {
+        await navCapture.router!.push('/detail?id=5').catch(() => {});
+        await flush();
+      });
+      refetch.mockClear();
+
+      await act(async () => {
+        await navCapture.router!.push('/list?id=5').catch(() => {});
+        await flush();
+      });
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('an unrelated re-render does not scroll again', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({}));
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const bump = { fn: null as null | (() => void) };
+    const Bump = () => {
+      const [, setN] = useState(0);
+      bump.fn = () => setN((n) => n + 1);
+      return (
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      );
+    };
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/b')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const view = await renderApp(<Bump />);
+    try {
+      await act(async () => {
+        await capture.router!.push('/b');
+        await flush();
+      });
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      scrollToSpy.mockClear();
+      await act(async () => {
+        bump.fn!();
+        await flush();
+      });
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    } finally {
+      scrollToSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('a second 404 with a query lands on the 404 route again', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4442,6 +4442,54 @@ describe('Router integration', () => {
     }
   });
 
+  test('an instant nav whose response rewrites the route pushes once', async () => {
+    let land: (() => void) | undefined;
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(
+      () =>
+        new Promise((resolve) => {
+          land = () =>
+            resolve({
+              [ROUTE_ID]: ['/streamed', ''],
+              [IS_STATIC_ID]: false,
+            });
+        }),
+    );
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        ...instantNavElements(),
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/streamed')]: <Probe />,
+      },
+    );
+    const historyPushSpy = vi.spyOn(window.history, 'pushState');
+    try {
+      // commits the attempted url first, then the response moves the route
+      const pushed = capture.router!.push('/next', {
+        unstable_instant: true,
+      });
+      await act(async () => {
+        await flush();
+      });
+      await act(async () => {
+        land!();
+        await pushed;
+        await flush();
+      });
+
+      expect(capture.router?.path).toBe('/streamed');
+      // the second reconcile must replace the entry it already pushed
+      expect(historyPushSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      historyPushSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('changeRoute applies route rewrite from refetch result', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
       [ROUTE_ID]: ['/streamed', 'x=1'],

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3663,6 +3663,52 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('the prefetch cache survives an unrelated re-render', async () => {
+    const shell = {
+      [unstable_getRouteSlotId('/next')]: <div>next-shell</div>,
+      [ROUTE_ID]: ['/next', ''],
+      [IS_STATIC_ID]: false,
+    };
+    vi.mocked(prefetchRsc).mockReturnValue(resolvedThenable(shell));
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const bump = { fn: null as null | (() => void) };
+    const Bump = () => {
+      const [, setN] = useState(0);
+      bump.fn = () => setN((n) => n + 1);
+      return (
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      );
+    };
+    testHoisted.elements = {
+      ...instantNavElements(),
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+    };
+    const view = await renderApp(<Bump />);
+    try {
+      await act(async () => {
+        capture.router!.prefetch('/next', { mode: 'once' });
+        await flush();
+      });
+      await act(async () => {
+        bump.fn!();
+        await flush();
+      });
+      await act(async () => {
+        capture.router!.prefetch('/next?q=a', { mode: 'once' });
+        await flush();
+      });
+
+      // a per render manager would forget the first prefetch and fetch again
+      expect(prefetchRsc).toHaveBeenCalledTimes(1);
+    } finally {
+      view.unmount();
+    }
+  });
+
   test('a repeat prefetch claims the stored response as its base', async () => {
     const first = {
       [unstable_getRouteSlotId('/next')]: <div>next-shell</div>,
@@ -6295,12 +6341,13 @@ describe('Router integration', () => {
     expect(
       (view.container.textContent?.match(/found-page/g) ?? []).length,
     ).toBe(2);
-    // both fetched the 404 route; strict mode may replay the dispatch
     expect(getRefetchMock()).toHaveBeenCalledWith(
       unstable_encodeRoutePath('/404'),
       expect.anything(),
       expect.anything(),
     );
+    // one per router, doubled by the strict mode replay we accept
+    expect(getRefetchMock()).toHaveBeenCalledTimes(4);
 
     view.unmount();
   });
@@ -6369,6 +6416,8 @@ describe('Router integration', () => {
 
     await flush();
     try {
+      // doubled by the strict mode replay we accept, and no more than that
+      expect(getRefetchMock()).toHaveBeenCalledTimes(2);
       expect(getRefetchMock()).toHaveBeenCalledWith(
         unstable_encodeRoutePath('/404'),
         expect.any(URLSearchParams),

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -6483,6 +6483,50 @@ describe('Router integration', () => {
     }
   });
 
+  test('the strict mode replay reports a superseded follow', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const ThrowNotFoundErrorObject = createCustomError('not-found', {
+      status: 404,
+    });
+    const ThrowNotFound = () => {
+      throw ThrowNotFoundErrorObject;
+    };
+    const view = await renderRouterInStrictMode(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <ThrowNotFound />,
+        [unstable_getRouteSlotId('/404')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+        [HAS404_ID]: true,
+      },
+    );
+    await flush();
+    try {
+      const events: string[] = [];
+      for (const name of ['start', 'complete', 'error'] as const) {
+        capture.router!.unstable_events.on(name, (route) =>
+          events.push(`${name} ${route.path}`),
+        );
+      }
+      await act(async () => {
+        await capture.router!.push('/start').catch(() => {});
+        await flush();
+        await flush();
+      });
+
+      // the replayed dispatch supersedes the first, so listeners see an
+      // error for a follow that then succeeds. dev only, and bounded.
+      expect(
+        events.filter((e) => e.startsWith('error')).length,
+      ).toBeLessThanOrEqual(2);
+      expect(events[events.length - 1]).toBe('complete /404');
+    } finally {
+      view.unmount();
+    }
+  });
+
   test('redirect error triggers same-origin client navigation', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -36,12 +36,14 @@ describe('makeRouterState', () => {
         history: 'push',
         scroll: true,
         pathChanged: true,
+        followCount: 0,
       },
     );
     expect(routerState.url).toBe('/a?x=1#top');
     expect(routerState.attempted).toEqual(['/a', 'x=1']);
     expect(routerState.history).toBe('push');
     expect(routerState.scroll).toEqual({ pathChanged: true });
+    expect(routerState.followCount).toBe(0);
   });
 
   test('no scroll intent when scrolling is off', () => {
@@ -49,6 +51,7 @@ describe('makeRouterState', () => {
       history: 'replace',
       scroll: false,
       pathChanged: true,
+      followCount: 0,
     });
     expect(routerState.scroll).toBeNull();
   });
@@ -60,6 +63,7 @@ describe('getRouterState', () => {
       history: 'push',
       scroll: false,
       pathChanged: false,
+      followCount: 0,
     });
     expect(getRouterState(withRouterState({}, routerState))).toBe(routerState);
     expect(getRouterState({})).toBeUndefined();
@@ -72,6 +76,7 @@ describe('resolveServerRedirect', () => {
       history: 'push',
       scroll: true,
       pathChanged: true,
+      followCount: 0,
     });
     const elements = { [ROUTE_ID]: ['/a', ''] };
 
@@ -82,7 +87,7 @@ describe('resolveServerRedirect', () => {
     expect(
       resolveServerRedirect(
         elements,
-        { ...attempt, failure: { error: new Error('x') } },
+        { ...attempt, failure: { error: new Error('x'), committedHash: '' } },
         '/f',
       ).url.pathname,
     ).toBe('/missing');
@@ -96,6 +101,7 @@ describe('resolveServerRedirect', () => {
         history: 'replace',
         scroll: false,
         pathChanged: false,
+        followCount: 0,
       },
     );
     const elements = { [ROUTE_ID]: ['/a', 'x=1'] };
@@ -113,6 +119,7 @@ describe('resolveServerRedirect', () => {
       history: 'replace',
       scroll: false,
       pathChanged: false,
+      followCount: 0,
     });
     const elements = { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true };
     const { route: resolvedRoute, url } = resolveServerRedirect(
@@ -129,6 +136,7 @@ describe('resolveServerRedirect', () => {
       history: 'push',
       scroll: false,
       pathChanged: true,
+      followCount: 0,
     });
     const elements = { [ROUTE_ID]: ['/b', 'y=2'] };
     const { route: resolvedRoute, url } = resolveServerRedirect(
@@ -148,6 +156,7 @@ describe('resolveServerRedirect', () => {
         history: 'replace',
         scroll: false,
         pathChanged: false,
+        followCount: 0,
       });
       const elements = { [ROUTE_ID]: ['/b', ''] };
       const { url } = resolveServerRedirect(elements, routerState, '/f');
@@ -162,6 +171,7 @@ describe('resolveServerRedirect', () => {
       history: 'replace',
       scroll: false,
       pathChanged: true,
+      followCount: 0,
     });
     const elements = { [ROUTE_ID]: ['/404', ''] };
     const { route: resolvedRoute, url } = resolveServerRedirect(

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -80,8 +80,11 @@ describe('resolveServerRedirect', () => {
       '/a',
     );
     expect(
-      resolveServerRedirect(elements, { ...attempt, failed: true }, '/f').url
-        .pathname,
+      resolveServerRedirect(
+        elements,
+        { ...attempt, failure: { error: new Error('x') } },
+        '/f',
+      ).url.pathname,
     ).toBe('/missing');
   });
 


### PR DESCRIPTION
`router/client.tsx` kept navigation bookkeeping in a dozen refs beside the state it described. Most of it now lives in `RouterState`, which already travels in the elements record under a client-only symbol: the fetch error, the reconcile marker, the follow count, the committed route, and the abort and announce pair.
  
`followingRef` is gone. It suppressed Strict Mode's replay, which is dev only and made dev differ from production.

Also fixes a scroll bug: after the server answered with a different route, the committed route kept the attempted fragment, so every Back to that path scrolled to the top.
  
`RouterState` gains `failure` and `followCount` and loses `failed` and `error`. Internal, but reachable through `unstable_RouterContext`.
