### PR TITLE
breaking: JSDoc policy, unstable_setAllEnv, and minimal *_UNSTABLE APIs

### DIFF
--- a/docs/guides/adapter-authoring.mdx
+++ b/docs/guides/adapter-authoring.mdx
@@ -146,7 +146,7 @@ The callback passed to `createServerEntryAdapter` receives:
 - `handlers`: the original `handleRequest` and `handleBuild` object.
 - `processRequest`: a Waku request processor that returns `Response | null`.
 - `processBuild`: a Waku build processor that emits generated files.
-- `setAllEnv`: updates Waku's server-side environment map.
+- `unstable_setAllEnv`: updates Waku's server-side environment map.
 - `config`: resolved Waku config without the Vite config.
 - `isBuild`: `true` while Vite is running the build environment.
 - `notFoundHtml`: prerendered not-found HTML, when available.
@@ -162,14 +162,14 @@ The returned server entry can include:
 
 ## Platform Environment Bindings
 
-Some platforms pass environment bindings as extra arguments to `fetch` instead of using `process.env`. Use `setAllEnv` before delegating to Waku so `getEnv()` and related server code see the platform values.
+Some platforms pass environment bindings as extra arguments to `fetch` instead of using `process.env`. Use `unstable_setAllEnv` before delegating to Waku so `getEnv()` and related server code see the platform values.
 
 ```ts
 export default createServerEntryAdapter(
-  ({ processRequest, processBuild, setAllEnv }) => {
+  ({ processRequest, processBuild, unstable_setAllEnv }) => {
     return {
       fetch: async (req: Request, env: Record<string, string>) => {
-        setAllEnv(env);
+        unstable_setAllEnv(env);
         const res = await processRequest(req);
         return res || new Response('Not Found', { status: 404 });
       },
@@ -188,11 +188,11 @@ Some runtimes need the module's default export to have a platform-specific shape
 ```ts
 export default createServerEntryAdapter(
   (
-    { processRequest, processBuild, setAllEnv },
+    { processRequest, processBuild, unstable_setAllEnv },
     options?: { handlers?: Record<string, unknown> },
   ) => {
     const fetch = async (req: Request, env: Record<string, string>) => {
-      setAllEnv(env);
+      unstable_setAllEnv(env);
       const res = await processRequest(req);
       return res || new Response('Not Found', { status: 404 });
     };

--- a/docs/guides/csp.mdx
+++ b/docs/guides/csp.mdx
@@ -94,7 +94,7 @@ If your adapter allows you to customize `handleRequest`, you can pass it manuall
 
 ```tsx
 import adapter from 'waku/adapters/default';
-import { Slot } from 'waku/minimal/client';
+import { Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import App from './components/App.js';
 import { encodeBase64 } from 'hono/utils/encode';
 

--- a/docs/guides/custom-router.mdx
+++ b/docs/guides/custom-router.mdx
@@ -48,7 +48,10 @@ Then define the server router in `src/waku.server.tsx`:
 ```tsx
 // src/waku.server.tsx
 import adapter from 'waku/adapters/default';
-import { Children_UNSTABLE as Children, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Children_UNSTABLE as Children,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 import { unstable_defineRouter as defineRouter } from 'waku/router/server';
 import AppLayout from './components/app-layout';
 import HomePage from './components/home-page';

--- a/docs/guides/custom-router.mdx
+++ b/docs/guides/custom-router.mdx
@@ -48,7 +48,7 @@ Then define the server router in `src/waku.server.tsx`:
 ```tsx
 // src/waku.server.tsx
 import adapter from 'waku/adapters/default';
-import { Children, Slot } from 'waku/minimal/client';
+import { Children_UNSTABLE as Children, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import { unstable_defineRouter as defineRouter } from 'waku/router/server';
 import AppLayout from './components/app-layout';
 import HomePage from './components/home-page';

--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -39,7 +39,8 @@ The minimal API is small, but it exposes both server-side handlers and client-si
 | `waku/minimal/client` | `useRefetch_UNSTABLE`        | Fetching and merging another RSC payload.                             |
 | `waku/minimal/client` | `unstable_*` helpers         | Building router-like abstractions.                                    |
 
-Examples below often import these as shorter names.
+Examples below often import these as shorter names. Deprecated aliases without
+the `_UNSTABLE` suffix still exist for one migration window.
 This guide does not document every exported helper from `waku/minimal/client`;
 undocumented exports are for Waku internals or custom integrations.
 

--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -23,7 +23,7 @@ If you are building an application, use `waku/router` instead. The minimal API d
 
 If you need programmatic routing while keeping Waku's router behavior, see the [`createPages` reference](/create-pages) or [Custom Router](/guides/custom-router). If you are implementing a deployment/runtime adapter, start with [Adapter Authoring](/guides/adapter-authoring).
 
-All `unstable_*` exports in this document are genuinely unstable and may change.
+Exports marked `unstable_*` or `*_UNSTABLE` in this document may still change.
 
 ### API Surface
 
@@ -33,14 +33,14 @@ The minimal API is small, but it exposes both server-side handlers and client-si
 | --------------------- | ---------------------------- | --------------------------------------------------------------------- |
 | `waku/minimal/server` | `unstable_defineHandlers`    | Defining `handleRequest` and `handleBuild`.                           |
 | `waku/minimal/server` | `unstable_defineServerEntry` | Writing server entries directly, usually for adapters.                |
-| `waku/minimal/client` | `Root`                       | Installing the minimal client runtime.                                |
-| `waku/minimal/client` | `Slot`                       | Rendering a server element by RSC ID.                                 |
-| `waku/minimal/client` | `Children`                   | Placing client-side `Slot` children inside a server-rendered element. |
-| `waku/minimal/client` | `useRefetch`                 | Fetching and merging another RSC payload.                             |
+| `waku/minimal/client` | `Root_UNSTABLE`              | Installing the minimal client runtime.                                |
+| `waku/minimal/client` | `Slot_UNSTABLE`              | Rendering a server element by RSC ID.                                 |
+| `waku/minimal/client` | `Children_UNSTABLE`          | Placing client-side `Slot` children inside a server-rendered element. |
+| `waku/minimal/client` | `useRefetch_UNSTABLE`        | Fetching and merging another RSC payload.                             |
 | `waku/minimal/client` | `unstable_*` helpers         | Building router-like abstractions.                                    |
 
-`Root`, `Slot`, `Children`, and `useRefetch` are the primary minimal client
-primitives; the `_UNSTABLE` export suffix marks that they may still change.
+Examples below often import these as shorter names. Deprecated aliases without
+the `_UNSTABLE` suffix still exist for one migration window.
 This guide does not document every exported helper from `waku/minimal/client`;
 undocumented exports are for Waku internals or custom integrations.
 
@@ -132,7 +132,10 @@ export default adapter(handlers);
 ```tsx
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>
@@ -434,7 +437,10 @@ A standard bootstrap looks like this:
 ```tsx
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -39,7 +39,10 @@ The minimal API is small, but it exposes both server-side handlers and client-si
 | `waku/minimal/client` | `useRefetch`                 | Fetching and merging another RSC payload.                             |
 | `waku/minimal/client` | `unstable_*` helpers         | Building router-like abstractions.                                    |
 
-`Root`, `Slot`, and `Children` are the stable minimal client primitives. This guide does not document every exported helper from `waku/minimal/client`; undocumented exports are for Waku internals or custom integrations and should be treated as unstable.
+`Root`, `Slot`, `Children`, and `useRefetch` are the primary minimal client
+primitives; the `_UNSTABLE` export suffix marks that they may still change.
+This guide does not document every exported helper from `waku/minimal/client`;
+undocumented exports are for Waku internals or custom integrations.
 
 ### Mental Model
 
@@ -87,7 +90,7 @@ A minimal SSR setup has two entry points:
 ```tsx
 import { unstable_defineHandlers as defineHandlers } from 'waku/minimal/server';
 import adapter from 'waku/adapters/default';
-import { Slot } from 'waku/minimal/client';
+import { Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import App from './components/App.js';
 
 const handlers = defineHandlers({
@@ -129,7 +132,7 @@ export default adapter(handlers);
 ```tsx
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>
@@ -408,7 +411,7 @@ The minimal client API lives in `waku/minimal/client`.
 `Root` is the top-level provider for the minimal client runtime.
 
 ```tsx
-import { Root } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root } from 'waku/minimal/client';
 ```
 
 Props:
@@ -431,7 +434,7 @@ A standard bootstrap looks like this:
 ```tsx
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>
@@ -453,7 +456,7 @@ if ((globalThis as any).__WAKU_HYDRATE__) {
 `Slot` renders a server element by RSC ID.
 
 ```tsx
-import { Slot } from 'waku/minimal/client';
+import { Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 ```
 
 ```tsx
@@ -473,11 +476,13 @@ Rules:
 
 `Children` lets a server element render the client children passed to `Slot`.
 
+```tsx
+import { Children_UNSTABLE as Children } from 'waku/minimal/client';
+```
+
 Server:
 
 ```tsx
-import { Children } from 'waku/minimal/client';
-
 return renderRsc({
   App: (
     <App>
@@ -497,9 +502,9 @@ Client:
 
 This is useful for nested layouts and composition patterns where the server tree decides where client-provided children should appear.
 
-#### `useRefetch()`
+#### `useRefetch`
 
-`useRefetch()` returns a function that fetches a new RSC payload and merges it into the current element map:
+`useRefetch` returns a function that fetches a new RSC payload and merges it into the current element map:
 
 ```tsx
 refetch(
@@ -513,7 +518,7 @@ Example:
 
 ```tsx
 import { useTransition } from 'react';
-import { useRefetch } from 'waku/minimal/client';
+import { useRefetch_UNSTABLE as useRefetch } from 'waku/minimal/client';
 
 const Counter = () => {
   const [isPending, startTransition] = useTransition();

--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -39,8 +39,7 @@ The minimal API is small, but it exposes both server-side handlers and client-si
 | `waku/minimal/client` | `useRefetch_UNSTABLE`        | Fetching and merging another RSC payload.                             |
 | `waku/minimal/client` | `unstable_*` helpers         | Building router-like abstractions.                                    |
 
-Examples below often import these as shorter names. Deprecated aliases without
-the `_UNSTABLE` suffix still exist for one migration window.
+Examples below often import these as shorter names.
 This guide does not document every exported helper from `waku/minimal/client`;
 undocumented exports are for Waku internals or custom integrations.
 

--- a/e2e/fixtures/define-router/src/waku.server.tsx
+++ b/e2e/fixtures/define-router/src/waku.server.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { readFile } from 'node:fs/promises';
 // NOTE: I think we need one spec to use non-default adapter
 import adapter from 'waku/adapters/node';
-import { Children, Slot } from 'waku/minimal/client';
+import { Children_UNSTABLE as Children, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import {
   unstable_defineRouter as defineRouter,
   unstable_redirect as redirect,

--- a/e2e/fixtures/define-router/src/waku.server.tsx
+++ b/e2e/fixtures/define-router/src/waku.server.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from 'react';
 import { readFile } from 'node:fs/promises';
 // NOTE: I think we need one spec to use non-default adapter
 import adapter from 'waku/adapters/node';
-import { Children_UNSTABLE as Children, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Children_UNSTABLE as Children,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 import {
   unstable_defineRouter as defineRouter,
   unstable_redirect as redirect,

--- a/e2e/fixtures/minimal-examples/src/components/App.tsx
+++ b/e2e/fixtures/minimal-examples/src/components/App.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Children } from 'waku/minimal/client';
+import { Children_UNSTABLE as Children } from 'waku/minimal/client';
 import { CookieInfo } from './CookieInfo';
 import { Island } from './Island';
 import { JotaiApp } from './JotaiApp';

--- a/e2e/fixtures/minimal-examples/src/components/Island.tsx
+++ b/e2e/fixtures/minimal-examples/src/components/Island.tsx
@@ -3,9 +3,9 @@
 import { use, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import {
-  Slot,
+  Slot_UNSTABLE as Slot,
   useElementsPromise_UNSTABLE as useElementsPromise,
-  useRefetch,
+  useRefetch_UNSTABLE as useRefetch,
 } from 'waku/minimal/client';
 import { Counter } from './Counter';
 

--- a/e2e/fixtures/minimal-examples/src/waku.client.tsx
+++ b/e2e/fixtures/minimal-examples/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/minimal-examples/src/waku.client.tsx
+++ b/e2e/fixtures/minimal-examples/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/minimal-examples/src/waku.server.tsx
+++ b/e2e/fixtures/minimal-examples/src/waku.server.tsx
@@ -3,7 +3,10 @@ import fs from 'node:fs/promises';
 import * as cookie from 'cookie';
 import { contextStorage } from 'hono/context-storage';
 import adapter from 'waku/adapters/default';
-import { Children_UNSTABLE as Children, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Children_UNSTABLE as Children,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 import { DynamicIsland } from './components/DynamicIsland';
 // eslint-disable-next-line import/no-unresolved
 import { App } from '@/components/App';

--- a/e2e/fixtures/minimal-examples/src/waku.server.tsx
+++ b/e2e/fixtures/minimal-examples/src/waku.server.tsx
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import * as cookie from 'cookie';
 import { contextStorage } from 'hono/context-storage';
 import adapter from 'waku/adapters/default';
-import { Children, Slot } from 'waku/minimal/client';
+import { Children_UNSTABLE as Children, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import { DynamicIsland } from './components/DynamicIsland';
 // eslint-disable-next-line import/no-unresolved
 import { App } from '@/components/App';

--- a/e2e/fixtures/rsc-asset/src/waku.client.tsx
+++ b/e2e/fixtures/rsc-asset/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/rsc-asset/src/waku.client.tsx
+++ b/e2e/fixtures/rsc-asset/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/rsc-basic/src/components/ClientCounter.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ClientCounter.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react';
 import { unstable_allowServer as allowServer } from 'waku/client';
-import { useRefetch } from 'waku/minimal/client';
+import { useRefetch_UNSTABLE as useRefetch } from 'waku/minimal/client';
 import { ClientBox } from './Box.js';
 
 export const ClientCounter = ({ params }: { params: unknown }) => {

--- a/e2e/fixtures/rsc-basic/src/waku.client.tsx
+++ b/e2e/fixtures/rsc-basic/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/rsc-basic/src/waku.client.tsx
+++ b/e2e/fixtures/rsc-basic/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/rsc-css-modules/src/waku.client.tsx
+++ b/e2e/fixtures/rsc-css-modules/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/rsc-css-modules/src/waku.client.tsx
+++ b/e2e/fixtures/rsc-css-modules/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-basic/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-basic/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 let rscPath = '';
 let slotId = 'App';

--- a/e2e/fixtures/ssr-basic/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-basic/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 let rscPath = '';
 let slotId = 'App';

--- a/e2e/fixtures/ssr-basic/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-basic/src/waku.server.tsx
@@ -1,5 +1,5 @@
 import adapter from 'waku/adapters/default';
-import { Slot } from 'waku/minimal/client';
+import { Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import App from './components/App.js';
 import { MixedForms, receivePlainPost } from './components/MixedForms.js';
 import TestApp from './components/test-app.js';

--- a/e2e/fixtures/ssr-context-provider/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-context-provider/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-context-provider/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-context-provider/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-context-provider/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-context-provider/src/waku.server.tsx
@@ -1,5 +1,5 @@
 import adapter from 'waku/adapters/default';
-import { Slot } from 'waku/minimal/client';
+import { Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import App from './components/app.js';
 
 export default adapter({

--- a/e2e/fixtures/ssr-nonce/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-nonce/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-nonce/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-nonce/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-nonce/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-nonce/src/waku.server.tsx
@@ -1,5 +1,5 @@
 import adapter from 'waku/adapters/default';
-import { Slot } from 'waku/minimal/client';
+import { Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import App from './components/App.js';
 
 // Fixed nonce for testing purposes

--- a/e2e/fixtures/ssr-swr/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-swr/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-swr/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-swr/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-swr/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-swr/src/waku.server.tsx
@@ -1,5 +1,5 @@
 import adapter from 'waku/adapters/default';
-import { Slot } from 'waku/minimal/client';
+import { Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import App from './components/App.js';
 
 export default adapter({

--- a/e2e/fixtures/ssr-target-bundle/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-target-bundle/src/waku.client.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
+import {
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
+} from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-target-bundle/src/waku.client.tsx
+++ b/e2e/fixtures/ssr-target-bundle/src/waku.client.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
-import { Root, Slot } from 'waku/minimal/client';
+import { Root_UNSTABLE as Root, Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/ssr-target-bundle/src/waku.server.tsx
+++ b/e2e/fixtures/ssr-target-bundle/src/waku.server.tsx
@@ -1,5 +1,5 @@
 import adapter from 'waku/adapters/default';
-import { Slot } from 'waku/minimal/client';
+import { Slot_UNSTABLE as Slot } from 'waku/minimal/client';
 import App from './components/App.js';
 
 export default adapter({

--- a/packages/create-waku/src/helpers/example-option.ts
+++ b/packages/create-waku/src/helpers/example-option.ts
@@ -20,12 +20,9 @@ async function isUrlOk(url: string): Promise<boolean> {
   }
 }
 
-/**
- * this is a part of the response type for github "Get a repository" API
- * @see {@link https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository|GitHub REST API}
- */
+// Part of the GitHub "Get a repository" API response type.
+// https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
 interface GetRepoInfo {
-  /** A default branch of the repository */
   default_branch: string;
 }
 async function getRepoInfo(url: URL): Promise<RepoInfo | undefined> {

--- a/packages/waku/src/adapters/cloudflare.ts
+++ b/packages/waku/src/adapters/cloudflare.ts
@@ -64,7 +64,7 @@ function removeGzipEncoding(res: Response): Response {
 
 export default createServerEntryAdapter(
   (
-    { processRequest, processBuild, setAllEnv, config, notFoundHtml },
+    { processRequest, processBuild, unstable_setAllEnv, config, notFoundHtml },
     options?: {
       static?: boolean;
       handlers?: Record<string, unknown>;
@@ -190,7 +190,7 @@ export default createServerEntryAdapter(
       defaultExport: {
         ...options?.handlers,
         fetch(req: Request, env: Record<string, unknown>) {
-          setAllEnv(env);
+          unstable_setAllEnv(env);
           return fetchFn(req);
         },
       },

--- a/packages/waku/src/adapters/cloudflare.ts
+++ b/packages/waku/src/adapters/cloudflare.ts
@@ -64,7 +64,7 @@ function removeGzipEncoding(res: Response): Response {
 
 export default createServerEntryAdapter(
   (
-    { processRequest, processBuild, setAllEnv, config, notFoundHtml },
+    { processRequest, processBuild, INTERNAL_setAllEnv, config, notFoundHtml },
     options?: {
       static?: boolean;
       handlers?: Record<string, unknown>;
@@ -190,7 +190,7 @@ export default createServerEntryAdapter(
       defaultExport: {
         ...options?.handlers,
         fetch(req: Request, env: Record<string, unknown>) {
-          setAllEnv(env);
+          INTERNAL_setAllEnv(env);
           return fetchFn(req);
         },
       },

--- a/packages/waku/src/adapters/cloudflare.ts
+++ b/packages/waku/src/adapters/cloudflare.ts
@@ -64,7 +64,7 @@ function removeGzipEncoding(res: Response): Response {
 
 export default createServerEntryAdapter(
   (
-    { processRequest, processBuild, INTERNAL_setAllEnv, config, notFoundHtml },
+    { processRequest, processBuild, setAllEnv, config, notFoundHtml },
     options?: {
       static?: boolean;
       handlers?: Record<string, unknown>;
@@ -190,7 +190,7 @@ export default createServerEntryAdapter(
       defaultExport: {
         ...options?.handlers,
         fetch(req: Request, env: Record<string, unknown>) {
-          INTERNAL_setAllEnv(env);
+          setAllEnv(env);
           return fetchFn(req);
         },
       },

--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -1,13 +1,9 @@
 import { getErrorInfo } from './lib/utils/custom-errors.js';
 
-/**
- * Experimental, the name and the behavior might change.
- */
+// Experimental, the name and the behavior might change.
 export const unstable_allowServer = <T>(x: T) => x;
 
-/**
- * Unsure if this is going to be a public API in the future.
- */
+// Unsure if this is going to be a public API in the future.
 export const unstable_defaultRootOptions = {
   onCaughtError(error: unknown) {
     if (getErrorInfo(error)) {

--- a/packages/waku/src/lib/env.ts
+++ b/packages/waku/src/lib/env.ts
@@ -1,10 +1,7 @@
 // The use of `globalThis` in this file is more or less a hack.
 // It should be revisited with a better solution.
 
-/**
- * This is an internal function and not for public use.
- */
-export function setAllEnv(newEnv: Readonly<Record<string, unknown>>) {
+export function INTERNAL_setAllEnv(newEnv: Readonly<Record<string, unknown>>) {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(newEnv)) {
     if (typeof value === 'string') {

--- a/packages/waku/src/lib/env.ts
+++ b/packages/waku/src/lib/env.ts
@@ -1,7 +1,7 @@
 // The use of `globalThis` in this file is more or less a hack.
 // It should be revisited with a better solution.
 
-export function INTERNAL_setAllEnv(newEnv: Readonly<Record<string, unknown>>) {
+export function unstable_setAllEnv(newEnv: Readonly<Record<string, unknown>>) {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(newEnv)) {
     if (typeof value === 'string') {

--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -105,7 +105,7 @@ export type Unstable_CreateServerEntryAdapter = <Options>(
       handlers: Unstable_Handlers;
       processRequest: Unstable_ProcessRequest;
       processBuild: Unstable_ProcessBuild;
-      setAllEnv: (newEnv: Readonly<Record<string, unknown>>) => void;
+      unstable_setAllEnv: (newEnv: Readonly<Record<string, unknown>>) => void;
       config: Omit<Required<Config>, 'vite'>;
       isBuild: boolean;
       notFoundHtml: string;

--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -105,7 +105,7 @@ export type Unstable_CreateServerEntryAdapter = <Options>(
       handlers: Unstable_Handlers;
       processRequest: Unstable_ProcessRequest;
       processBuild: Unstable_ProcessBuild;
-      INTERNAL_setAllEnv: (newEnv: Readonly<Record<string, unknown>>) => void;
+      setAllEnv: (newEnv: Readonly<Record<string, unknown>>) => void;
       config: Omit<Required<Config>, 'vite'>;
       isBuild: boolean;
       notFoundHtml: string;

--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -105,7 +105,7 @@ export type Unstable_CreateServerEntryAdapter = <Options>(
       handlers: Unstable_Handlers;
       processRequest: Unstable_ProcessRequest;
       processBuild: Unstable_ProcessBuild;
-      setAllEnv: (newEnv: Readonly<Record<string, unknown>>) => void;
+      INTERNAL_setAllEnv: (newEnv: Readonly<Record<string, unknown>>) => void;
       config: Omit<Required<Config>, 'vite'>;
       isBuild: boolean;
       notFoundHtml: string;

--- a/packages/waku/src/lib/vite-entries/entry.build.ts
+++ b/packages/waku/src/lib/vite-entries/entry.build.ts
@@ -1,5 +1,5 @@
 import serverEntry from 'virtual:vite-rsc-waku/server-entry';
-import { INTERNAL_setAllEnv } from '../env.js';
+import { unstable_setAllEnv } from '../env.js';
 import type { Unstable_EmitFile } from '../types.js';
 import { joinPath } from '../utils/path.js';
 
@@ -31,7 +31,7 @@ export async function INTERNAL_runBuild({
   rootDir: string;
   emitFile: Unstable_EmitFile;
 }) {
-  INTERNAL_setAllEnv(process.env);
+  unstable_setAllEnv(process.env);
   const prunableFiles = new Set<string>();
   let build = serverEntry.build;
   for (const enhancer of serverEntry.buildEnhancers || []) {

--- a/packages/waku/src/lib/vite-entries/entry.build.ts
+++ b/packages/waku/src/lib/vite-entries/entry.build.ts
@@ -1,5 +1,5 @@
 import serverEntry from 'virtual:vite-rsc-waku/server-entry';
-import { setAllEnv } from '../env.js';
+import { INTERNAL_setAllEnv } from '../env.js';
 import type { Unstable_EmitFile } from '../types.js';
 import { joinPath } from '../utils/path.js';
 
@@ -31,7 +31,7 @@ export async function INTERNAL_runBuild({
   rootDir: string;
   emitFile: Unstable_EmitFile;
 }) {
-  setAllEnv(process.env);
+  INTERNAL_setAllEnv(process.env);
   const prunableFiles = new Set<string>();
   let build = serverEntry.build;
   for (const enhancer of serverEntry.buildEnhancers || []) {

--- a/packages/waku/src/lib/vite-entries/entry.server.tsx
+++ b/packages/waku/src/lib/vite-entries/entry.server.tsx
@@ -1,5 +1,5 @@
 import serverEntry from 'virtual:vite-rsc-waku/server-entry';
-import { INTERNAL_setAllEnv } from '../env.js';
+import { unstable_setAllEnv } from '../env.js';
 
 export { serverEntry as unstable_serverEntry };
 
@@ -8,7 +8,7 @@ export async function INTERNAL_runFetch(
   req: Request,
   ...args: any[]
 ) {
-  INTERNAL_setAllEnv(env);
+  unstable_setAllEnv(env);
   return serverEntry.fetch(req, ...args);
 }
 

--- a/packages/waku/src/lib/vite-entries/entry.server.tsx
+++ b/packages/waku/src/lib/vite-entries/entry.server.tsx
@@ -1,5 +1,5 @@
 import serverEntry from 'virtual:vite-rsc-waku/server-entry';
-import { setAllEnv } from '../env.js';
+import { INTERNAL_setAllEnv } from '../env.js';
 
 export { serverEntry as unstable_serverEntry };
 
@@ -8,7 +8,7 @@ export async function INTERNAL_runFetch(
   req: Request,
   ...args: any[]
 ) {
-  setAllEnv(env);
+  INTERNAL_setAllEnv(env);
   return serverEntry.fetch(req, ...args);
 }
 

--- a/packages/waku/src/lib/vite-rsc/handler.ts
+++ b/packages/waku/src/lib/vite-rsc/handler.ts
@@ -10,7 +10,7 @@ import { buildMetadata } from 'virtual:vite-rsc-waku/build-metadata';
 import { config, isBuild } from 'virtual:vite-rsc-waku/config';
 import notFoundHtml from 'virtual:vite-rsc-waku/not-found';
 import { BUILD_METADATA_FILE, DIST_PUBLIC, DIST_SERVER } from '../constants.js';
-import { setAllEnv } from '../env.js';
+import { INTERNAL_setAllEnv } from '../env.js';
 import type {
   Unstable_CreateServerEntryAdapter as CreateServerEntryAdapter,
   Unstable_HandleBuild as HandleBuild,
@@ -178,7 +178,7 @@ export const createServerEntryAdapter: CreateServerEntryAdapter =
         handlers,
         processRequest,
         processBuild,
-        setAllEnv,
+        INTERNAL_setAllEnv,
         config,
         isBuild,
         notFoundHtml,

--- a/packages/waku/src/lib/vite-rsc/handler.ts
+++ b/packages/waku/src/lib/vite-rsc/handler.ts
@@ -10,7 +10,7 @@ import { buildMetadata } from 'virtual:vite-rsc-waku/build-metadata';
 import { config, isBuild } from 'virtual:vite-rsc-waku/config';
 import notFoundHtml from 'virtual:vite-rsc-waku/not-found';
 import { BUILD_METADATA_FILE, DIST_PUBLIC, DIST_SERVER } from '../constants.js';
-import { INTERNAL_setAllEnv } from '../env.js';
+import { unstable_setAllEnv } from '../env.js';
 import type {
   Unstable_CreateServerEntryAdapter as CreateServerEntryAdapter,
   Unstable_HandleBuild as HandleBuild,
@@ -178,7 +178,7 @@ export const createServerEntryAdapter: CreateServerEntryAdapter =
         handlers,
         processRequest,
         processBuild,
-        setAllEnv: INTERNAL_setAllEnv,
+        unstable_setAllEnv,
         config,
         isBuild,
         notFoundHtml,

--- a/packages/waku/src/lib/vite-rsc/handler.ts
+++ b/packages/waku/src/lib/vite-rsc/handler.ts
@@ -178,7 +178,7 @@ export const createServerEntryAdapter: CreateServerEntryAdapter =
         handlers,
         processRequest,
         processBuild,
-        INTERNAL_setAllEnv,
+        setAllEnv: INTERNAL_setAllEnv,
         config,
         isBuild,
         notFoundHtml,

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -587,11 +587,8 @@ const ElementsContext = createContext<Promise<Elements> | null>(null);
 /**
  * Client root. Seeds the initial elements, bridges the store to React state,
  * and provides the elements to `Slot` descendants.
- *
- * This API is technically unstable and may change or be removed,
- * even though it does not carry the `unstable_` prefix.
  */
-export const Root = ({
+export const Root_UNSTABLE = ({
   initialRscPath,
   initialRscParams,
   children,
@@ -663,22 +660,16 @@ export const Root = ({
   );
 };
 
-/**
- * This API is technically unstable and may change or be removed,
- * even though it does not carry the `unstable_` prefix.
- */
-export const useRefetch = () => use(RefetchContext);
+/** Fetch and merge another RSC payload into the current element map. */
+export const useRefetch_UNSTABLE = () => use(RefetchContext);
 
 export const useMergeElements_UNSTABLE = () => use(MergeElementsContext);
 
 const ChildrenContext = createContext<ReactNode>(undefined);
 const ChildrenContextProvider = memo(ChildrenContext);
 
-/**
- * This API is technically unstable and may change or be removed,
- * even though it does not carry the `unstable_` prefix.
- */
-export const Children = () => use(ChildrenContext);
+/** Render the client children passed to the enclosing Slot. */
+export const Children_UNSTABLE = () => use(ChildrenContext);
 
 export const useElementsPromise_UNSTABLE = () => {
   const elementsPromise = use(ElementsContext);
@@ -701,11 +692,8 @@ export const useElementsPromise_UNSTABLE = () => {
  * ```
  *   <Root><Slot id="foo" /><Slot id="bar" /></Root>
  * ```
- *
- * This API is technically unstable and may change or be removed,
- * even though it does not carry the `unstable_` prefix.
  */
-export const Slot = ({
+export const Slot_UNSTABLE = ({
   id,
   children,
 }: {
@@ -729,10 +717,6 @@ export const Slot = ({
   );
 };
 
-/**
- * ServerRoot for SSR
- * This is not a public API.
- */
 export const INTERNAL_ServerRoot = ({
   elementsPromise,
   children,

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -717,15 +717,6 @@ export const Slot_UNSTABLE = ({
   );
 };
 
-/** @deprecated Use `Root_UNSTABLE`. */
-export const Root = Root_UNSTABLE;
-/** @deprecated Use `Slot_UNSTABLE`. */
-export const Slot = Slot_UNSTABLE;
-/** @deprecated Use `Children_UNSTABLE`. */
-export const Children = Children_UNSTABLE;
-/** @deprecated Use `useRefetch_UNSTABLE`. */
-export const useRefetch = useRefetch_UNSTABLE;
-
 export const INTERNAL_ServerRoot = ({
   elementsPromise,
   children,

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -717,6 +717,15 @@ export const Slot_UNSTABLE = ({
   );
 };
 
+/** @deprecated Use `Root_UNSTABLE`. */
+export const Root = Root_UNSTABLE;
+/** @deprecated Use `Slot_UNSTABLE`. */
+export const Slot = Slot_UNSTABLE;
+/** @deprecated Use `Children_UNSTABLE`. */
+export const Children = Children_UNSTABLE;
+/** @deprecated Use `useRefetch_UNSTABLE`. */
+export const useRefetch = useRefetch_UNSTABLE;
+
 export const INTERNAL_ServerRoot = ({
   elementsPromise,
   children,

--- a/packages/waku/src/router/client-utils/prefetch-cache.ts
+++ b/packages/waku/src/router/client-utils/prefetch-cache.ts
@@ -7,7 +7,9 @@ type Elements = Record<string | symbol, unknown>;
 export type PrefetchMode = 'always' | 'once';
 
 export type PrefetchOptions = {
+  /** Default: dedupe by TTL only. `'once'` also skips if this path was already stored. */
   mode?: PrefetchMode;
+  /** Milliseconds; defaults to `PREFETCH_TTL`. */
   ttl?: number;
 };
 
@@ -31,7 +33,6 @@ export const PREFETCH_LIMIT = 100;
 const prefetchCacheKey = (rscPath: string, query: string): string =>
   rscPath + '\0' + query;
 
-/** Return a still-fresh entry for the key, evicting it if it has expired. */
 const getPrefetch = (
   cache: PrefetchCache,
   key: string,
@@ -45,7 +46,6 @@ const getPrefetch = (
   return entry;
 };
 
-/** Insert an entry, evicting the oldest ones once the size limit is reached. */
 const setPrefetch = (
   cache: PrefetchCache,
   key: string,
@@ -61,7 +61,6 @@ const setPrefetch = (
   cache.set(key, entry);
 };
 
-/** Reserve a route in the store while its first prefetch is in flight. */
 const reservePrefetchedElements = (
   store: PrefetchedElementsStore,
   rscPath: string,
@@ -78,7 +77,6 @@ const reservePrefetchedElements = (
   store.set(rscPath, null);
 };
 
-/** Release a reservation that was never fulfilled. */
 const releasePrefetchedElements = (
   store: PrefetchedElementsStore,
   rscPath: string,
@@ -88,7 +86,6 @@ const releasePrefetchedElements = (
   }
 };
 
-/** Merge a prefetched response into the session store. */
 const mergePrefetchedElements = (
   store: PrefetchedElementsStore,
   rscPath: string,
@@ -99,7 +96,6 @@ const mergePrefetchedElements = (
   store.set(rscPath, existing ? { ...existing, ...elements } : elements);
 };
 
-/** One store for prefetched routes; the router does not see the two caches. */
 type PrefetchManager = {
   prefetch: (
     rscPath: string,
@@ -129,7 +125,6 @@ export const createPrefetchManager = (): PrefetchManager => {
   };
 };
 
-/** Start a prefetch unless the mode or an entry within its ttl dedupes it. */
 const startPrefetch = (
   cache: PrefetchCache,
   store: PrefetchedElementsStore,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -26,8 +26,8 @@ import type {
 } from 'react';
 import { preloadModule } from 'react-dom';
 import {
-  Root,
-  Slot,
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
   unstable_addBase as addBase,
   unstable_getErrorInfo as getErrorInfo,
   unstable_isImmutableElement as isImmutableElement,
@@ -37,7 +37,7 @@ import {
   unstable_upsertRscReloadListener as upsertRscReloadListener,
   useElementsPromise_UNSTABLE as useElementsPromise,
   useMergeElements_UNSTABLE as useMergeElements,
-  useRefetch,
+  useRefetch_UNSTABLE as useRefetch,
 } from '../minimal/client.js';
 import {
   getRouteFromElements,
@@ -998,7 +998,6 @@ export function Slice({
     }
   }, [fetchingSlices, refetch, id, needsToFetchSlice]);
   if (props.lazy && !(slotId in elements)) {
-    // FIXME the fallback doesn't show on refetch after the first one.
     return props.fallback;
   }
   return <Slot id={slotId}>{children}</Slot>;
@@ -1122,8 +1121,7 @@ const InnerRouter = ({
     createRouteChangeListeners,
   );
 
-  // FIXME this "fetchingSlices" hack feels suboptimal.
-  // state, not a ref: it is read during render
+  // state, not a ref: it is read during render (passed through context)
   const [fetchingSlices] = useState(() => new Set<SliceId>());
   const pendingNavigationRef = useRef<{
     controller: AbortController;
@@ -1394,10 +1392,6 @@ const MOCK_ROUTE_CHANGE_LISTENER: Record<
   off: () => notAvailableInServer('routeChange:off'),
 };
 
-/**
- * ServerRouter for SSR
- * This is not a public API.
- */
 export function INTERNAL_ServerRouter({ route }: { route: RouteProps }) {
   const routeElement = <Slot id={getRouteSlotId(route.path)} />;
   const rootElement = <Slot id="root">{routeElement}</Slot>;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -998,6 +998,7 @@ export function Slice({
     }
   }, [fetchingSlices, refetch, id, needsToFetchSlice]);
   if (props.lazy && !(slotId in elements)) {
+    // FIXME the fallback doesn't show on refetch after the first one.
     return props.fallback;
   }
   return <Slot id={slotId}>{children}</Slot>;

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -1,6 +1,9 @@
 import { createElement } from 'react';
 import type { FunctionComponent, ReactElement, ReactNode } from 'react';
-import { Children_UNSTABLE as Children, Slot_UNSTABLE as Slot } from '../minimal/client.js';
+import {
+  Children_UNSTABLE as Children,
+  Slot_UNSTABLE as Slot,
+} from '../minimal/client.js';
 import {
   unstable_createCustomError as createCustomError,
   unstable_getGrouplessPath as getGrouplessPath,

--- a/packages/waku/src/router/create-pages.tsx
+++ b/packages/waku/src/router/create-pages.tsx
@@ -1,6 +1,6 @@
 import { createElement } from 'react';
 import type { FunctionComponent, ReactElement, ReactNode } from 'react';
-import { Children, Slot } from '../minimal/client.js';
+import { Children_UNSTABLE as Children, Slot_UNSTABLE as Slot } from '../minimal/client.js';
 import {
   unstable_createCustomError as createCustomError,
   unstable_getGrouplessPath as getGrouplessPath,
@@ -102,11 +102,7 @@ const forEachConcreteStaticPath = (
 
 // createPages API (a wrapper around unstable_defineRouter)
 
-/** Assumes that the path is a part of a slug path. */
 type IsValidPathItem<T> = T extends `/${string}` | '[]' | '' ? false : true;
-/**
- * This is a helper type to check if a path is valid in a slug path.
- */
 export type IsValidPathInSlugPath<T> = T extends `/${infer L}/${infer R}`
   ? IsValidPathItem<L> extends true
     ? IsValidPathInSlugPath<`/${R}`>
@@ -114,7 +110,6 @@ export type IsValidPathInSlugPath<T> = T extends `/${infer L}/${infer R}`
   : T extends `/${infer U}`
     ? IsValidPathItem<U>
     : false;
-/** Checks if a particular slug name exists in a path. */
 export type HasSlugInPath<
   T,
   K extends string,
@@ -158,7 +153,6 @@ type StaticSlugRoutePaths<T extends string> =
       ? readonly string[]
       : StaticSlugRoutePathsTuple<T>[];
 
-/** Remove Slug from Path */
 export type PathWithoutSlug<T> = T extends '/'
   ? T
   : IsValidPathInSlugPath<T> extends true
@@ -397,15 +391,6 @@ export type CreateRoot = (
 
 export type CreateInterceptor = (interceptor: HandlerInterceptor) => void;
 
-/**
- * Root component for all pages
- * ```tsx
- *   <html>
- *     <head></head>
- *     <body>{children}</body>
- *   </html>
- * ```
- */
 const DefaultRoot = ({ children }: { children: ReactNode }) => (
   <ErrorBoundary>
     <html>
@@ -559,7 +544,6 @@ export const createPages = <
     dynamicPageEntryByRoutePath.has(path) ||
     wildcardPageEntryByRoutePath.has(path);
 
-  /** Creates a function to map pathname to component props */
   const createPathPropsMapper = (path: string) => {
     const layoutMatchPath = groupedRoutePathByRoutePath.get(path) ?? path;
     const routePathSpec = parsePathWithSlug(layoutMatchPath);
@@ -588,7 +572,6 @@ export const createPages = <
     );
   };
 
-  /** Builds the routeElement renderer from layouts and page slots */
   const buildRouteElement = (
     layouts: { layoutPath: string; layoutIdPath: string }[],
     path: string,
@@ -601,7 +584,6 @@ export const createPages = <
       createNestedElements(layoutElements, <Slot id={getPageSlotId(path)} />);
   };
 
-  /** Renders the root component */
   const renderRoot = () =>
     createElement(
       rootItem ? rootItem.component : DefaultRoot,

--- a/packages/waku/src/router/isomorphic-utils/path-spec.ts
+++ b/packages/waku/src/router/isomorphic-utils/path-spec.ts
@@ -82,14 +82,6 @@ const matchSpecSegment = (
   return true;
 };
 
-// getPathMapping(
-//   [
-//     { type: 'literal', name: 'foo' },
-//     { type: 'group', name: 'a' },
-//   ],
-//   '/foo/bar',
-// );
-// // => { a: 'bar' }
 export const getPathMapping = (
   pathSpec: PathSpec,
   pathname: string,

--- a/packages/waku/src/router/isomorphic-utils/path-spec.ts
+++ b/packages/waku/src/router/isomorphic-utils/path-spec.ts
@@ -30,7 +30,6 @@ export const parsePathWithSlug = (path: string): PathSpec =>
       };
     });
 
-/** Convert a path spec to a string for the path */
 export const pathSpecAsString = (path: PathSpec) => {
   return (
     '/' +
@@ -83,21 +82,14 @@ const matchSpecSegment = (
   return true;
 };
 
-/**
- * Helper function to get the path mapping from the path spec and the pathname.
- *
- * @param pathSpec
- * @param pathname - route as a string
- * @example
- * getPathMapping(
- *   [
- *     { type: 'literal', name: 'foo' },
- *     { type: 'group', name: 'a' },
- *   ],
- *   '/foo/bar',
- * );
- * // => { a: 'bar' }
- */
+// getPathMapping(
+//   [
+//     { type: 'literal', name: 'foo' },
+//     { type: 'group', name: 'a' },
+//   ],
+//   '/foo/bar',
+// );
+// // => { a: 'bar' }
 export const getPathMapping = (
   pathSpec: PathSpec,
   pathname: string,

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -4,7 +4,7 @@ import type { TypeEqual } from 'ts-expect';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MockedFunction } from 'vitest';
 import { getErrorInfo } from '../src/lib/utils/custom-errors.js';
-import { Children } from '../src/minimal/client.js';
+import { Children_UNSTABLE as Children } from '../src/minimal/client.js';
 import type { PathsForPages } from '../src/router/base-types.js';
 import type { GetSlugs } from '../src/router/create-pages-utils/inferred-path-types.js';
 import {

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -17,8 +17,8 @@ import { getErrorInfo } from '../src/lib/utils/custom-errors.js';
 import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import { fetchRscStore } from '../src/minimal/client-utils/fetch-store.js';
 import {
-  Root,
-  Slot,
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
   unstable_callServerRsc,
   unstable_fetchRsc,
   unstable_prefetchRsc,
@@ -26,7 +26,7 @@ import {
   unstable_registerFetchEnhancer,
   unstable_registerFetchRscInputTransformer,
   useElementsPromise_UNSTABLE,
-  useRefetch,
+  useRefetch_UNSTABLE as useRefetch,
 } from '../src/minimal/client.js';
 
 type CallServer = (funcId: string, args: unknown[]) => Promise<unknown>;

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -20,10 +20,10 @@ import {
   fetchRscStore,
 } from '../src/minimal/client-utils/fetch-store.js';
 import {
-  Root,
+  Root_UNSTABLE as Root,
   unstable_isImmutableElement as isImmutableElement,
   unstable_prefetchRsc as prefetchRsc,
-  useRefetch,
+  useRefetch_UNSTABLE as useRefetch,
 } from '../src/minimal/client.js';
 import { unstable_buildElements as buildElements } from '../src/minimal/server.js';
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -20,12 +20,12 @@ import { createCustomError } from '../src/lib/utils/custom-errors.js';
 import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import { fetchRscStore } from '../src/minimal/client-utils/fetch-store.js';
 import {
-  Children,
+  Children_UNSTABLE as Children,
   INTERNAL_ServerRoot,
-  Root,
-  Slot,
+  Root_UNSTABLE as Root,
+  Slot_UNSTABLE as Slot,
   unstable_prefetchRsc as prefetchRsc,
-  useRefetch,
+  useRefetch_UNSTABLE as useRefetch,
 } from '../src/minimal/client.js';
 import { PREFETCH_LIMIT } from '../src/router/client-utils/prefetch-cache.js';
 import {
@@ -283,7 +283,7 @@ vi.mock('../src/minimal/client.js', async () => {
     const valueRef = React.useRef<Record<string, unknown>>(undefined);
     if (!valueRef.current) {
       valueRef.current = {
-        root: React.createElement(actual.Children),
+        root: React.createElement(actual.Children_UNSTABLE),
         ...testHoisted.elements,
       };
     }
@@ -390,7 +390,7 @@ vi.mock('../src/minimal/client.js', async () => {
 
   return {
     ...actual,
-    Root: vi.fn((props: Parameters<typeof actual.Root>[0]) =>
+    Root_UNSTABLE: vi.fn((props: Parameters<typeof actual.Root_UNSTABLE>[0]) =>
       React.createElement(StatefulRoot, props),
     ),
     // The router writes route metadata here when no fetch carries it; route it
@@ -400,7 +400,7 @@ vi.mock('../src/minimal/client.js', async () => {
       return store ? store.applySync : noopMergeElements;
     },
     unstable_prefetchRsc: vi.fn(),
-    useRefetch: vi.fn(useMockRefetch),
+    useRefetch_UNSTABLE: vi.fn(useMockRefetch),
   };
 });
 

--- a/packages/website/src/lib/load-routing.ts
+++ b/packages/website/src/lib/load-routing.ts
@@ -1,9 +1,6 @@
 import { loadCreatePages, loadReadme } from './load-docs';
 
-/**
- * Extracts file-based routing documentation from README.md
- * Returns content from "### Overview" through the end of the Routing section
- */
+// README "## Routing" from "### Overview" through the end of that section.
 export const loadRoutingFileBased = (): string => {
   const readme = loadReadme();
   const routingSectionMatch = readme.match(
@@ -21,10 +18,7 @@ export const loadRoutingFileBased = (): string => {
   return contentAfterOverview.trim();
 };
 
-/**
- * Extracts config-based routing documentation from create-pages.mdx
- * Removes frontmatter and adjusts the main heading
- */
+// create-pages.mdx without frontmatter / main heading (config-based routing docs).
 export const loadRoutingConfigBased = (): string => {
   const createPages = loadCreatePages();
   const withoutFrontmatter = createPages.replace(/^---[\s\S]*?---\n*/, '');
@@ -35,10 +29,7 @@ export const loadRoutingConfigBased = (): string => {
   return withoutMainHeading.trim();
 };
 
-/**
- * Extracts everything before the Routing section from README.md
- * Used to render Introduction, Getting started, and Rendering sections
- */
+// README from "## Introduction" up to (not including) "## Routing".
 export const loadBeforeRouting = (): string => {
   const readme = loadReadme();
   const match = readme.match(/(^## Introduction[\s\S]*?)(?=^## Routing)/m);
@@ -49,10 +40,7 @@ export const loadBeforeRouting = (): string => {
   return content.trim();
 };
 
-/**
- * Extracts everything after the Routing section from README.md
- * Used to render Navigation and all subsequent sections
- */
+// README from the section after "## Routing" to the end.
 export const loadAfterRouting = (): string => {
   const readme = loadReadme();
   const match = readme.match(

--- a/packages/website/src/lib/load-routing.ts
+++ b/packages/website/src/lib/load-routing.ts
@@ -1,6 +1,5 @@
 import { loadCreatePages, loadReadme } from './load-docs';
 
-// README "## Routing" from "### Overview" through the end of that section.
 export const loadRoutingFileBased = (): string => {
   const readme = loadReadme();
   const routingSectionMatch = readme.match(
@@ -18,7 +17,6 @@ export const loadRoutingFileBased = (): string => {
   return contentAfterOverview.trim();
 };
 
-// create-pages.mdx without frontmatter / main heading (config-based routing docs).
 export const loadRoutingConfigBased = (): string => {
   const createPages = loadCreatePages();
   const withoutFrontmatter = createPages.replace(/^---[\s\S]*?---\n*/, '');
@@ -29,7 +27,6 @@ export const loadRoutingConfigBased = (): string => {
   return withoutMainHeading.trim();
 };
 
-// README from "## Introduction" up to (not including) "## Routing".
 export const loadBeforeRouting = (): string => {
   const readme = loadReadme();
   const match = readme.match(/(^## Introduction[\s\S]*?)(?=^## Routing)/m);
@@ -40,7 +37,6 @@ export const loadBeforeRouting = (): string => {
   return content.trim();
 };
 
-// README from the section after "## Routing" to the end.
 export const loadAfterRouting = (): string => {
   const readme = loadReadme();
   const match = readme.match(

--- a/packages/website/src/pages/_api/llms.txt.ts
+++ b/packages/website/src/pages/_api/llms.txt.ts
@@ -1,8 +1,5 @@
 import { loadGuides, loadReadme } from '../../lib/load-docs';
 
-/**
- * Serves consolidated documentation as plain text for LLMs
- */
 export const GET = async () => {
   let readme = loadReadme();
   readme = readme.replace(


### PR DESCRIPTION
## Summary
- Keep full JSDoc on public APIs; drop narrating docs on internals (an export is not automatically a public API).
- Rename the env seeder to `unstable_setAllEnv` (adapter callback and implementation).
- **Breaking:** export minimal client primitives as `Root_UNSTABLE`, `Slot_UNSTABLE`, `Children_UNSTABLE`, and `useRefetch_UNSTABLE`. Call sites and docs may import them with `as`.
- Drop the `fetchingSlices` FIXME wording.
## Notes
- Companion update needed in `wakujs/waku-examples` when its Waku pin moves.
