### PR TITLE
refactor(router): rename learnStaticPath; trim version-skew comments

### DIFF
--- a/e2e/fs-router.spec.ts
+++ b/e2e/fs-router.spec.ts
@@ -77,7 +77,7 @@ test.describe('fs-router', () => {
     mode,
   }) => {
     // https://github.com/wakujs/waku/issues/2238
-    // The dev bootstrap imports a virtual module, not a hashed asset.
+    // Dev bootstrap is a virtual module, not a hashed asset.
     // eslint-disable-next-line playwright/no-skipped-test
     test.skip(mode === 'DEV', 'covers the production bootstrap import only');
     const staleEntry = '/assets/index-stale-build.js';
@@ -97,11 +97,8 @@ test.describe('fs-router', () => {
         currentEntryRequests++;
       }
     });
-    // Model a deploy-window skew. The first document is the old build, so it
-    // points at an entry chunk that is no longer deployed. The reload gets the
-    // current document, pointing at the chunk that really is deployed. The
-    // entry hash appears in a modulepreload link as well as in the bootstrap
-    // import, so rewrite every occurrence.
+    // First document: rewrite every entry url to a missing chunk; reload gets
+    // the current document (preload + bootstrap both use the hash).
     let firstDocument = true;
     await page.route(`http://localhost:${port}/`, async (route) => {
       if (!firstDocument) {
@@ -148,10 +145,7 @@ test.describe('fs-router', () => {
         navigations++;
       }
     });
-    // Unlike the test above, every document points at the missing chunk, so
-    // recovery can never succeed. Without the retry marker this reloads
-    // forever, so what matters is that the count settles rather than its
-    // exact value.
+    // Every document keeps the missing chunk; assert navigations settle (no loop).
     await page.route(`http://localhost:${port}/`, async (route) => {
       const response = await route.fetch();
       const html = await response.text();

--- a/packages/waku/src/lib/utils/ssr.ts
+++ b/packages/waku/src/lib/utils/ssr.ts
@@ -9,10 +9,10 @@ function getRecoveryBuildId(): string | undefined {
   return buildId;
 }
 
-// Must run before the bootstrap `import()`. https://github.com/wakujs/waku/issues/2238
-// Reloading while the SSR HTML is still streaming is unreliable.
-// Recovery is skipped unless the retry marker persists, because without it a
-// broken build would reload forever.
+// https://github.com/wakujs/waku/issues/2238
+// Must run before the bootstrap import. Defer reload until DOMContentLoaded
+// (streaming HTML is unreliable). Persist a build-id marker so a broken build
+// cannot loop forever.
 function getVersionSkewRecoveryCode(): string {
   const buildId = getRecoveryBuildId();
   if (!buildId) {
@@ -44,9 +44,8 @@ function getVersionSkewRecoveryCode(): string {
   `;
 }
 
-// A bare `import()` dispatches no `vite:preloadError` on failure, so mirror
-// Vite's `__vitePreload` semantics to reach the recovery listener above.
-// https://github.com/wakujs/waku/issues/2238
+// Bare import() does not fire vite:preloadError; mirror __vitePreload so the
+// recovery listener above runs. https://github.com/wakujs/waku/issues/2238
 export function createBootstrapScriptContent(entryUrl: string): string {
   const entryImport = `import(${JSON.stringify(entryUrl)})`;
   if (!getRecoveryBuildId()) {

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -260,7 +260,6 @@ const createRouteChangeListeners = (): [
   ];
 };
 
-// This is an internal thing, not a public API
 const RouterContext = createContext<{
   route: RouteProps;
   routerState?: RouterState | undefined;
@@ -1029,7 +1028,7 @@ const InnerRouter = ({
   const staticPathSetRef = useRef<Set<string>>(undefined);
   staticPathSetRef.current ??= new Set();
   // a record mid navigation pairs the new route id with the old static flag
-  const learnStaticPath = useCallback(
+  const addToStaticPathSet = useCallback(
     (responseElements: Record<string, unknown>) => {
       const route = getRouteFromElements(responseElements);
       if (route && isStaticFromElements(responseElements)) {
@@ -1038,11 +1037,10 @@ const InnerRouter = ({
     },
     [],
   );
-  const initialElementsRef = useRef<typeof elements>(undefined);
-  initialElementsRef.current ??= elements;
+  const initialElementsRef = useRef(elements);
   useEffect(() => {
-    learnStaticPath(initialElementsRef.current!);
-  }, [learnStaticPath]);
+    addToStaticPathSet(initialElementsRef.current);
+  }, [addToStaticPathSet]);
   const resolvedElementsRef = useRef(elements);
   useLayoutEffect(() => {
     resolvedElementsRef.current = elements;
@@ -1107,7 +1105,7 @@ const InnerRouter = ({
           void refetch(
             encodeRoutePath(settledRoute.path),
             createRscParams(settledRoute.query),
-          ).then(learnStaticPath, () => {});
+          ).then(addToStaticPathSet, () => {});
         });
       };
       upsertRscReloadListener(
@@ -1116,7 +1114,7 @@ const InnerRouter = ({
       );
       globalThis.__WAKU_REFETCH_ROUTE__ = refetchRouteOnHmr;
     }
-  }, [refetch, learnStaticPath, routeFallback]);
+  }, [refetch, addToStaticPathSet, routeFallback]);
 
   const [[routeChangeEvents, emitRouteChangeEvent]] = useState(
     createRouteChangeListeners,
@@ -1144,7 +1142,7 @@ const InnerRouter = ({
       if (superseded?.startEmitted) {
         emitRouteChangeEvent('error', superseded.route);
       }
-      // a listener can navigate synchronously, which aborts this one
+      // a start listener can navigate synchronously, which aborts this one
       if (isAborted()) {
         return;
       }
@@ -1219,7 +1217,7 @@ const InnerRouter = ({
           return;
         }
         pendingNavigationRef.current = null;
-        learnStaticPath(resolved);
+        addToStaticPathSet(resolved);
         emitRouteChangeEvent(
           'complete',
           getServerRedirect(resolved, nextRoute) ?? nextRoute,
@@ -1247,7 +1245,7 @@ const InnerRouter = ({
       refetch,
       mergeElements,
       emitRouteChangeEvent,
-      learnStaticPath,
+      addToStaticPathSet,
     ],
   );
 
@@ -1281,7 +1279,7 @@ const InnerRouter = ({
   );
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
-      learnStaticPath(elements);
+      addToStaticPathSet(elements);
       const { [ROUTE_ID]: routeData, [IS_STATIC_ID]: isStatic } = elements;
       applyChangeRouteData(routeData, isStatic).catch((err) => {
         if (!isFollowable(err)) {
@@ -1290,7 +1288,7 @@ const InnerRouter = ({
       });
     };
     return registerCallServerElementsListener(listener);
-  }, [applyChangeRouteData, learnStaticPath]);
+  }, [applyChangeRouteData, addToStaticPathSet]);
 
   const prefetchRoute: PrefetchRoute = useCallback((route, options) => {
     preloadRouteModules(route.path);
@@ -1413,8 +1411,8 @@ export function INTERNAL_ServerRouter({ route }: { route: RouteProps }) {
   );
 }
 
-// Expose internal APIs
-// Subject to change without notice
+// Internal APIs exposed for other Waku packages and integrations.
+// Subject to change without notice.
 export type Unstable_RouteProps = RouteProps;
 export const unstable_HAS404_ID = HAS404_ID;
 export const unstable_IS_STATIC_ID = IS_STATIC_ID;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1019,8 +1019,7 @@ const InnerRouter = ({
     routeFromElements && routeFromElements.path !== fallbackRoute.path
       ? { ...routeFromElements, hash: fallbackRoute.hash }
       : fallbackRoute;
-  const initialHashRef = useRef<string>(undefined);
-  initialHashRef.current ??= resolvedRoute.hash;
+  const initialHashRef = useRef(resolvedRoute.hash);
   // state, not a ref: it is read during render
   const [initialRoute] = useState(() => ({ ...resolvedRoute, hash: '' }));
 
@@ -1054,7 +1053,7 @@ const InnerRouter = ({
   // starts empty so hydration matches the server, then the effect fills it
   const [restoredHash, setRestoredHash] = useState('');
   useEffect(() => {
-    setRestoredHash(window.location.hash || initialHashRef.current!);
+    setRestoredHash(window.location.hash || initialHashRef.current);
   }, []);
 
   const routeFallback = useMemo(

--- a/packages/waku/tests/ssr-utils.test.ts
+++ b/packages/waku/tests/ssr-utils.test.ts
@@ -14,7 +14,6 @@ describe('createBootstrapScriptContent', () => {
     const content = createBootstrapScriptContent('/assets/index-abc123.js');
     expect(content).toContain('import("/assets/index-abc123.js").catch');
     expect(content).toContain('vite:preloadError');
-    // must be valid JS
     expect(() => new Function(content)).not.toThrow();
   });
 
@@ -25,8 +24,7 @@ describe('createBootstrapScriptContent', () => {
   });
 
   it('emits a terminated bare import without a build id', () => {
-    // The trailing semicolon guards the concatenated extraScriptContent
-    // against continuing the import expression.
+    // Trailing semicolon: extraScriptContent must not continue the import.
     expect(createBootstrapScriptContent('/assets/index-abc123.js')).toBe(
       'import("/assets/index-abc123.js");',
     );
@@ -132,8 +130,7 @@ describe('version skew recovery code', () => {
     expect(backing.get('waku:preload-error-build-id')).toBe('test-build');
   });
 
-  // Failing open here would reload forever, because the next document load
-  // cannot tell that it already retried.
+  // Without a marker the next load cannot tell it already retried.
   it('does not reload when sessionStorage is unavailable', () => {
     const throwing = () => {
       throw new Error('sessionStorage is disabled');
@@ -195,7 +192,6 @@ describe('getBootstrapPreamble', () => {
       debugId: 'debug-1',
     });
     expect(preamble).toContain('globalThis.__WAKU_INITIAL_RSC__ = (() =>');
-    // The initial entry carries the streamed Response and its debug id.
     expect(preamble).toContain('e.response = Promise.resolve(new Response(');
     expect(preamble).toContain('e.debugId = "debug-1";');
   });
@@ -208,8 +204,7 @@ describe('getBootstrapPreamble', () => {
   });
 
   it('strips indentation but keeps line boundaries', () => {
-    // Joining the lines without a separator would let a line comment in any
-    // emitted snippet comment out the rest of the script.
+    // Keep newlines so a // in a snippet cannot comment out the rest.
     vi.stubEnv('WAKU_BUILD_ID', 'test-build');
     const preamble = getBootstrapPreamble({
       hydrate: true,


### PR DESCRIPTION
Rename to addToStaticPathSet and simplify initialElementsRef. Drop the narrating RouterContext note; keep a clarified disclaimer on the unstable re-exports. Tighten wordy #2240 recovery comments to why-only.