### PR TITLE
refactor(router): reconcile a navigation once

### DIFF
--- a/packages/waku/src/router/client-utils/error-route.ts
+++ b/packages/waku/src/router/client-utils/error-route.ts
@@ -11,6 +11,11 @@ export type ErrorRoute =
   | { type: 'unfollowable'; location: string }
   | { type: 'none' };
 
+export const isFollowable = (error: unknown) => {
+  const info = getErrorInfo(error);
+  return info?.status === 404 || !!info?.location;
+};
+
 export const resolveErrorRoute = (
   error: unknown,
   attemptedUrl: URL,

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -76,6 +76,28 @@ export const resolveServerRedirect = (
   };
 };
 
+/**
+ * The route that actually landed, which a navigation measures itself against.
+ * A failed one keeps the hash that is still on screen, unlike the route the
+ * router paints, which takes its hash from the attempted url.
+ */
+export const getSettledRoute = (
+  elements: Record<string | symbol, unknown>,
+  fallback: RouteProps,
+): RouteProps => {
+  const routerState = getRouterState(elements);
+  if (!routerState) {
+    return fallback;
+  }
+  if (routerState.failure) {
+    return {
+      ...(getRouteFromElements(elements) ?? fallback),
+      hash: routerState.failure.committedHash,
+    };
+  }
+  return resolveServerRedirect(elements, routerState, fallback.path).route;
+};
+
 export const canCommitInstantly = (
   routeSlotId: string,
   resolvedElements: Record<string, unknown>,

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -14,7 +14,6 @@ export const ROUTER_STATE_ID = Symbol('waku-router-state');
 export type RouterState = {
   readonly url: string; // pathname + search + hash, with the base path
   readonly attempted: readonly [path: string, query: string];
-  // null leaves history alone: the browser already wrote it
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
   readonly followCount: number;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -61,6 +61,7 @@ import {
   ROUTER_STATE_ID,
   canCommitInstantly,
   getRouterState,
+  getSettledRoute,
   makeRouterState,
   pinForSwr,
   resolveServerRedirect,
@@ -799,12 +800,12 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOWS_PER_NAVIGATION = 20;
 
-const appliedStates = new WeakSet<RouterState>();
-
 const isFollowable = (error: unknown) => {
   const info = getErrorInfo(error);
   return info?.status === 404 || !!info?.location;
 };
+
+const appliedStates = new WeakSet<RouterState>();
 
 const FollowError = ({
   error,
@@ -1131,20 +1132,14 @@ const InnerRouter = ({
       destination ? destination.route : { ...initialRoute, hash: restoredHash },
     [destination, initialRoute, restoredHash],
   );
-  const committedRoute = useCallback((): RouteProps => {
-    const committed = resolvedElementsRef.current;
-    const state = getRouterState(committed);
-    if (!state) {
-      return { ...initialRoute, hash: restoredHash };
-    }
-    if (state.failure) {
-      return {
-        ...(getRouteFromElements(committed) ?? initialRoute),
-        hash: state.failure.committedHash,
-      };
-    }
-    return resolveServerRedirect(committed, state, initialRoute.path).route;
-  }, [initialRoute, restoredHash]);
+  const committedRoute = useCallback(
+    (): RouteProps =>
+      getSettledRoute(resolvedElementsRef.current, {
+        ...initialRoute,
+        hash: restoredHash,
+      }),
+    [initialRoute, restoredHash],
+  );
   const destinationHref = destination?.url.href;
   const currentHash = currentRoute.hash;
   useLayoutEffect(() => {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1142,12 +1142,12 @@ const InnerRouter = ({
       return;
     }
     const applied = appliedStates.has(routerState);
-    appliedStates.add(routerState);
     // history null still writes: the state's url is the one that should show
     commitHistory(
       new URL(destinationHref),
       applied ? 'replace' : routerState.history,
     );
+    appliedStates.add(routerState);
     if (routerState.scroll && !applied && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
       scrollToHash(currentHash, pathChanged ? 'instant' : 'auto', pathChanged);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -142,17 +142,15 @@ const parseRouteFromLocation = (): RouteProps => {
   return parseRoute(new URL(window.location.href));
 };
 
-// returns whether it pushed, so a second pass can downgrade to replace
-const commitHistory = (url: URL, mode: 'push' | 'replace' | null): boolean => {
+const commitHistory = (url: URL, mode: 'push' | 'replace' | null): void => {
   if (window.location.href === url.href) {
-    return false;
+    return;
   }
   if (mode === 'push') {
     window.history.pushState(window.history.state, '', url);
-    return true;
+  } else {
+    window.history.replaceState(window.history.state, '', url);
   }
-  window.history.replaceState(window.history.state, '', url);
-  return false;
 };
 
 const reloadWithUrl = (url: URL) => {
@@ -704,7 +702,7 @@ export function Link<Path extends RoutePath>({
         startTransitionFn,
       ).catch(() => {});
     } else if (url.hash && scroll !== false) {
-      scrollToRoute(parseRoute(url), 'auto', false);
+      scrollToHash(url.hash, 'auto', false);
     }
   };
   const onClick = (event: MouseEvent<HTMLAnchorElement>) => {
@@ -801,7 +799,7 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOWS_PER_NAVIGATION = 20;
 
-const appliedByState = new WeakMap<RouterState, { pushed: boolean }>();
+const appliedStates = new WeakSet<RouterState>();
 
 const isFollowable = (error: unknown) => {
   const info = getErrorInfo(error);
@@ -1031,13 +1029,13 @@ const getHashElement = (hash: string): HTMLElement | null => {
   }
 };
 
-const scrollToRoute = (
-  route: RouteProps,
+const scrollToHash = (
+  hash: string,
   behavior: ScrollBehavior,
   scrollTopForMissingHash: boolean,
 ) => {
-  if (route.hash) {
-    const element = getHashElement(route.hash);
+  if (hash) {
+    const element = getHashElement(hash);
     if (!element) {
       if (!scrollTopForMissingHash) {
         return;
@@ -1147,29 +1145,24 @@ const InnerRouter = ({
     }
     return resolveServerRedirect(committed, state, initialRoute.path).route;
   }, [initialRoute, restoredHash]);
+  const destinationHref = destination?.url.href;
+  const currentHash = currentRoute.hash;
   useLayoutEffect(() => {
-    if (!routerState || !destination) {
+    if (!routerState || !destinationHref) {
       return;
     }
-    const { url } = destination;
-    const applied = appliedByState.get(routerState);
-    const wasPushed = applied?.pushed ?? false;
+    const applied = appliedStates.has(routerState);
+    appliedStates.add(routerState);
     // history null still writes: the state's url is the one that should show
-    const pushed =
-      commitHistory(
-        url,
-        routerState.history === 'push' && !wasPushed ? 'push' : 'replace',
-      ) || wasPushed;
-    appliedByState.set(routerState, { pushed });
+    commitHistory(
+      new URL(destinationHref),
+      applied ? 'replace' : routerState.history,
+    );
     if (routerState.scroll && !applied && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
-      scrollToRoute(
-        currentRoute,
-        pathChanged ? 'instant' : 'auto',
-        pathChanged,
-      );
+      scrollToHash(currentHash, pathChanged ? 'instant' : 'auto', pathChanged);
     }
-  }, [routerState, destination, currentRoute]);
+  }, [routerState, destinationHref, currentHash]);
 
   useEffect(() => {
     if (import.meta.hot) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -800,8 +800,6 @@ export class ErrorBoundary extends Component<
 
 const MAX_FOLLOWS_PER_NAVIGATION = 20;
 
-const appliedStates = new WeakSet<RouterState>();
-
 const FollowError = ({
   error,
   has404,
@@ -1135,19 +1133,20 @@ const InnerRouter = ({
       }),
     [initialRoute, restoredHash],
   );
+  const appliedRef = useRef<RouterState>(undefined);
   const destinationHref = destination?.url.href;
   const currentHash = currentRoute.hash;
   useLayoutEffect(() => {
     if (!routerState || !destinationHref) {
       return;
     }
-    const applied = appliedStates.has(routerState);
+    const applied = appliedRef.current === routerState;
     // history null still writes: the state's url is the one that should show
     commitHistory(
       new URL(destinationHref),
       applied ? 'replace' : routerState.history,
     );
-    appliedStates.add(routerState);
+    appliedRef.current = routerState;
     if (routerState.scroll && !applied && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
       scrollToHash(currentHash, pathChanged ? 'instant' : 'auto', pathChanged);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -45,7 +45,7 @@ import {
   has404FromElements,
   isStaticFromElements,
 } from './client-utils/elements-meta.js';
-import { resolveErrorRoute } from './client-utils/error-route.js';
+import { isFollowable, resolveErrorRoute } from './client-utils/error-route.js';
 import {
   type PrefetchOptions,
   createPrefetchManager,
@@ -799,11 +799,6 @@ export class ErrorBoundary extends Component<
 }
 
 const MAX_FOLLOWS_PER_NAVIGATION = 20;
-
-const isFollowable = (error: unknown) => {
-  const info = getErrorInfo(error);
-  return info?.status === 404 || !!info?.location;
-};
 
 const appliedStates = new WeakSet<RouterState>();
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4596,6 +4596,53 @@ describe('Router integration', () => {
     }
   });
 
+  test('an instant nav scrolls once, not again when the response lands', async () => {
+    let land: (() => void) | undefined;
+    const refetch = vi.fn<ReturnType<typeof useRefetch>>(
+      () =>
+        new Promise((resolve) => {
+          land = () =>
+            resolve({
+              [ROUTE_ID]: ['/next', ''],
+              [IS_STATIC_ID]: false,
+            });
+        }),
+    );
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        ...instantNavElements(),
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+      },
+    );
+    try {
+      const pushed = capture.router!.push('/next', {
+        unstable_instant: true,
+      });
+      await act(async () => {
+        await flush();
+      });
+      await act(async () => {
+        land!();
+        await pushed;
+        await flush();
+      });
+
+      // the shell commit scrolls; the response landing must not scroll again
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      scrollToSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('an instant nav whose response rewrites the route pushes once', async () => {
     let land: (() => void) | undefined;
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(
@@ -6235,6 +6282,60 @@ describe('Router integration', () => {
       expect(refetch).toHaveBeenCalledTimes(1);
     } finally {
       consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('an unrelated element merge does not scroll or push again', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const grab = { refetch: null as null | ReturnType<typeof useRefetch> };
+    const Grabber = () => {
+      grab.refetch = useRefetch();
+      return null;
+    };
+    const refetch = vi.fn<RefetchInner>(async () => ({}));
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: (
+          <>
+            <Probe />
+            <Grabber />
+          </>
+        ),
+        [unstable_getRouteSlotId('/b')]: (
+          <>
+            <Probe />
+            <Grabber />
+          </>
+        ),
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/b');
+        await flush();
+      });
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      expect(pushSpy).toHaveBeenCalledTimes(1);
+      refetch.mockResolvedValueOnce({ 'sidebar:/': <div>fresh</div> });
+      await act(async () => {
+        await grab.refetch!('sidebar');
+        await flush();
+      });
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      expect(pushSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      scrollToSpy.mockRestore();
+      pushSpy.mockRestore();
       view.unmount();
     }
   });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -4668,6 +4668,7 @@ describe('Router integration', () => {
       },
     );
     const historyPushSpy = vi.spyOn(window.history, 'pushState');
+    const historyReplaceSpy = vi.spyOn(window.history, 'replaceState');
     try {
       // commits the attempted url first, then the response moves the route
       const pushed = capture.router!.push('/next', {
@@ -4683,9 +4684,14 @@ describe('Router integration', () => {
       });
 
       expect(capture.router?.path).toBe('/streamed');
+      expect(window.location.pathname).toBe('/streamed');
       // the second reconcile must replace the entry it already pushed
       expect(historyPushSpy).toHaveBeenCalledTimes(1);
+      expect(String(historyReplaceSpy.mock.lastCall?.[2])).toContain(
+        '/streamed',
+      );
     } finally {
+      historyReplaceSpy.mockRestore();
       historyPushSpy.mockRestore();
       view.unmount();
     }
@@ -6395,6 +6401,8 @@ describe('Router integration', () => {
       });
       expect(scrollToSpy).toHaveBeenCalledTimes(1);
       expect(pushSpy).toHaveBeenCalledTimes(1);
+      // this merge suspends the root, so the router remounts and the layout
+      // effect runs again for the same state. a ref could not remember that.
       refetch.mockResolvedValueOnce({ 'sidebar:/': <div>fresh</div> });
       await act(async () => {
         await grab.refetch!('sidebar');

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -6286,6 +6286,75 @@ describe('Router integration', () => {
     }
   });
 
+  test('an instant retry already at its url replaces the entry a failure wrote', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    let land: (() => void) | undefined;
+    const refetch = vi.fn<RefetchInner>();
+    refetch.mockRejectedValueOnce(createCustomError('nf', { status: 404 }));
+    refetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          land = () =>
+            resolve({
+              [ROUTE_ID]: ['/other', ''],
+              [IS_STATIC_ID]: false,
+            });
+        }),
+    );
+    installRefetch(refetch);
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    const replaceSpy = vi.spyOn(window.history, 'replaceState');
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const nextSlotId = unstable_getRouteSlotId('/next');
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [nextSlotId]: <div>next</div>,
+        [unstable_getRouteSlotId('/other')]: <div>other</div>,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+        [`${ETAG_ID_PREFIX}${nextSlotId}`]: IMMUTABLE_ETAG,
+        [HAS404_ID]: false,
+      },
+    );
+    try {
+      // the failure writes /next itself, and with no 404 route to follow to
+      // the router stays mounted, so the retry starts already at its url
+      await act(async () => {
+        await expect(capture.router!.push('/next')).rejects.toBeTruthy();
+        await flush();
+      });
+      expect(window.location.pathname).toBe('/next');
+      pushSpy.mockClear();
+      replaceSpy.mockClear();
+
+      const retried = capture.router!.push('/next', {
+        unstable_instant: true,
+        scroll: false,
+      });
+      await act(async () => {
+        await flush();
+      });
+      await act(async () => {
+        land!();
+        await retried;
+        await flush();
+      });
+      expect(window.location.pathname).toBe('/other');
+      expect(pushSpy).not.toHaveBeenCalled();
+      expect(replaceSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      pushSpy.mockRestore();
+      replaceSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('an unrelated element merge does not scroll or push again', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -6401,8 +6401,8 @@ describe('Router integration', () => {
       });
       expect(scrollToSpy).toHaveBeenCalledTimes(1);
       expect(pushSpy).toHaveBeenCalledTimes(1);
-      // this merge suspends the root, so the router remounts and the layout
-      // effect runs again for the same state. a ref could not remember that.
+      // this merge suspends the root, so React replays the layout effect for
+      // a state it has already applied
       refetch.mockResolvedValueOnce({ 'sidebar:/': <div>fresh</div> });
       await act(async () => {
         await grab.refetch!('sidebar');

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -5,6 +5,7 @@ import {
   ROUTER_STATE_ID,
   canCommitInstantly,
   getRouterState,
+  getSettledRoute,
   makeRouterState,
   pinForSwr,
   resolveServerRedirect,
@@ -181,6 +182,71 @@ describe('resolveServerRedirect', () => {
     );
     expect(resolvedRoute.path).toBe('/404');
     expect(url.pathname).toBe('/missing');
+  });
+});
+
+describe('getSettledRoute', () => {
+  const fallback = route('/f', '', '#restored');
+
+  test('the fallback until a navigation has landed', () => {
+    expect(getSettledRoute({}, fallback)).toEqual(fallback);
+  });
+
+  test('a failed navigation keeps the hash that is still on screen', () => {
+    const routerState = makeRouterState(route('/b'), urlOf('/b#target'), {
+      history: 'push',
+      scroll: true,
+      pathChanged: true,
+      followCount: 0,
+    });
+    const elements = withRouterState(
+      { [ROUTE_ID]: ['/a', 'x=1'] },
+      {
+        ...routerState,
+        failure: { error: new Error('x'), committedHash: '#onscreen' },
+      },
+    );
+    // the route id is the one the client came from, not the failed attempt
+    expect(getSettledRoute(elements, fallback)).toEqual({
+      path: '/a',
+      query: 'x=1',
+      hash: '#onscreen',
+    });
+  });
+
+  test('a failure with no route id falls back, still with the on screen hash', () => {
+    const routerState = makeRouterState(route('/b'), urlOf('/b'), {
+      history: 'push',
+      scroll: false,
+      pathChanged: true,
+      followCount: 0,
+    });
+    const elements = withRouterState(
+      {},
+      {
+        ...routerState,
+        failure: { error: new Error('x'), committedHash: '' },
+      },
+    );
+    expect(getSettledRoute(elements, fallback)).toEqual({
+      path: '/f',
+      query: '',
+      hash: '',
+    });
+  });
+
+  test('a landed navigation resolves the server redirect', () => {
+    const routerState = makeRouterState(route('/a'), urlOf('/a#top'), {
+      history: 'push',
+      scroll: true,
+      pathChanged: true,
+      followCount: 0,
+    });
+    const elements = withRouterState(
+      { [ROUTE_ID]: ['/b', 'y=2'] },
+      routerState,
+    );
+    expect(getSettledRoute(elements, fallback)).toEqual(route('/b', 'y=2'));
   });
 });
 


### PR DESCRIPTION
The reconcile effect re-ran for navigations it had already applied, so it kept a WeakMap of what it did. It now takes plain values and remembers the last state it applied in a ref.

Also moves the settled route into router-state, where it finally gets unit tests, and isFollowable next to resolveErrorRoute.

One behavior change: an instant retry that is already at its url replaces the entry a failed attempt wrote, instead of pushing a new one.
