### PR TITLE
docs: add coding rules and conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent instructions
+
+Read and follow [CONTRIBUTING.md](./CONTRIBUTING.md), especially the coding
+rules and conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,0 @@
-# Agent instructions
-
-Read and follow [CONTRIBUTING.md](./CONTRIBUTING.md), especially the coding
-rules and conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,10 @@ More examples can be found in the [waku-examples](https://github.com/wakujs/waku
 Run the checks relevant to your changes:
 
 ```shell
+pnpm run compile
 pnpm run test:unit
 pnpm run test:lint
+pnpm exec playwright install --with-deps
 pnpm run e2e
 ```
 
@@ -64,19 +66,21 @@ To try an app with an experimental version of Waku, change the `waku` dependency
 
 ## Coding rules and conventions
 
-Keep changes focused and code direct. Prefer fewer concepts, respect existing
-module boundaries, and preserve observable behavior. Public APIs need explicit
-types and useful JSDoc; implementation details should generally rely on
-inference and avoid narrating comments. Add focused tests for changed behavior.
+In short, keep changes focused and code direct. Prefer fewer concepts, respect
+existing module boundaries, and preserve observable behavior. Public APIs need
+explicit types and useful JSDoc; implementation details should generally rely
+on inference and avoid narrating comments. Add focused tests for changed
+behavior.
 
 Unstable APIs use `_UNSTABLE` for React components and hooks, `Unstable_` for
 TypeScript types, and `unstable_` for other values and functions.
 
 ### For AI agents
 
-Configure agent instruction files such as `AGENTS.md` to tell agents to read
-this file. Treat the rules below as hard constraints, not style tips. Prefer
-compression over completeness.
+Agent instruction files such as `AGENTS.md` should tell agents to read this
+file. Treat the rules below as hard constraints, not style tips. Here,
+compression means reducing the concepts a reader must hold in mind, not making
+code terse or public documentation incomplete.
 
 #### Scope and design
 
@@ -121,7 +125,8 @@ compression over completeness.
   states.
 - Prefer plain functions and objects. Use a class only when required by a
   framework or platform contract.
-- Prefer `while` or recursion to `for (;;)`.
+- Use `while (true)`, never `for (;;)`. Use recursion when the problem is
+  naturally recursive and the call depth is safe.
 - Await or return promises. Do not leave asynchronous work floating.
 - Normalize configuration and optional inputs once near the boundary.
 
@@ -144,9 +149,9 @@ compression over completeness.
 - Do not restate names or repeat the same fact in multiple places.
 - `TODO`, `FIXME`, and `HACK` are acceptable when they describe an unresolved
   issue. Remove them only when the issue is actually resolved.
-- Public APIs should have complete JSDoc suitable for editor documentation,
-  including behavior, parameters, return values, important caveats, and useful
-  examples.
+- Public APIs should have complete JSDoc suitable for editor documentation.
+  Cover the behavior, parameters, return values, caveats, and examples needed to
+  use the API correctly. Public API documentation does not need to be short.
 - Document non-obvious behavior and caveats without enumerating every edge case
   already captured by tests.
 - Public unstable APIs should have the same useful editor documentation as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ constraints, not style tips. Here, compression means reducing the concepts a
 reader must hold in mind, not making code terse or public documentation
 incomplete.
 
-#### Scope and design
+### Scope and design
 
 - Fix behavior in the layer that owns it. Do not spread a special case across
   unrelated modules.
@@ -108,7 +108,7 @@ incomplete.
 - Keep platform-specific behavior in adapters. Do not import Node APIs into
   browser or isomorphic modules.
 
-#### Implementation
+### Implementation
 
 - Prefer direct control flow, early returns, and native platform APIs.
 - Use `const` unless a binding must be reassigned. Local mutation of an array,
@@ -131,7 +131,7 @@ incomplete.
 - Await or return promises. Do not leave asynchronous work floating.
 - Normalize configuration and optional inputs once near the boundary.
 
-#### TypeScript
+### TypeScript
 
 - Prefer inference for local implementation details and explicit types for
   public contracts or important boundaries.
@@ -142,7 +142,7 @@ incomplete.
   weaken types throughout the caller to satisfy one integration point.
 - Use `import type` for type-only imports.
 
-#### Comments and documentation
+### Comments and documentation
 
 - If the code already says it, omit the comment.
 - Comment why a branch exists, which invariant must be preserved, or which
@@ -161,7 +161,7 @@ incomplete.
   use lean or no JSDoc unless the types cannot express an important contract.
 - Do not add narrating JSDoc that merely restates a symbol's name or type.
 
-#### Tests
+### Tests
 
 - Reproduce a reported bug before describing it as confirmed.
 - Every regression test must fail when its production fix is removed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,10 +77,11 @@ TypeScript types, and `unstable_` for other values and functions.
 
 ### For AI agents
 
-Agent instruction files such as `AGENTS.md` should tell agents to read this
-file. Treat the rules below as hard constraints, not style tips. Here,
-compression means reducing the concepts a reader must hold in mind, not making
-code terse or public documentation incomplete.
+If you use a coding agent, configure your local instruction file, such as
+`AGENTS.md`, to tell the agent to read this file. Treat the rules below as hard
+constraints, not style tips. Here, compression means reducing the concepts a
+reader must hold in mind, not making code terse or public documentation
+incomplete.
 
 #### Scope and design
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,12 @@
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/en/download/): see specific version in [package.json](./package.json)
+- [Node.js](https://nodejs.org/en/download/): see the supported versions in
+  [packages/waku/package.json](./packages/waku/package.json)
+- [pnpm](https://pnpm.io/installation): see the version in
+  [package.json](./package.json)
 
 ```shell
-corepack enable
 pnpm install
 ```
 
@@ -36,11 +38,15 @@ More examples can be found in the [waku-examples](https://github.com/wakujs/waku
 
 ## Testing
 
-We are using [playwright](https://playwright.dev/) for end-to-end testing.
+Run the checks relevant to your changes:
 
 ```shell
+pnpm run test:unit
+pnpm run test:lint
 pnpm run e2e
 ```
+
+End-to-end tests use [Playwright](https://playwright.dev/).
 
 ## Trying an experimental version
 
@@ -53,3 +59,108 @@ To try an app with an experimental version of Waku, change the `waku` dependency
   }
 }
 ```
+
+---
+
+## Coding rules and conventions
+
+Keep changes focused and code direct. Prefer fewer concepts, respect existing
+module boundaries, and preserve observable behavior. Public APIs need explicit
+types and useful JSDoc; implementation details should generally rely on
+inference and avoid narrating comments. Add focused tests for changed behavior.
+
+Unstable APIs use `_UNSTABLE` for React components and hooks, `Unstable_` for
+TypeScript types, and `unstable_` for other values and functions.
+
+### For AI agents
+
+Configure agent instruction files such as `AGENTS.md` to tell agents to read
+this file. Treat the rules below as hard constraints, not style tips. Prefer
+compression over completeness.
+
+#### Scope and design
+
+- Fix behavior in the layer that owns it. Do not spread a special case across
+  unrelated modules.
+- Keep changes focused. Do not combine a bug fix with an unrelated refactor.
+  Prefer a readable diff over either the fewest changed lines or a broad
+  cleanup.
+- Do not expand the task to improve nearby code. Within production code already
+  being changed, fix trivial misleading names or bindings and remove misleading
+  or redundant comments. In tests, avoid unrelated cleanup.
+- Do not add a public option, generic abstraction, or compatibility layer for
+  one exceptional case.
+- Prefer fewer concepts. Every new name, file, or type should represent a
+  distinction the code needs, not make the design look complete or symmetric.
+- Split a module only at a real boundary, not to move one small helper into its
+  own file.
+- Preserve existing ordering and other observable contracts unless changing
+  them is the purpose of the change.
+- Validate external input at its boundary. Do not add speculative guards for
+  states already excluded by internal types or invariants.
+- Keep Waku core independent from Waku Router. Router-specific integration in
+  core should be exceptional and narrowly scoped.
+- Keep platform-specific behavior in adapters. Do not import Node APIs into
+  browser or isomorphic modules.
+
+#### Implementation
+
+- Prefer direct control flow, early returns, and native platform APIs.
+- Use `const` unless a binding must be reassigned. Local mutation of an array,
+  map, set, or result object is fine when it makes the algorithm clearer.
+- Name functions with verbs. Do not create a wrapper that only supplies fixed
+  arguments to another function.
+- Name operations and results, not stages in the control flow. Avoid helpers and
+  variables that only narrate the current step.
+- Extract a helper when it owns a meaningful operation or invariant, not merely
+  to shorten the caller.
+- Do not add refs, contexts, locks, or other coordination state that only
+  narrates existing control flow.
+- Prefer an early return or thrown error to an outcome union that is consumed
+  only once. Use a discriminated union when callers actually branch on its
+  states.
+- Prefer plain functions and objects. Use a class only when required by a
+  framework or platform contract.
+- Prefer `while` or recursion to `for (;;)`.
+- Await or return promises. Do not leave asynchronous work floating.
+- Normalize configuration and optional inputs once near the boundary.
+
+#### TypeScript
+
+- Prefer inference for local implementation details and explicit types for
+  public contracts or important boundaries.
+- Prefer `unknown` to `any`. Narrow values before using them.
+- Prefer type aliases. Use interfaces when declaration merging or augmentation
+  is required.
+- Keep casts narrow and close to third-party or framework boundaries. Do not
+  weaken types throughout the caller to satisfy one integration point.
+- Use `import type` for type-only imports.
+
+#### Comments and documentation
+
+- If the code already says it, omit the comment.
+- Comment why a branch exists, which invariant must be preserved, or which
+  external behavior requires a workaround.
+- Do not restate names or repeat the same fact in multiple places.
+- `TODO`, `FIXME`, and `HACK` are acceptable when they describe an unresolved
+  issue. Remove them only when the issue is actually resolved.
+- Public APIs should have complete JSDoc suitable for editor documentation,
+  including behavior, parameters, return values, important caveats, and useful
+  examples.
+- Document non-obvious behavior and caveats without enumerating every edge case
+  already captured by tests.
+- Public unstable APIs should have the same useful editor documentation as
+  other public APIs.
+- An exported symbol is not necessarily a public API. Internal exports should
+  use lean or no JSDoc unless the types cannot express an important contract.
+- Do not add narrating JSDoc that merely restates a symbol's name or type.
+
+#### Tests
+
+- Reproduce a reported bug before describing it as confirmed.
+- Every regression test must fail when its production fix is removed.
+- Test observable behavior. Prefer a real existing fixture or integration
+  boundary to a loose mock.
+- Prefer a few cases at important behavioral boundaries to a scenario matrix
+  that mirrors implementation branches.
+- Do not change an existing assertion merely to make a new fixture case fit.


### PR DESCRIPTION
Document the coding style expected in Waku, with detailed guidance for AI agents. Also update the setup and testing instructions.