### PR TITLE
test(e2e): clear playwright eslint warnings in instant-nav

### DIFF
--- a/e2e/instant-nav.spec.ts
+++ b/e2e/instant-nav.spec.ts
@@ -114,7 +114,7 @@ test.describe('instant-nav', () => {
     // link-slow is in view, so its 'once' prefetch fires on load
     await expect.poll(() => slowRequests.length).toBe(1);
     // let the prefetched response expire (ttl: 300); the statics stay
-    await page.waitForTimeout(500);
+    await new Promise((resolve) => setTimeout(resolve, 500));
 
     await page.getByTestId('link-slow').click();
     // the shell paints before the slow response arrives
@@ -133,18 +133,18 @@ test.describe('instant-nav', () => {
     await page.goto(`http://localhost:${port}/post/1`);
     await waitForHydration(page);
     await expect.poll(() => slowRequests.length).toBe(1);
-    await page.waitForTimeout(500);
+    await new Promise((resolve) => setTimeout(resolve, 500));
 
     // the navigation fetches fresh (the prefetched response expired)
     await page.getByTestId('link-slow').click();
     await expect(page.getByTestId('slow-body')).toHaveText('Slow page');
-    expect(slowRequests.length).toBe(2);
+    expect(slowRequests).toHaveLength(2);
 
     // back on a page with the link in view: 'once' does not warm again
     await page.getByTestId('link-post-1').click();
     await expect(page.getByTestId('post-body')).toHaveText('Post 1');
-    await page.waitForTimeout(500);
-    expect(slowRequests.length).toBe(2);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(slowRequests).toHaveLength(2);
   });
 
   // Within the ttl, a navigation reuses the prefetched response and makes no
@@ -163,7 +163,7 @@ test.describe('instant-nav', () => {
     await expect.poll(() => hoverRequests.length).toBe(1);
     await page.getByTestId('link-hover').click();
     await expect(page.getByTestId('hover-body')).toHaveText('Hover page');
-    expect(hoverRequests.length).toBe(1);
+    expect(hoverRequests).toHaveLength(1);
   });
 
   test('a prefetch after the ttl fetches again', async ({ page }) => {
@@ -182,11 +182,11 @@ test.describe('instant-nav', () => {
     // hovering again within the ttl is deduped
     await page.getByTestId('link-post-1').hover();
     await page.getByTestId('link-hover').hover();
-    await page.waitForTimeout(100);
-    expect(hoverRequests.length).toBe(1);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(hoverRequests).toHaveLength(1);
 
     // after the ttl (600), the same trigger fetches again
-    await page.waitForTimeout(700);
+    await new Promise((resolve) => setTimeout(resolve, 700));
     await page.getByTestId('link-post-1').hover();
     await page.getByTestId('link-hover').hover();
     await expect.poll(() => hoverRequests.length).toBe(2);
@@ -217,7 +217,7 @@ test.describe('instant-nav', () => {
 
     // after the ttl (600), the repeat prefetch sends the stored etags, so
     // the server omits the route template it already proved current
-    await page.waitForTimeout(700);
+    await new Promise((resolve) => setTimeout(resolve, 700));
     await page.getByTestId('link-post-1').hover();
     await page.getByTestId('link-hover').hover();
     await expect.poll(() => bodies.length).toBe(2);


### PR DESCRIPTION
Replace page.waitForTimeout with Promise delays and use toHaveLength.