### PR TITLE
test(e2e): cover disableSSR on a dynamic route

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -817,6 +817,25 @@ test.describe(`create-pages`, () => {
     },
   );
 
+  test('no ssr with render=dynamic and no client component', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/no-ssr-server-only`);
+    await expect(
+      page.getByRole('heading', { name: 'No SSR Server Only', exact: true }),
+    ).toBeVisible();
+  });
+
+  test('no ssr with render=dynamic', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/no-ssr-dynamic`);
+    await expect(
+      page.getByRole('heading', { name: 'No SSR Dynamic', exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Only client component', exact: true }),
+    ).toBeVisible();
+  });
+
   test('no ssr', async ({ page }) => {
     await page.goto(`http://localhost:${port}/no-ssr`);
     await expect(

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -819,7 +819,14 @@ test.describe(`create-pages`, () => {
 
   test('no ssr with render=dynamic and no client component', async ({
     page,
+    request,
   }) => {
+    // nothing else about this page says the server skipped it
+    const response = await request.get(
+      `http://localhost:${port}/no-ssr-server-only`,
+    );
+    expect(await response.text()).not.toContain('No SSR Server Only');
+
     await page.goto(`http://localhost:${port}/no-ssr-server-only`);
     await expect(
       page.getByRole('heading', { name: 'No SSR Server Only', exact: true }),

--- a/e2e/fixtures/create-pages/src/components/NoSsrDynamic.tsx
+++ b/e2e/fixtures/create-pages/src/components/NoSsrDynamic.tsx
@@ -1,0 +1,10 @@
+import { OnlyClient } from './OnlyClient.js';
+
+const NoSsrDynamic = () => (
+  <div>
+    <h2>No SSR Dynamic</h2>
+    <OnlyClient />
+  </div>
+);
+
+export default NoSsrDynamic;

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -17,6 +17,7 @@ import {
 import NestedBazPage from './components/NestedBazPage.js';
 import NestedLayout from './components/NestedLayout.js';
 import NoSsr from './components/NoSsr.js';
+import NoSsrDynamic from './components/NoSsrDynamic.js';
 import RedirectToSearchPage from './components/RedirectToSearchPage.js';
 import { RerenderActionPage } from './components/RerenderActionPage.js';
 import SearchPage from './components/SearchPage.js';
@@ -519,6 +520,20 @@ const pages: ReturnType<typeof createPages> = createPages(
       render: 'static',
       path: '/no-ssr',
       component: NoSsr,
+      unstable_disableSSR: true,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/no-ssr-dynamic',
+      component: NoSsrDynamic,
+      unstable_disableSSR: true,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/no-ssr-server-only',
+      component: () => <h2>No SSR Server Only</h2>,
       unstable_disableSSR: true,
     }),
 

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1256,8 +1256,9 @@ const InnerRouter = ({
   ) : (
     <Slot id={getRouteSlotId(currentRoute.path)} />
   );
-  // TODO the root layout renders outside this, so a followable error thrown by
-  // an action it calls is never followed
+  // TODO a followable error thrown by the root layout, or by an action it
+  // calls, is not followed. The layout's own ErrorBoundary catches it first,
+  // so wrapping this slot in another handler does not reach it
   const rootElement = (
     <Slot id="root">
       <CustomErrorHandler has404={has404}>{routeElement}</CustomErrorHandler>


### PR DESCRIPTION
The only page with disableSSR renders static, so it is prerendered and the client never has to render it. These two are dynamic, one with a client component and one without, which is the path that actually fetches and renders in the browser.

Also points the follow TODO at what blocks it: the layout's own ErrorBoundary catches the error before anything around the route slot can.