### PR TITLE
fix(router): aim at a hash target that arrives after the paint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 /packages/website/.vercel
 /packages/create-waku/templates
 .env.local
+/*.local.md
 .devcontainer
 .vscode
 *.tsbuildinfo

--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -175,7 +175,7 @@ When the shell is cached, the layout and the `Loading...` fallback appear with n
 
 The `<Suspense>` boundary decides how localized the loading state is. Wrapping the whole page area (as above) swaps the page for a skeleton; wrapping only a dynamic slice inside an otherwise-static page leaves the rest in place and shows the skeleton for just that slice.
 
-Because an instant navigation commits before the server responds, it reconciles afterward: a server redirect updates the URL to the redirect target, while a not-found (404) response keeps the attempted URL, so the 404 page shows at the address the user tried.
+Because an instant navigation commits before the server responds, it reconciles afterward: a server redirect updates the URL to the redirect target, while a not-found (404) response keeps the requested URL, so the 404 page shows at the address the user tried.
 
 Instant navigation commits urgently rather than inside a React transition, since a transition would suppress the immediate skeleton. A custom `unstable_startTransition` therefore does not run for instant links, and `useNavigationStatus_UNSTABLE()` does not report `pending` for them. An instant navigation paints its cached shell immediately, so the shell itself is the pending state.
 

--- a/packages/waku/src/router/client-utils/error-route.ts
+++ b/packages/waku/src/router/client-utils/error-route.ts
@@ -18,12 +18,12 @@ export const isFollowable = (error: unknown) => {
 
 export const resolveErrorRoute = (
   error: unknown,
-  attemptedUrl: URL,
+  requestedUrl: URL,
   has404: boolean,
 ): ErrorRoute => {
   const info = getErrorInfo(error);
   if (info?.location) {
-    const parsed = parseRedirectUrl(info.location, attemptedUrl);
+    const parsed = parseRedirectUrl(info.location, requestedUrl);
     if (!parsed) {
       return { type: 'unfollowable', location: info.location };
     }
@@ -43,10 +43,10 @@ export const resolveErrorRoute = (
   if (info?.status === 404 && has404) {
     const target = {
       path: '/404',
-      query: attemptedUrl.searchParams.toString(),
+      query: requestedUrl.searchParams.toString(),
       hash: '',
     };
-    return { type: 'route', target, url: attemptedUrl };
+    return { type: 'route', target, url: requestedUrl };
   }
   return { type: 'none' };
 };

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -46,14 +46,12 @@ export const makeRouterState = (
   followCount: options.followCount,
 });
 
-// a redirect to the 404 route keeps the url that was requested
 export const resolveServerRedirect = (
   elements: Record<string | symbol, unknown>,
   routerState: RouterState,
   fallbackPath: string,
 ): { route: RouteProps; url: URL } => {
   const stateUrl = new URL(routerState.url, window.location.href);
-  // nothing landed on a failed navigation, so there is no redirect to read
   const redirect = routerState.failure
     ? undefined
     : getServerRedirect(elements, {
@@ -76,8 +74,7 @@ export const resolveServerRedirect = (
 };
 
 /**
- * The route that actually landed, which a navigation measures itself against.
- * A failed one keeps the hash that is still on screen, unlike the route the
+ * A failed navigation keeps the hash still on screen, unlike the route the
  * router paints, which takes its hash from the requested url.
  */
 export const getSettledRoute = (

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -13,7 +13,7 @@ export const ROUTER_STATE_ID = Symbol('waku-router-state');
 // merges carry this object by reference; the reconciler keys off its identity
 export type RouterState = {
   readonly url: string; // pathname + search + hash, with the base path
-  readonly attempted: readonly [path: string, query: string];
+  readonly requested: readonly [path: string, query: string];
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
   readonly followCount: number;
@@ -40,13 +40,13 @@ export const makeRouterState = (
   },
 ): RouterState => ({
   url: url.pathname + url.search + url.hash,
-  attempted: [route.path, route.query],
+  requested: [route.path, route.query],
   history: options.history,
   scroll: options.scroll ? { pathChanged: options.pathChanged } : null,
   followCount: options.followCount,
 });
 
-// a redirect to the 404 route keeps the url that was attempted
+// a redirect to the 404 route keeps the url that was requested
 export const resolveServerRedirect = (
   elements: Record<string | symbol, unknown>,
   routerState: RouterState,
@@ -57,8 +57,8 @@ export const resolveServerRedirect = (
   const redirect = routerState.failure
     ? undefined
     : getServerRedirect(elements, {
-        path: routerState.attempted[0],
-        query: routerState.attempted[1],
+        path: routerState.requested[0],
+        query: routerState.requested[1],
         hash: '',
       });
   if (redirect && redirect.path !== '/404') {
@@ -78,7 +78,7 @@ export const resolveServerRedirect = (
 /**
  * The route that actually landed, which a navigation measures itself against.
  * A failed one keeps the hash that is still on screen, unlike the route the
- * router paints, which takes its hash from the attempted url.
+ * router paints, which takes its hash from the requested url.
  */
 export const getSettledRoute = (
   elements: Record<string | symbol, unknown>,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1008,13 +1008,16 @@ export function Slice({
   return <Slot id={slotId}>{children}</Slot>;
 }
 
-const decodeHash = (raw: string) => {
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    return raw;
-  }
-};
+// percent decoding leaves a malformed escape alone instead of giving up on the
+// whole fragment, and a run decodes together so multi byte characters survive
+const decodeHash = (raw: string) =>
+  raw.replace(/(?:%[0-9A-Fa-f]{2})+/g, (escapes) => {
+    try {
+      return decodeURIComponent(escapes);
+    } catch {
+      return escapes;
+    }
+  });
 
 const getHashElement = (hash: string): HTMLElement | null => {
   const raw = hash.slice(1);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1153,14 +1153,17 @@ const InnerRouter = ({
       applied ? 'replace' : routerState.history,
     );
     appliedRef.current = routerState;
-    if (routerState.scroll && !applied && !routerState.failure) {
+    if (applied) {
+      return;
+    }
+    awaitedHashRef.current = null;
+    if (routerState.scroll && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
       const behavior = pathChanged ? 'instant' : 'auto';
       scrollToHash(currentHash, behavior, pathChanged);
-      awaitedHashRef.current =
-        currentHash && !getHashElement(currentHash)
-          ? { hash: currentHash, behavior }
-          : null;
+      if (currentHash && !getHashElement(currentHash)) {
+        awaitedHashRef.current = { hash: currentHash, behavior };
+      }
     }
   }, [routerState, destinationHref, currentHash]);
 

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -150,7 +150,7 @@ const commitHistory = (url: URL, mode: 'push' | 'replace' | null): void => {
     window.history.pushState(window.history.state, '', url);
     return;
   }
-  // 'replace' and null both write: null means the url should still show
+  // null still writes: the state url is the one that should show
   window.history.replaceState(window.history.state, '', url);
 };
 
@@ -1165,7 +1165,7 @@ const InnerRouter = ({
     [elements, routerState, initialRoute],
   );
   const currentRoute = destination ? destination.route : routeFallback;
-  // only the current state is reconciled; a single slot is enough to skip repeats
+  // only the current state is reconciled, so one slot is enough
   const appliedRef = useRef<RouterState>(undefined);
   const settledRoute = useCallback(
     (): RouteProps =>

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1020,7 +1020,8 @@ const decodeHash = (raw: string) =>
 
 const getHashElement = (hash: string): HTMLElement | null => {
   const raw = hash.slice(1);
-  for (const name of new Set([raw, decodeHash(raw)])) {
+  const decoded = decodeHash(raw);
+  for (const name of new Set([raw, decoded])) {
     const byId = document.getElementById(name);
     if (byId) {
       return byId;
@@ -1032,9 +1033,7 @@ const getHashElement = (hash: string): HTMLElement | null => {
       }
     }
   }
-  return decodeHash(raw).toLowerCase() === 'top'
-    ? document.documentElement
-    : null;
+  return decoded.toLowerCase() === 'top' ? document.documentElement : null;
 };
 
 // a slot can resolve without re-rendering the router, so watch the dom
@@ -1167,7 +1166,7 @@ const InnerRouter = ({
   const currentRoute = destination ? destination.route : routeFallback;
   // only the current state is reconciled, so one slot is enough
   const appliedRef = useRef<RouterState>(undefined);
-  const settledRoute = useCallback(
+  const readSettledRoute = useCallback(
     (): RouteProps =>
       getSettledRoute(resolvedElementsRef.current, routeFallback),
     [routeFallback],
@@ -1191,16 +1190,14 @@ const InnerRouter = ({
       awaitedHashRef.current?.stop();
       awaitedHashRef.current = null;
     }
-    if (applied) {
+    if (applied || !routerState.scroll || routerState.failure) {
       return;
     }
-    if (routerState.scroll && !routerState.failure) {
-      const { pathChanged } = routerState.scroll;
-      const behavior = pathChanged ? 'instant' : 'auto';
-      scrollToHash(currentHash, behavior, pathChanged);
-      if (currentHash && !getHashElement(currentHash)) {
-        awaitedHashRef.current = awaitHashElement(currentHash, behavior);
-      }
+    const { pathChanged } = routerState.scroll;
+    const behavior = pathChanged ? 'instant' : 'auto';
+    scrollToHash(currentHash, behavior, pathChanged);
+    if (currentHash && !getHashElement(currentHash)) {
+      awaitedHashRef.current = awaitHashElement(currentHash, behavior);
     }
   }, [routerState, destinationHref, currentHash]);
 
@@ -1211,12 +1208,12 @@ const InnerRouter = ({
       const refetchRouteOnHmr = () => {
         prefetchManagerRef.current!.clear();
         staticPathSetRef.current!.clear();
-        const route = settledRoute();
+        const settledRoute = readSettledRoute();
         startTransition(() => {
           // the reload clears the set, so the response has to teach it again
           void refetch(
-            encodeRoutePath(route.path),
-            createRscParams(route.query),
+            encodeRoutePath(settledRoute.path),
+            createRscParams(settledRoute.query),
           ).then(learnStaticPath, () => {});
         });
       };
@@ -1226,7 +1223,7 @@ const InnerRouter = ({
       );
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
     }
-  }, [refetch, learnStaticPath, settledRoute]);
+  }, [refetch, learnStaticPath, readSettledRoute]);
 
   const [[routeChangeEvents, emitRouteChangeEvent]] = useState(
     createRouteChangeListeners,
@@ -1264,18 +1261,18 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      const routeBefore = settledRoute();
+      const settledRoute = readSettledRoute();
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
       const routerState = makeRouterState(nextRoute, targetUrl, {
         history: options.history,
         scroll: options.shouldScroll,
-        pathChanged: nextRoute.path !== routeBefore.path,
+        pathChanged: nextRoute.path !== settledRoute.path,
         followCount: options.isFollow
           ? (getRouterState(resolvedElementsRef.current)?.followCount ?? 0) + 1
           : 0,
       });
       const shouldRefetch =
-        options.refetch ?? !isSameRscRoute(nextRoute, routeBefore);
+        options.refetch ?? !isSameRscRoute(nextRoute, settledRoute);
       if (staticPathSetRef.current!.has(nextRoute.path) || !shouldRefetch) {
         mergeElements({
           [ROUTE_ID]: [nextRoute.path, nextRoute.query],
@@ -1343,7 +1340,7 @@ const InnerRouter = ({
           [ROUTER_STATE_ID]: {
             ...routerState,
             history: null, // the url above is already written
-            failure: { error: e, committedHash: routeBefore.hash },
+            failure: { error: e, committedHash: settledRoute.hash },
           },
         });
         emitRouteChangeEvent('error', nextRoute);
@@ -1351,7 +1348,7 @@ const InnerRouter = ({
       }
     },
     [
-      settledRoute,
+      readSettledRoute,
       refetch,
       mergeElements,
       emitRouteChangeEvent,
@@ -1365,8 +1362,11 @@ const InnerRouter = ({
         return;
       }
       const [path, query] = routeData as [string, string];
-      const settled = settledRoute();
-      if (settled.path === path && (isStatic || settled.query === query)) {
+      const settledRoute = readSettledRoute();
+      if (
+        settledRoute.path === path &&
+        (isStatic || settledRoute.query === query)
+      ) {
         return;
       }
       const route = { path, query, hash: '' };
@@ -1379,7 +1379,7 @@ const InnerRouter = ({
         url: is404 ? new URL(window.location.href) : getRouteUrl(route),
       });
     },
-    [changeRoute, settledRoute],
+    [changeRoute, readSettledRoute],
   );
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
@@ -1420,7 +1420,10 @@ const InnerRouter = ({
       }
       startTransition(() => {
         changeRoute(nextRoute, {
-          shouldScroll: shouldScrollForRouteChange(nextRoute, settledRoute()),
+          shouldScroll: shouldScrollForRouteChange(
+            nextRoute,
+            readSettledRoute(),
+          ),
           history: null, // the browser already moved the address bar
           // keep the url it moved to; an interceptor rewrite needs a new one
           url: isSameRoute(nextRoute, popped)
@@ -1437,7 +1440,7 @@ const InnerRouter = ({
     return () => {
       window.removeEventListener('popstate', callback);
     };
-  }, [changeRoute, routeInterceptor, settledRoute]);
+  }, [changeRoute, routeInterceptor, readSettledRoute]);
 
   const routeElement = routerState?.failure ? (
     <ThrowError error={routerState.failure.error} />

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -380,11 +380,9 @@ export function useRouter() {
     });
   }, [changeRoute]);
   const back = useCallback(() => {
-    // FIXME is this correct?
     window.history.back();
   }, []);
   const forward = useCallback(() => {
-    // FIXME is this correct?
     window.history.forward();
   }, []);
   const prefetch = useCallback(

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1037,7 +1037,7 @@ const getHashElement = (hash: string): HTMLElement | null => {
 };
 
 // a slot can resolve without re-rendering the router, so watch the dom
-const awaitHashElement = (hash: string, behavior: ScrollBehavior) => {
+const watchForHashElement = (hash: string, behavior: ScrollBehavior) => {
   const stop = () => {
     observer.disconnect();
     window.removeEventListener('wheel', stop);
@@ -1166,12 +1166,7 @@ const InnerRouter = ({
   const currentRoute = destination ? destination.route : routeFallback;
   // only the current state is reconciled, so one slot is enough
   const appliedRef = useRef<RouterState>(undefined);
-  const readSettledRoute = useCallback(
-    (): RouteProps =>
-      getSettledRoute(resolvedElementsRef.current, routeFallback),
-    [routeFallback],
-  );
-  const awaitedHashRef = useRef<ReturnType<typeof awaitHashElement> | null>(
+  const hashWatchRef = useRef<ReturnType<typeof watchForHashElement> | null>(
     null,
   );
   const destinationHref = destination?.url.href;
@@ -1186,9 +1181,9 @@ const InnerRouter = ({
       applied ? 'replace' : routerState.history,
     );
     appliedRef.current = routerState;
-    if (!applied || awaitedHashRef.current?.hash !== currentHash) {
-      awaitedHashRef.current?.stop();
-      awaitedHashRef.current = null;
+    if (!applied || hashWatchRef.current?.hash !== currentHash) {
+      hashWatchRef.current?.stop();
+      hashWatchRef.current = null;
     }
     if (applied || !routerState.scroll || routerState.failure) {
       return;
@@ -1197,18 +1192,21 @@ const InnerRouter = ({
     const behavior = pathChanged ? 'instant' : 'auto';
     scrollToHash(currentHash, behavior, pathChanged);
     if (currentHash && !getHashElement(currentHash)) {
-      awaitedHashRef.current = awaitHashElement(currentHash, behavior);
+      hashWatchRef.current = watchForHashElement(currentHash, behavior);
     }
   }, [routerState, destinationHref, currentHash]);
 
-  useEffect(() => () => awaitedHashRef.current?.stop(), []);
+  useEffect(() => () => hashWatchRef.current?.stop(), []);
 
   useEffect(() => {
     if (import.meta.hot) {
       const refetchRouteOnHmr = () => {
         prefetchManagerRef.current!.clear();
         staticPathSetRef.current!.clear();
-        const settledRoute = readSettledRoute();
+        const settledRoute = getSettledRoute(
+          resolvedElementsRef.current,
+          routeFallback,
+        );
         startTransition(() => {
           // the reload clears the set, so the response has to teach it again
           void refetch(
@@ -1223,7 +1221,7 @@ const InnerRouter = ({
       );
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
     }
-  }, [refetch, learnStaticPath, readSettledRoute]);
+  }, [refetch, learnStaticPath, routeFallback]);
 
   const [[routeChangeEvents, emitRouteChangeEvent]] = useState(
     createRouteChangeListeners,
@@ -1261,7 +1259,10 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      const settledRoute = readSettledRoute();
+      const settledRoute = getSettledRoute(
+        resolvedElementsRef.current,
+        routeFallback,
+      );
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
       const routerState = makeRouterState(nextRoute, targetUrl, {
         history: options.history,
@@ -1348,7 +1349,7 @@ const InnerRouter = ({
       }
     },
     [
-      readSettledRoute,
+      routeFallback,
       refetch,
       mergeElements,
       emitRouteChangeEvent,
@@ -1362,7 +1363,10 @@ const InnerRouter = ({
         return;
       }
       const [path, query] = routeData as [string, string];
-      const settledRoute = readSettledRoute();
+      const settledRoute = getSettledRoute(
+        resolvedElementsRef.current,
+        routeFallback,
+      );
       if (
         settledRoute.path === path &&
         (isStatic || settledRoute.query === query)
@@ -1379,7 +1383,7 @@ const InnerRouter = ({
         url: is404 ? new URL(window.location.href) : getRouteUrl(route),
       });
     },
-    [changeRoute, readSettledRoute],
+    [changeRoute, routeFallback],
   );
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
@@ -1422,7 +1426,7 @@ const InnerRouter = ({
         changeRoute(nextRoute, {
           shouldScroll: shouldScrollForRouteChange(
             nextRoute,
-            readSettledRoute(),
+            getSettledRoute(resolvedElementsRef.current, routeFallback),
           ),
           history: null, // the browser already moved the address bar
           // keep the url it moved to; an interceptor rewrite needs a new one
@@ -1440,7 +1444,7 @@ const InnerRouter = ({
     return () => {
       window.removeEventListener('popstate', callback);
     };
-  }, [changeRoute, routeInterceptor, readSettledRoute]);
+  }, [changeRoute, routeInterceptor, routeFallback]);
 
   const routeElement = routerState?.failure ? (
     <ThrowError error={routerState.failure.error} />

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -850,10 +850,10 @@ const FollowError = ({
   }, [routePath, routeQuery, routeHash, routerState, reset, fail, error]);
   const followCaughtError = useEffectEvent(() => {
     // the requested url may not have reached the address bar yet
-    const requestedUrl = routerState
+    const stateUrl = routerState
       ? new URL(routerState.url, window.location.href)
       : new URL(window.location.href);
-    const errorRoute = resolveErrorRoute(error, requestedUrl, has404);
+    const errorRoute = resolveErrorRoute(error, stateUrl, has404);
     if (errorRoute.type === 'none') {
       return;
     }
@@ -874,8 +874,8 @@ const FollowError = ({
     const requested = routerState?.requested;
     const caught = requested
       ? { path: requested[0], query: requested[1] }
-      : parseRoute(requestedUrl);
-    if (isSameRscRoute(target, caught) && url.href === requestedUrl.href) {
+      : parseRoute(stateUrl);
+    if (isSameRscRoute(target, caught) && url.href === stateUrl.href) {
       fail(error, new Error('detected a navigation loop', { cause: error }));
       return;
     }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -139,9 +139,8 @@ type Prefetch = {
   ): void;
 };
 
-const parseRouteFromLocation = (): RouteProps => {
-  return parseRoute(new URL(window.location.href));
-};
+const parseRouteFromLocation = (): RouteProps =>
+  parseRoute(new URL(window.location.href));
 
 const commitHistory = (url: URL, mode: 'push' | 'replace' | null): void => {
   if (window.location.href === url.href) {
@@ -149,9 +148,10 @@ const commitHistory = (url: URL, mode: 'push' | 'replace' | null): void => {
   }
   if (mode === 'push') {
     window.history.pushState(window.history.state, '', url);
-  } else {
-    window.history.replaceState(window.history.state, '', url);
+    return;
   }
+  // 'replace' and null both write: null means the url should still show
+  window.history.replaceState(window.history.state, '', url);
 };
 
 const reloadWithUrl = (url: URL) => {
@@ -1118,6 +1118,10 @@ const InnerRouter = ({
     setRestoredHash(window.location.hash || initialHashRef.current!);
   }, []);
 
+  const routeFallback = useMemo(
+    () => ({ ...initialRoute, hash: restoredHash }),
+    [initialRoute, restoredHash],
+  );
   const routerState = getRouterState(elements);
   const destination = useMemo(
     () =>
@@ -1125,20 +1129,14 @@ const InnerRouter = ({
       resolveServerRedirect(elements, routerState, initialRoute.path),
     [elements, routerState, initialRoute],
   );
-  const currentRoute = useMemo(
-    () =>
-      destination ? destination.route : { ...initialRoute, hash: restoredHash },
-    [destination, initialRoute, restoredHash],
-  );
-  const committedRoute = useCallback(
-    (): RouteProps =>
-      getSettledRoute(resolvedElementsRef.current, {
-        ...initialRoute,
-        hash: restoredHash,
-      }),
-    [initialRoute, restoredHash],
-  );
+  const currentRoute = destination ? destination.route : routeFallback;
+  // only the current state is reconciled; a single slot is enough to skip repeats
   const appliedRef = useRef<RouterState>(undefined);
+  const settledRoute = useCallback(
+    (): RouteProps =>
+      getSettledRoute(resolvedElementsRef.current, routeFallback),
+    [routeFallback],
+  );
   const awaitedHashRef = useRef<{
     hash: string;
     behavior: ScrollBehavior;
@@ -1150,7 +1148,6 @@ const InnerRouter = ({
       return;
     }
     const applied = appliedRef.current === routerState;
-    // history null still writes: the state's url is the one that should show
     commitHistory(
       new URL(destinationHref),
       applied ? 'replace' : routerState.history,
@@ -1160,7 +1157,6 @@ const InnerRouter = ({
       const { pathChanged } = routerState.scroll;
       const behavior = pathChanged ? 'instant' : 'auto';
       scrollToHash(currentHash, behavior, pathChanged);
-      // an instant nav paints before its response, so the target may be absent
       awaitedHashRef.current =
         currentHash && !getHashElement(currentHash)
           ? { hash: currentHash, behavior }
@@ -1181,7 +1177,7 @@ const InnerRouter = ({
       const refetchRouteOnHmr = () => {
         prefetchManagerRef.current!.clear();
         staticPathSetRef.current!.clear();
-        const route = committedRoute();
+        const route = settledRoute();
         startTransition(() => {
           // the reload clears the set, so the response has to teach it again
           void refetch(
@@ -1196,7 +1192,7 @@ const InnerRouter = ({
       );
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
     }
-  }, [refetch, learnStaticPath, committedRoute]);
+  }, [refetch, learnStaticPath, settledRoute]);
 
   const [[routeChangeEvents, emitRouteChangeEvent]] = useState(
     createRouteChangeListeners,
@@ -1234,7 +1230,7 @@ const InnerRouter = ({
       if (isAborted()) {
         return;
       }
-      const routeBefore = committedRoute();
+      const routeBefore = settledRoute();
       const targetUrl = options.url ?? getRouteUrl(nextRoute);
       const routerState = makeRouterState(nextRoute, targetUrl, {
         history: options.history,
@@ -1321,7 +1317,7 @@ const InnerRouter = ({
       }
     },
     [
-      committedRoute,
+      settledRoute,
       refetch,
       mergeElements,
       emitRouteChangeEvent,
@@ -1335,11 +1331,8 @@ const InnerRouter = ({
         return;
       }
       const [path, query] = routeData as [string, string];
-      const currentRoute = committedRoute();
-      if (
-        currentRoute.path === path &&
-        (isStatic || currentRoute.query === query)
-      ) {
+      const settled = settledRoute();
+      if (settled.path === path && (isStatic || settled.query === query)) {
         return;
       }
       const route = { path, query, hash: '' };
@@ -1352,7 +1345,7 @@ const InnerRouter = ({
         url: is404 ? new URL(window.location.href) : getRouteUrl(route),
       });
     },
-    [changeRoute, committedRoute],
+    [changeRoute, settledRoute],
   );
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
@@ -1393,7 +1386,7 @@ const InnerRouter = ({
       }
       startTransition(() => {
         changeRoute(nextRoute, {
-          shouldScroll: shouldScrollForRouteChange(nextRoute, committedRoute()),
+          shouldScroll: shouldScrollForRouteChange(nextRoute, settledRoute()),
           history: null, // the browser already moved the address bar
           // keep the url it moved to; an interceptor rewrite needs a new one
           url: isSameRoute(nextRoute, popped)
@@ -1410,7 +1403,7 @@ const InnerRouter = ({
     return () => {
       window.removeEventListener('popstate', callback);
     };
-  }, [changeRoute, routeInterceptor, committedRoute]);
+  }, [changeRoute, routeInterceptor, settledRoute]);
 
   const routeElement = routerState?.failure ? (
     <ThrowError error={routerState.failure.error} />

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1019,13 +1019,18 @@ const decodeHash = (raw: string) => {
 const getHashElement = (hash: string): HTMLElement | null => {
   const raw = hash.slice(1);
   for (const name of new Set([raw, decodeHash(raw)])) {
-    const element =
-      document.getElementById(name) ?? document.getElementsByName(name)[0];
-    if (element) {
-      return element;
+    const byId = document.getElementById(name);
+    if (byId) {
+      return byId;
+    }
+    // the spec names anchors only, so a meta or an input is not a target
+    for (const named of document.getElementsByName(name)) {
+      if (named.localName === 'a') {
+        return named;
+      }
     }
   }
-  return raw.toLowerCase() === 'top' ? document.body : null;
+  return raw.toLowerCase() === 'top' ? document.documentElement : null;
 };
 
 const scrollToHash = (
@@ -1153,10 +1158,12 @@ const InnerRouter = ({
       applied ? 'replace' : routerState.history,
     );
     appliedRef.current = routerState;
+    if (!applied || awaitedHashRef.current?.hash !== currentHash) {
+      awaitedHashRef.current = null;
+    }
     if (applied) {
       return;
     }
-    awaitedHashRef.current = null;
     if (routerState.scroll && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
       const behavior = pathChanged ? 'instant' : 'auto';

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1030,7 +1030,39 @@ const getHashElement = (hash: string): HTMLElement | null => {
       }
     }
   }
-  return raw.toLowerCase() === 'top' ? document.documentElement : null;
+  return decodeHash(raw).toLowerCase() === 'top'
+    ? document.documentElement
+    : null;
+};
+
+/**
+ * Streamed content can bring the target in long after the scroll, and a slot
+ * resolving on its own does not re-render the router, so this watches the dom
+ * rather than react. It gives up as soon as the reader scrolls themselves.
+ */
+const awaitHashElement = (hash: string, behavior: ScrollBehavior) => {
+  const stop = () => {
+    observer.disconnect();
+    window.removeEventListener('wheel', stop);
+    window.removeEventListener('touchmove', stop);
+    window.removeEventListener('keydown', stop);
+  };
+  const observer = new MutationObserver(() => {
+    if (getHashElement(hash)) {
+      stop();
+      scrollToHash(hash, behavior, false);
+    }
+  });
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['id', 'name'],
+  });
+  window.addEventListener('wheel', stop, { passive: true });
+  window.addEventListener('touchmove', stop, { passive: true });
+  window.addEventListener('keydown', stop);
+  return { hash, stop };
 };
 
 const scrollToHash = (
@@ -1142,10 +1174,9 @@ const InnerRouter = ({
       getSettledRoute(resolvedElementsRef.current, routeFallback),
     [routeFallback],
   );
-  const awaitedHashRef = useRef<{
-    hash: string;
-    behavior: ScrollBehavior;
-  } | null>(null);
+  const awaitedHashRef = useRef<ReturnType<typeof awaitHashElement> | null>(
+    null,
+  );
   const destinationHref = destination?.url.href;
   const currentHash = currentRoute.hash;
   useLayoutEffect(() => {
@@ -1159,6 +1190,7 @@ const InnerRouter = ({
     );
     appliedRef.current = routerState;
     if (!applied || awaitedHashRef.current?.hash !== currentHash) {
+      awaitedHashRef.current?.stop();
       awaitedHashRef.current = null;
     }
     if (applied) {
@@ -1169,18 +1201,12 @@ const InnerRouter = ({
       const behavior = pathChanged ? 'instant' : 'auto';
       scrollToHash(currentHash, behavior, pathChanged);
       if (currentHash && !getHashElement(currentHash)) {
-        awaitedHashRef.current = { hash: currentHash, behavior };
+        awaitedHashRef.current = awaitHashElement(currentHash, behavior);
       }
     }
   }, [routerState, destinationHref, currentHash]);
 
-  useEffect(() => {
-    const awaited = awaitedHashRef.current;
-    if (awaited && getHashElement(awaited.hash)) {
-      awaitedHashRef.current = null;
-      scrollToHash(awaited.hash, awaited.behavior, false);
-    }
-  });
+  useEffect(() => () => awaitedHashRef.current?.stop(), []);
 
   useEffect(() => {
     if (import.meta.hot) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -838,8 +838,8 @@ const FollowError = ({
       !routerState.failure
     ) {
       const landed =
-        routerState.attempted[0] === dispatched.route.path &&
-        routerState.attempted[1] === dispatched.route.query;
+        routerState.requested[0] === dispatched.route.path &&
+        routerState.requested[1] === dispatched.route.query;
       const arrived = landed
         ? dispatched.route.path === routePath
         : routerState.url === dispatched.url;
@@ -851,11 +851,11 @@ const FollowError = ({
     }
   }, [routePath, routeQuery, routeHash, routerState, reset, fail, error]);
   const followCaughtError = useEffectEvent(() => {
-    // the attempted url may not have reached the address bar yet
-    const attemptedUrl = routerState
+    // the requested url may not have reached the address bar yet
+    const requestedUrl = routerState
       ? new URL(routerState.url, window.location.href)
       : new URL(window.location.href);
-    const errorRoute = resolveErrorRoute(error, attemptedUrl, has404);
+    const errorRoute = resolveErrorRoute(error, requestedUrl, has404);
     if (errorRoute.type === 'none') {
       return;
     }
@@ -873,11 +873,11 @@ const FollowError = ({
       return;
     }
     const { target, url } = errorRoute;
-    const attempted = routerState?.attempted;
-    const caught = attempted
-      ? { path: attempted[0], query: attempted[1] }
-      : parseRoute(attemptedUrl);
-    if (isSameRscRoute(target, caught) && url.href === attemptedUrl.href) {
+    const requested = routerState?.requested;
+    const caught = requested
+      ? { path: requested[0], query: requested[1] }
+      : parseRoute(requestedUrl);
+    if (isSameRscRoute(target, caught) && url.href === requestedUrl.href) {
       fail(error, new Error('detected a navigation loop', { cause: error }));
       return;
     }

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1010,17 +1010,24 @@ export function Slice({
   return <Slot id={slotId}>{children}</Slot>;
 }
 
+const decodeHash = (raw: string) => {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+};
+
 const getHashElement = (hash: string): HTMLElement | null => {
   const raw = hash.slice(1);
-  const rawElement = document.getElementById(raw);
-  if (rawElement) {
-    return rawElement;
+  for (const name of new Set([raw, decodeHash(raw)])) {
+    const element =
+      document.getElementById(name) ?? document.getElementsByName(name)[0];
+    if (element) {
+      return element;
+    }
   }
-  try {
-    return document.getElementById(decodeURIComponent(raw));
-  } catch {
-    return null;
-  }
+  return raw.toLowerCase() === 'top' ? document.body : null;
 };
 
 const scrollToHash = (
@@ -1134,6 +1141,10 @@ const InnerRouter = ({
     [initialRoute, restoredHash],
   );
   const appliedRef = useRef<RouterState>(undefined);
+  const awaitedHashRef = useRef<{
+    hash: string;
+    behavior: ScrollBehavior;
+  } | null>(null);
   const destinationHref = destination?.url.href;
   const currentHash = currentRoute.hash;
   useLayoutEffect(() => {
@@ -1149,9 +1160,23 @@ const InnerRouter = ({
     appliedRef.current = routerState;
     if (routerState.scroll && !applied && !routerState.failure) {
       const { pathChanged } = routerState.scroll;
-      scrollToHash(currentHash, pathChanged ? 'instant' : 'auto', pathChanged);
+      const behavior = pathChanged ? 'instant' : 'auto';
+      scrollToHash(currentHash, behavior, pathChanged);
+      // an instant nav paints before its response, so the target may be absent
+      awaitedHashRef.current =
+        currentHash && !getHashElement(currentHash)
+          ? { hash: currentHash, behavior }
+          : null;
     }
   }, [routerState, destinationHref, currentHash]);
+
+  useEffect(() => {
+    const awaited = awaitedHashRef.current;
+    if (awaited && getHashElement(awaited.hash)) {
+      awaitedHashRef.current = null;
+      scrollToHash(awaited.hash, awaited.behavior, false);
+    }
+  });
 
   useEffect(() => {
     if (import.meta.hot) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1008,8 +1008,7 @@ export function Slice({
   return <Slot id={slotId}>{children}</Slot>;
 }
 
-// percent decoding leaves a malformed escape alone instead of giving up on the
-// whole fragment, and a run decodes together so multi byte characters survive
+// a run decodes together, so a multi byte character survives
 const decodeHash = (raw: string) =>
   raw.replace(/(?:%[0-9A-Fa-f]{2})+/g, (escapes) => {
     try {
@@ -1026,7 +1025,7 @@ const getHashElement = (hash: string): HTMLElement | null => {
     if (byId) {
       return byId;
     }
-    // the spec names anchors only, so a meta or an input is not a target
+    // the spec counts anchors only, not a meta or an input
     for (const named of document.getElementsByName(name)) {
       if (named.localName === 'a') {
         return named;
@@ -1038,11 +1037,7 @@ const getHashElement = (hash: string): HTMLElement | null => {
     : null;
 };
 
-/**
- * Streamed content can bring the target in long after the scroll, and a slot
- * resolving on its own does not re-render the router, so this watches the dom
- * rather than react. It gives up as soon as the reader scrolls themselves.
- */
+// a slot can resolve without re-rendering the router, so watch the dom
 const awaitHashElement = (hash: string, behavior: ScrollBehavior) => {
   const stop = () => {
     observer.disconnect();

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2834,6 +2834,111 @@ describe('Router integration', () => {
     }
   });
 
+  test('a server rewrite drops a hash target the response did not keep', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const nextSlotId = unstable_getRouteSlotId('/next');
+    let land: (() => void) | undefined;
+    const refetch = vi.fn<RefetchInner>(
+      () =>
+        new Promise((resolve) => {
+          land = () =>
+            resolve({
+              [unstable_getRouteSlotId('/rewritten')]: (
+                <>
+                  <Probe />
+                  <div id="intro">intro</div>
+                </>
+              ),
+              [ROUTE_ID]: ['/rewritten', ''],
+              [IS_STATIC_ID]: false,
+            });
+        }),
+    );
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [nextSlotId]: <div>shell</div>,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+        [`${ETAG_ID_PREFIX}${nextSlotId}`]: IMMUTABLE_ETAG,
+      },
+    );
+    try {
+      document.body.append(view.container);
+      const pushed = capture.router!.push('/next#intro', {
+        unstable_instant: true,
+      });
+      await act(async () => {
+        await flush();
+      });
+      scrollToSpy.mockClear();
+
+      // the rewritten route has an #intro of its own, but it was never asked for
+      await act(async () => {
+        land!();
+        await pushed;
+        await flush();
+      });
+
+      expect(capture.router!.path).toBe('/rewritten');
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    } finally {
+      view.container.remove();
+      view.unmount();
+      scrollToSpy.mockRestore();
+    }
+  });
+
+  test('a named element that is not an anchor is not a hash target', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<RefetchInner>(async () => ({}));
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/next')]: (
+          <>
+            <Probe />
+            <input name="section" readOnly />
+          </>
+        ),
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    try {
+      document.body.append(view.container);
+      await act(async () => {
+        await capture.router!.push('/next');
+        await flush();
+      });
+      scrollToSpy.mockClear();
+
+      // same path, so a real target would scroll and a miss does nothing
+      await act(async () => {
+        await capture.router!.push('/next#section');
+        await flush();
+      });
+
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    } finally {
+      view.container.remove();
+      view.unmount();
+      scrollToSpy.mockRestore();
+    }
+  });
+
   test('a later navigation drops a hash target that never arrived', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -2977,8 +3082,10 @@ describe('Router integration', () => {
     const getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
-        // the document is scrolled down, so the body starts above the viewport
-        return { top: this === document.body ? -100 : 0 } as DOMRect;
+        // the document is scrolled down, so the root starts above the viewport
+        return {
+          top: this === document.documentElement ? -100 : 0,
+        } as DOMRect;
       });
     const view = await renderRouter(
       { initialRoute: { path: '/start', query: '', hash: '' } },

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3001,6 +3001,137 @@ describe('Router integration', () => {
     }
   });
 
+  test('a reader who scrolls is not pulled to a late hash target', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const nextSlotId = unstable_getRouteSlotId('/next');
+    let land: (() => void) | undefined;
+    const refetch = vi.fn<RefetchInner>(
+      () =>
+        new Promise((resolve) => {
+          land = () =>
+            resolve({
+              extra: <div id="target">target</div>,
+              [ROUTE_ID]: ['/next', ''],
+              [IS_STATIC_ID]: false,
+            });
+        }),
+    );
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [nextSlotId]: (
+          <>
+            <Probe />
+            <Slot id="extra" />
+          </>
+        ),
+        extra: <div>placeholder</div>,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+        [`${ETAG_ID_PREFIX}${nextSlotId}`]: IMMUTABLE_ETAG,
+      },
+    );
+    try {
+      document.body.append(view.container);
+      const pushed = capture.router!.push('/next#target', {
+        unstable_instant: true,
+      });
+      await act(async () => {
+        await flush();
+      });
+      scrollToSpy.mockClear();
+
+      // the reader takes over before the target arrives
+      window.dispatchEvent(new Event('wheel'));
+      await act(async () => {
+        land!();
+        await pushed;
+        await flush();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(document.getElementById('target')).not.toBeNull();
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    } finally {
+      view.container.remove();
+      view.unmount();
+      scrollToSpy.mockRestore();
+    }
+  });
+
+  test('a percent encoded #top still means the top of the document', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<RefetchInner>(async () => ({}));
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'scrollY',
+    );
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 100,
+    });
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        return {
+          top: this === document.documentElement ? -100 : 0,
+        } as DOMRect;
+      });
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/next')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    try {
+      document.body.append(view.container);
+      await act(async () => {
+        await capture.router!.push('/next');
+        await flush();
+      });
+      scrollToSpy.mockClear();
+
+      await act(async () => {
+        await capture.router!.push('/next#%74op');
+        await flush();
+      });
+
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      expect(scrollToSpy).toHaveBeenLastCalledWith({
+        left: 0,
+        top: 0,
+        behavior: 'auto',
+      });
+    } finally {
+      view.container.remove();
+      view.unmount();
+      getBoundingClientRectSpy.mockRestore();
+      scrollToSpy.mockRestore();
+      if (scrollYDescriptor) {
+        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
+      } else {
+        Object.defineProperty(window, 'scrollY', {
+          configurable: true,
+          value: 0,
+        });
+      }
+    }
+  });
+
   test('a hash target can be an old style name anchor', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -2834,6 +2834,68 @@ describe('Router integration', () => {
     }
   });
 
+  test('a later navigation drops a hash target that never arrived', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const grab = { refetch: null as null | ReturnType<typeof useRefetch> };
+    const Grabber = () => {
+      grab.refetch = useRefetch();
+      return null;
+    };
+    const refetch = vi.fn<RefetchInner>(async () => ({}));
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/a')]: (
+          <>
+            <Probe />
+            <Grabber />
+          </>
+        ),
+        [unstable_getRouteSlotId('/b')]: (
+          <>
+            <Probe />
+            <Grabber />
+            <Slot id="late" />
+          </>
+        ),
+        late: <div>nothing yet</div>,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    try {
+      document.body.append(view.container);
+      // the target never shows up on /a
+      await act(async () => {
+        await capture.router!.push('/a#target');
+        await flush();
+      });
+      await act(async () => {
+        await capture.router!.push('/b', { scroll: false });
+        await flush();
+      });
+      scrollToSpy.mockClear();
+
+      refetch.mockResolvedValueOnce({ late: <div id="target">target</div> });
+      await act(async () => {
+        await grab.refetch!('late');
+        await flush();
+      });
+
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    } finally {
+      view.container.remove();
+      view.unmount();
+      scrollToSpy.mockRestore();
+    }
+  });
+
   test('a hash target can be an old style name anchor', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3065,6 +3065,70 @@ describe('Router integration', () => {
     }
   });
 
+  test('a malformed escape does not spoil the rest of a hash target', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<RefetchInner>(async () => ({}));
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'scrollY',
+    );
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 100,
+    });
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        return { top: this.id === 'foo bar%ZZ' ? 40 : 0 } as DOMRect;
+      });
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/next')]: (
+          <>
+            <Probe />
+            <div id="foo bar%ZZ">target</div>
+          </>
+        ),
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    try {
+      document.body.append(view.container);
+      // %20 decodes, %ZZ is not an escape and stays as written
+      await act(async () => {
+        await capture.router!.push('/next#foo%20bar%ZZ');
+        await flush();
+      });
+
+      expect(scrollToSpy).toHaveBeenLastCalledWith({
+        left: 0,
+        top: 140,
+        behavior: 'instant',
+      });
+    } finally {
+      view.container.remove();
+      view.unmount();
+      getBoundingClientRectSpy.mockRestore();
+      scrollToSpy.mockRestore();
+      if (scrollYDescriptor) {
+        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
+      } else {
+        Object.defineProperty(window, 'scrollY', {
+          configurable: true,
+          value: 0,
+        });
+      }
+    }
+  });
+
   test('a percent encoded #top still means the top of the document', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -421,6 +421,18 @@ const renderApp = async (element: ReactElement) => {
   };
 };
 
+const stubScrollY = (value: number) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, 'scrollY');
+  Object.defineProperty(window, 'scrollY', { configurable: true, value });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(window, 'scrollY', descriptor);
+    } else {
+      Reflect.deleteProperty(window, 'scrollY');
+    }
+  };
+};
+
 const flush = async () => {
   await act(async () => {
     await new Promise<void>((resolve) => setTimeout(resolve));
@@ -1142,14 +1154,7 @@ describe('useRouter + Link with context', () => {
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
       return;
     });
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const hashTarget = document.createElement('div');
     hashTarget.id = 'target';
     const getBoundingClientRectSpy = vi
@@ -1198,11 +1203,7 @@ describe('useRouter + Link with context', () => {
       getBoundingClientRectSpy.mockRestore();
       hashTarget.remove();
       window.history.replaceState({}, '', '/');
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Reflect.deleteProperty(window, 'scrollY');
-      }
+      restoreScrollY();
     }
   });
 
@@ -2680,14 +2681,7 @@ describe('Router integration', () => {
         hash: window.location.hash,
       });
     });
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
@@ -2738,14 +2732,7 @@ describe('Router integration', () => {
     } finally {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -2769,14 +2756,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
@@ -2823,14 +2803,7 @@ describe('Router integration', () => {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
       scrollToSpy.mockRestore();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -3073,14 +3046,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
@@ -3118,14 +3084,7 @@ describe('Router integration', () => {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
       scrollToSpy.mockRestore();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -3137,14 +3096,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
@@ -3185,14 +3137,7 @@ describe('Router integration', () => {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
       scrollToSpy.mockRestore();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -3202,14 +3147,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
@@ -3247,14 +3185,7 @@ describe('Router integration', () => {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
       scrollToSpy.mockRestore();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -3266,14 +3197,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
@@ -3316,14 +3240,7 @@ describe('Router integration', () => {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
       scrollToSpy.mockRestore();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -3348,14 +3265,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
       return;
     });
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
@@ -3400,14 +3310,7 @@ describe('Router integration', () => {
     } finally {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -3461,14 +3364,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
       return;
     });
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const hashTarget = document.createElement('div');
     hashTarget.id = 'target';
     const getBoundingClientRectSpy = vi
@@ -3504,14 +3400,7 @@ describe('Router integration', () => {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
       hashTarget.remove();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -3527,14 +3416,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
       return;
     });
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     // `%E6%97%A5...` is the percent-encoded form of the id "日本語見出し", which
     // is how `URL.hash` (and therefore `route.hash`) represents a non-ASCII
     // fragment. Use the encoded form explicitly so the test reproduces the bug
@@ -3574,14 +3456,7 @@ describe('Router integration', () => {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
       hashTarget.remove();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -3597,14 +3472,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
       return;
     });
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     // Per the HTML fragment navigation algorithm, the raw fragment must be
     // tried first and the percent-decoded form only as a fallback. With both
     // ids present, `#a%20b` must scroll to `id="a%20b"`, not `id="a b"`.
@@ -3646,14 +3514,7 @@ describe('Router integration', () => {
       decodedRectSpy.mockRestore();
       rawTarget.remove();
       decodedTarget.remove();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 
@@ -4949,14 +4810,7 @@ describe('Router integration', () => {
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
       return;
     });
-    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
-      window,
-      'scrollY',
-    );
-    Object.defineProperty(window, 'scrollY', {
-      configurable: true,
-      value: 100,
-    });
+    const restoreScrollY = stubScrollY(100);
     const hashTarget = document.createElement('div');
     hashTarget.id = 'target';
     const getBoundingClientRectSpy = vi
@@ -4984,14 +4838,7 @@ describe('Router integration', () => {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
       hashTarget.remove();
-      if (scrollYDescriptor) {
-        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
-      } else {
-        Object.defineProperty(window, 'scrollY', {
-          configurable: true,
-          value: 0,
-        });
-      }
+      restoreScrollY();
     }
   });
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -23,6 +23,7 @@ import {
   Children,
   INTERNAL_ServerRoot,
   Root,
+  Slot,
   unstable_prefetchRsc as prefetchRsc,
   useRefetch,
 } from '../src/minimal/client.js';
@@ -2737,6 +2738,220 @@ describe('Router integration', () => {
     } finally {
       view.unmount();
       getBoundingClientRectSpy.mockRestore();
+      if (scrollYDescriptor) {
+        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
+      } else {
+        Object.defineProperty(window, 'scrollY', {
+          configurable: true,
+          value: 0,
+        });
+      }
+    }
+  });
+
+  test('an instant nav aims at a hash target that arrives with the response', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const nextSlotId = unstable_getRouteSlotId('/next');
+    let land: (() => void) | undefined;
+    const refetch = vi.fn<RefetchInner>(
+      () =>
+        new Promise((resolve) => {
+          land = () =>
+            resolve({
+              extra: <div id="target">target</div>,
+              [ROUTE_ID]: ['/next', ''],
+              [IS_STATIC_ID]: false,
+            });
+        }),
+    );
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'scrollY',
+    );
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 100,
+    });
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        return { top: this.id === 'target' ? 40 : 0 } as DOMRect;
+      });
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        // the cached shell paints without #target; it streams in after
+        [nextSlotId]: (
+          <>
+            <Probe />
+            <Slot id="extra" />
+          </>
+        ),
+        extra: <div>placeholder</div>,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+        [`${ETAG_ID_PREFIX}${nextSlotId}`]: IMMUTABLE_ETAG,
+      },
+    );
+    try {
+      document.body.append(view.container);
+      const pushed = capture.router!.push('/next#target', {
+        unstable_instant: true,
+      });
+      await act(async () => {
+        await flush();
+      });
+      await act(async () => {
+        land!();
+        await pushed;
+        await flush();
+      });
+
+      expect(scrollToSpy).toHaveBeenLastCalledWith({
+        left: 0,
+        top: 140,
+        behavior: 'instant',
+      });
+    } finally {
+      view.container.remove();
+      view.unmount();
+      getBoundingClientRectSpy.mockRestore();
+      scrollToSpy.mockRestore();
+      if (scrollYDescriptor) {
+        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
+      } else {
+        Object.defineProperty(window, 'scrollY', {
+          configurable: true,
+          value: 0,
+        });
+      }
+    }
+  });
+
+  test('a hash target can be an old style name anchor', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'scrollY',
+    );
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 100,
+    });
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        return {
+          top: this.getAttribute('name') === 'target' ? 40 : 0,
+        } as DOMRect;
+      });
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/next')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    const anchor = document.createElement('a');
+    anchor.setAttribute('name', 'target');
+    try {
+      document.body.append(view.container);
+      document.body.append(anchor);
+      await act(async () => {
+        await capture.router!.push('/next#target');
+        await flush();
+      });
+
+      expect(scrollToSpy).toHaveBeenLastCalledWith({
+        left: 0,
+        top: 140,
+        behavior: 'instant',
+      });
+    } finally {
+      anchor.remove();
+      view.container.remove();
+      view.unmount();
+      getBoundingClientRectSpy.mockRestore();
+      scrollToSpy.mockRestore();
+      if (scrollYDescriptor) {
+        Object.defineProperty(window, 'scrollY', scrollYDescriptor);
+      } else {
+        Object.defineProperty(window, 'scrollY', {
+          configurable: true,
+          value: 0,
+        });
+      }
+    }
+  });
+
+  test('a #top hash with no such element means the top of the document', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<RefetchInner>(async () => ({}));
+    installRefetch(refetch);
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const scrollYDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'scrollY',
+    );
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 100,
+    });
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        // the document is scrolled down, so the body starts above the viewport
+        return { top: this === document.body ? -100 : 0 } as DOMRect;
+      });
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/next')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+    try {
+      document.body.append(view.container);
+      await act(async () => {
+        await capture.router!.push('/next');
+        await flush();
+      });
+      scrollToSpy.mockClear();
+
+      // same path, so a missing target would not fall back to the top
+      await act(async () => {
+        await capture.router!.push('/next#top');
+        await flush();
+      });
+
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      expect(scrollToSpy).toHaveBeenLastCalledWith({
+        left: 0,
+        top: 0,
+        behavior: 'auto',
+      });
+    } finally {
+      view.container.remove();
+      view.unmount();
+      getBoundingClientRectSpy.mockRestore();
+      scrollToSpy.mockRestore();
       if (scrollYDescriptor) {
         Object.defineProperty(window, 'scrollY', scrollYDescriptor);
       } else {

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1926,7 +1926,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a server function 404 keeps the attempted url', async () => {
+  test('a server function 404 keeps the requested url', async () => {
     window.history.replaceState({}, '', '/start?a=1');
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
@@ -3710,7 +3710,7 @@ describe('Router integration', () => {
     const replaceLocationSpy = vi
       .spyOn(window.location, 'replace')
       .mockImplementation(() => {});
-    // an instant commit writes the attempted url before the response lands
+    // an instant commit writes the requested url before the response lands
     window.history.replaceState({}, '', '/next?x=1');
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(() =>
       Promise.reject(
@@ -4463,7 +4463,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a server rewrite drops the attempted hash from the committed route', async () => {
+  test('a server rewrite drops the requested hash from the committed route', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const refetch = vi.fn<ReturnType<typeof useRefetch>>(async () => ({
@@ -4500,7 +4500,7 @@ describe('Router integration', () => {
         await flush();
       });
 
-      // nothing moved, so the attempted '#frag' must not still count as committed
+      // nothing moved, so the requested '#frag' must not still count as committed
       expect(scrollToSpy).not.toHaveBeenCalled();
     } finally {
       scrollToSpy.mockRestore();
@@ -4885,7 +4885,7 @@ describe('Router integration', () => {
     const historyPushSpy = vi.spyOn(window.history, 'pushState');
     const historyReplaceSpy = vi.spyOn(window.history, 'replaceState');
     try {
-      // commits the attempted url first, then the response moves the route
+      // commits the requested url first, then the response moves the route
       const pushed = capture.router!.push('/next', {
         unstable_instant: true,
       });
@@ -5050,7 +5050,7 @@ describe('Router integration', () => {
     expect(replaceLocationSpy).toHaveBeenCalledTimes(1);
     expect(replaceLocationSpy.mock.calls[0]![0]).toContain('/next');
     expect(capture.router!.path).toBe('/start');
-    // the attempted entry is written first, so leaving it keeps /start behind
+    // the requested entry is written first, so leaving it keeps /start behind
     expect(window.location.pathname).toBe('/moved');
     replaceLocationSpy.mockRestore();
     view.unmount();
@@ -5111,7 +5111,7 @@ describe('Router integration', () => {
     }
   });
 
-  test('a rejected redirect resolves a relative location against the attempted url', async () => {
+  test('a rejected redirect resolves a relative location against the requested url', async () => {
     const assignSpy = vi
       .spyOn(window.location, 'assign')
       .mockImplementation(() => {});
@@ -5217,7 +5217,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('an instant 404 keeps the attempted url in the address bar', async () => {
+  test('an instant 404 keeps the requested url in the address bar', async () => {
     const refetch = vi.fn<ReturnType<typeof useRefetch>>();
     refetch
       .mockImplementationOnce(() =>
@@ -5261,7 +5261,7 @@ describe('Router integration', () => {
       await flush();
     });
 
-    // the 404 route renders while the address bar keeps the attempted url
+    // the 404 route renders while the address bar keeps the requested url
     expect(capture.router.path).toBe('/404');
     expect(window.location.pathname).toBe('/account/profile');
     expect(window.history.length).toBe(lengthBefore + 1);
@@ -5269,7 +5269,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a redirect that keeps the attempted pathname still scrolls', async () => {
+  test('a redirect that keeps the requested pathname still scrolls', async () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
@@ -5319,9 +5319,9 @@ describe('Router integration', () => {
     });
 
     // the visible navigation is from /start, so the page scrolls even
-    // though the redirect keeps the attempted pathname
+    // though the redirect keeps the requested pathname
     expect(capture.router.query).toBe('login=1');
-    // twice: the attempted commit, then the follow
+    // twice: the requested commit, then the follow
     expect(scrollToSpy).toHaveBeenCalledTimes(2);
 
     scrollToSpy.mockRestore();
@@ -5376,7 +5376,7 @@ describe('Router integration', () => {
       await flush();
     });
 
-    // the attempted entry is written once, then replaced by the redirect
+    // the requested entry is written once, then replaced by the redirect
     expect(capture.router.path).toBe('/login');
     expect(window.location.pathname).toBe('/login');
     expect(window.history.length).toBe(lengthBefore + 1);
@@ -5384,7 +5384,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a slow redirect after an instant error writes one attempted entry', async () => {
+  test('a slow redirect after an instant error writes one requested entry', async () => {
     const RedirectErrorObject = createCustomError('moved', {
       status: 307,
       location: 'login',
@@ -5435,7 +5435,7 @@ describe('Router integration', () => {
       pushPromise = capture.router!.push('/account/profile', {
         unstable_instant: true,
       });
-      // flush the attempted route's commit while the redirect is pending
+      // flush the requested route's commit while the redirect is pending
       await flush();
       await flush();
     });
@@ -5559,7 +5559,7 @@ describe('Router integration', () => {
     });
 
     expect(capture.router.query).toBe('page=3');
-    // twice: the attempted commit, then the follow
+    // twice: the requested commit, then the follow
     expect(scrollToSpy).toHaveBeenCalledTimes(2);
 
     scrollToSpy.mockRestore();
@@ -5887,14 +5887,14 @@ describe('Router integration', () => {
     // the visible navigation is /start -> /account/profile?login=1, so
     // the redirect scrolls even though it only changed the query
     expect(capture.router.query).toBe('login=1');
-    // twice: the attempted commit, then the follow
+    // twice: the requested commit, then the follow
     expect(scrollToSpy).toHaveBeenCalledTimes(2);
 
     scrollToSpy.mockRestore();
     view.unmount();
   });
 
-  test('a redirect back to the current route scrolls like the attempted navigation', async () => {
+  test('a redirect back to the current route scrolls like the requested navigation', async () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
@@ -6044,7 +6044,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a 404 follow fetches the 404 route with the attempted query', async () => {
+  test('a 404 follow fetches the 404 route with the requested query', async () => {
     const { view, refetch, capture, router } = await renderFollowRouter({
       responses: [
         { reject: { status: 404 } },
@@ -6848,7 +6848,7 @@ describe('Router integration', () => {
       await flush();
       await flush();
     });
-    // the attempted query update does not scroll, and the redirect
+    // the requested query update does not scroll, and the redirect
     // inherits that decision
     expect(capture.router!.path).toBe('/login');
     expect(scrollToSpy).not.toHaveBeenCalled();
@@ -7703,7 +7703,7 @@ describe('Router integration', () => {
       await flush();
       await flush();
     });
-    // the attempted entry is written, then the browser leaves from it
+    // the requested entry is written, then the browser leaves from it
     expect(window.location.pathname).toBe('/protected');
     expect(window.history.length).toBe(lengthBefore + 1);
     // leaving still closes the navigation it was asked for

--- a/packages/waku/tests/router-error-route.test.ts
+++ b/packages/waku/tests/router-error-route.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
   vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
 });
 
-const attempted = (href: string) => new URL(href, window.location.href);
+const requested = (href: string) => new URL(href, window.location.href);
 
 describe('resolveErrorRoute', () => {
   test('an app path redirect keeps the route and rebuilds its url', () => {
@@ -16,7 +16,7 @@ describe('resolveErrorRoute', () => {
       location: '/next?a=1#frag',
     });
 
-    const errorRoute = resolveErrorRoute(error, attempted('/from'), false);
+    const errorRoute = resolveErrorRoute(error, requested('/from'), false);
 
     expect(errorRoute).toEqual({
       type: 'route',
@@ -35,7 +35,7 @@ describe('resolveErrorRoute', () => {
       location: '/next',
     });
 
-    const errorRoute = resolveErrorRoute(error, attempted('/docs/from'), false);
+    const errorRoute = resolveErrorRoute(error, requested('/docs/from'), false);
 
     expect(errorRoute.type === 'route' && errorRoute.target.path).toBe('/next');
     expect(errorRoute.type === 'route' && errorRoute.url.pathname).toBe(
@@ -49,7 +49,7 @@ describe('resolveErrorRoute', () => {
       location: `${window.location.origin}/next`,
     });
 
-    const errorRoute = resolveErrorRoute(error, attempted('/from'), false);
+    const errorRoute = resolveErrorRoute(error, requested('/from'), false);
 
     expect(errorRoute.type === 'route' && errorRoute.target.path).toBe('/next');
   });
@@ -61,7 +61,7 @@ describe('resolveErrorRoute', () => {
       unstable_redirected: true,
     });
 
-    const errorRoute = resolveErrorRoute(error, attempted('/from'), false);
+    const errorRoute = resolveErrorRoute(error, requested('/from'), false);
 
     expect(errorRoute.type).toBe('leave');
     expect(errorRoute.type === 'leave' && errorRoute.url.pathname).toBe(
@@ -75,7 +75,7 @@ describe('resolveErrorRoute', () => {
       location: 'https://example.com/next',
     });
 
-    const errorRoute = resolveErrorRoute(error, attempted('/from'), false);
+    const errorRoute = resolveErrorRoute(error, requested('/from'), false);
 
     expect(errorRoute).toEqual({ type: 'leave', url: expect.any(URL) });
     expect(errorRoute.type === 'leave' && errorRoute.url.href).toBe(
@@ -89,7 +89,7 @@ describe('resolveErrorRoute', () => {
       location: '//example.com/next',
     });
 
-    const errorRoute = resolveErrorRoute(error, attempted('/from'), false);
+    const errorRoute = resolveErrorRoute(error, requested('/from'), false);
 
     expect(errorRoute.type).toBe('leave');
   });
@@ -100,7 +100,7 @@ describe('resolveErrorRoute', () => {
       location: 'javascript:alert(1)',
     });
 
-    const errorRoute = resolveErrorRoute(error, attempted('/from'), false);
+    const errorRoute = resolveErrorRoute(error, requested('/from'), false);
 
     expect(errorRoute).toEqual({
       type: 'unfollowable',
@@ -108,12 +108,12 @@ describe('resolveErrorRoute', () => {
     });
   });
 
-  test('a 404 goes to the 404 route with the attempted query and url', () => {
+  test('a 404 goes to the 404 route with the requested query and url', () => {
     const error = createCustomError('nf', { status: 404 });
 
     const errorRoute = resolveErrorRoute(
       error,
-      attempted('/missing?foo=bar'),
+      requested('/missing?foo=bar'),
       true,
     );
 
@@ -130,14 +130,14 @@ describe('resolveErrorRoute', () => {
   test('a 404 without a 404 route is not followed', () => {
     const error = createCustomError('nf', { status: 404 });
 
-    expect(resolveErrorRoute(error, attempted('/missing'), false)).toEqual({
+    expect(resolveErrorRoute(error, requested('/missing'), false)).toEqual({
       type: 'none',
     });
   });
 
   test('a plain error is not followed', () => {
     expect(
-      resolveErrorRoute(new Error('boom'), attempted('/from'), true),
+      resolveErrorRoute(new Error('boom'), requested('/from'), true),
     ).toEqual({
       type: 'none',
     });

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -29,7 +29,7 @@ const withRouterState = (
 ) => ({ ...elements, [ROUTER_STATE_ID]: routerState });
 
 describe('makeRouterState', () => {
-  test('captures the url, the attempted route and the intents', () => {
+  test('captures the url, the requested route and the intents', () => {
     const routerState = makeRouterState(
       route('/a', 'x=1'),
       urlOf('/a?x=1#top'),
@@ -41,7 +41,7 @@ describe('makeRouterState', () => {
       },
     );
     expect(routerState.url).toBe('/a?x=1#top');
-    expect(routerState.attempted).toEqual(['/a', 'x=1']);
+    expect(routerState.requested).toEqual(['/a', 'x=1']);
     expect(routerState.history).toBe('push');
     expect(routerState.scroll).toEqual({ pathChanged: true });
     expect(routerState.followCount).toBe(0);
@@ -167,7 +167,7 @@ describe('resolveServerRedirect', () => {
     }
   });
 
-  test('a server redirect to the 404 route keeps the attempted url', () => {
+  test('a server redirect to the 404 route keeps the requested url', () => {
     const routerState = makeRouterState(route('/missing'), urlOf('/missing'), {
       history: 'replace',
       scroll: false,


### PR DESCRIPTION
An instant navigation paints its cached shell before the response, so a #target in the streamed part does not exist yet and the scroll falls back to the top of the page. It now remembers the hash it could not find and aims at it once it shows up, and only while the current route still asks for it. Hash lookup also follows the html spec: an anchor name counts, and #top means the top of the document.

Riding along: RouterState.attempted becomes requested, which is reachable through unstable_RouterContext, the FIXMEs on back and forward go since the popstate handler answers them, plus some naming and memo nits.
