### PR TITLE
refactor(router): clarify client naming and drop thin wrappers

### DIFF
--- a/packages/waku/src/router/client-utils/prefetch-cache.ts
+++ b/packages/waku/src/router/client-utils/prefetch-cache.ts
@@ -20,12 +20,12 @@ export type PrefetchEntry = {
 
 type PrefetchCache = Map<string, PrefetchEntry>;
 
-// Session store of prefetched responses, keyed by rscPath alone. Entries are
+// Session cache of prefetched responses, keyed by rscPath alone. Entries are
 // only served under the etag protocol: they paint immutable slots (which
 // cannot vary by query) and fall back for a dynamic slot only when the
 // server omits it, which proves the stored copy current. A null entry marks
 // a route whose first prefetch is still in flight.
-type PrefetchedElementsStore = Map<string, Elements | null>;
+type PrefetchedElementsCache = Map<string, Elements | null>;
 
 export const PREFETCH_TTL = 1000 * 60;
 export const PREFETCH_LIMIT = 100;
@@ -34,66 +34,69 @@ const prefetchCacheKey = (rscPath: string, query: string): string =>
   rscPath + '\0' + query;
 
 const getPrefetch = (
-  cache: PrefetchCache,
+  prefetchCache: PrefetchCache,
   key: string,
   now: number,
 ): PrefetchEntry | undefined => {
-  const entry = cache.get(key);
+  const entry = prefetchCache.get(key);
   if (entry && entry.expireAt <= now) {
-    cache.delete(key);
+    prefetchCache.delete(key);
     return undefined;
   }
   return entry;
 };
 
 const setPrefetch = (
-  cache: PrefetchCache,
+  prefetchCache: PrefetchCache,
   key: string,
   entry: PrefetchEntry,
 ): void => {
-  while (cache.size >= PREFETCH_LIMIT) {
-    const oldest = cache.keys().next().value;
+  while (prefetchCache.size >= PREFETCH_LIMIT) {
+    const oldest = prefetchCache.keys().next().value;
     if (oldest === undefined) {
       break;
     }
-    cache.delete(oldest);
+    prefetchCache.delete(oldest);
   }
-  cache.set(key, entry);
+  prefetchCache.set(key, entry);
 };
 
 const reservePrefetchedElements = (
-  store: PrefetchedElementsStore,
+  prefetchedElementsCache: PrefetchedElementsCache,
   rscPath: string,
 ): void => {
-  if (store.has(rscPath)) {
+  if (prefetchedElementsCache.has(rscPath)) {
     return;
   }
-  if (store.size >= PREFETCH_LIMIT) {
-    const oldestKey = store.keys().next().value;
+  if (prefetchedElementsCache.size >= PREFETCH_LIMIT) {
+    const oldestKey = prefetchedElementsCache.keys().next().value;
     if (oldestKey !== undefined) {
-      store.delete(oldestKey);
+      prefetchedElementsCache.delete(oldestKey);
     }
   }
-  store.set(rscPath, null);
+  prefetchedElementsCache.set(rscPath, null);
 };
 
 const releasePrefetchedElements = (
-  store: PrefetchedElementsStore,
+  prefetchedElementsCache: PrefetchedElementsCache,
   rscPath: string,
 ): void => {
-  if (store.get(rscPath) === null) {
-    store.delete(rscPath);
+  if (prefetchedElementsCache.get(rscPath) === null) {
+    prefetchedElementsCache.delete(rscPath);
   }
 };
 
 const mergePrefetchedElements = (
-  store: PrefetchedElementsStore,
+  prefetchedElementsCache: PrefetchedElementsCache,
   rscPath: string,
   elements: Elements,
 ): void => {
-  reservePrefetchedElements(store, rscPath);
-  const existing = store.get(rscPath);
-  store.set(rscPath, existing ? { ...existing, ...elements } : elements);
+  reservePrefetchedElements(prefetchedElementsCache, rscPath);
+  const existing = prefetchedElementsCache.get(rscPath);
+  prefetchedElementsCache.set(
+    rscPath,
+    existing ? { ...existing, ...elements } : elements,
+  );
 };
 
 type PrefetchManager = {
@@ -109,59 +112,66 @@ type PrefetchManager = {
 };
 
 export const createPrefetchManager = (): PrefetchManager => {
-  let cache: PrefetchCache = new Map();
-  let store: PrefetchedElementsStore = new Map();
+  let prefetchCache: PrefetchCache = new Map();
+  let prefetchedElementsCache: PrefetchedElementsCache = new Map();
   return {
     prefetch: (rscPath, query, fetchElements, options) =>
-      startPrefetch(cache, store, rscPath, query, fetchElements, options),
+      startPrefetch(
+        prefetchCache,
+        prefetchedElementsCache,
+        rscPath,
+        query,
+        fetchElements,
+        options,
+      ),
     get: (rscPath, query) =>
-      getPrefetch(cache, prefetchCacheKey(rscPath, query), Date.now()),
-    getElements: (rscPath) => store.get(rscPath) ?? undefined,
+      getPrefetch(prefetchCache, prefetchCacheKey(rscPath, query), Date.now()),
+    getElements: (rscPath) => prefetchedElementsCache.get(rscPath) ?? undefined,
     clear: () => {
       // replace the maps so an in-flight prefetch completes into detached ones
-      cache = new Map();
-      store = new Map();
+      prefetchCache = new Map();
+      prefetchedElementsCache = new Map();
     },
   };
 };
 
 const startPrefetch = (
-  cache: PrefetchCache,
-  store: PrefetchedElementsStore,
+  prefetchCache: PrefetchCache,
+  prefetchedElementsCache: PrefetchedElementsCache,
   rscPath: string,
   query: string,
   fetchElements: (base: Elements | undefined) => Promise<Elements>,
   options: PrefetchOptions | undefined,
 ): void => {
-  if (options?.mode === 'once' && store.has(rscPath)) {
+  if (options?.mode === 'once' && prefetchedElementsCache.has(rscPath)) {
     return;
   }
-  // Dedupe per (path, query), so a repeat trigger within the ttl keeps an
-  // already-resolved response instead of replacing it with an in-flight one.
+  // Keep an already-resolved response within the ttl instead of replacing it
+  // with an in-flight one.
   const key = prefetchCacheKey(rscPath, query);
   const now = Date.now();
-  if (getPrefetch(cache, key, now)) {
+  if (getPrefetch(prefetchCache, key, now)) {
     return;
   }
-  const base = store.get(rscPath) ?? undefined;
+  const base = prefetchedElementsCache.get(rscPath) ?? undefined;
   const promise = fetchElements(base);
   const entry: PrefetchEntry = {
     promise,
     expireAt: now + (options?.ttl ?? PREFETCH_TTL),
   };
-  setPrefetch(cache, key, entry);
-  reservePrefetchedElements(store, rscPath);
+  setPrefetch(prefetchCache, key, entry);
+  reservePrefetchedElements(prefetchedElementsCache, rscPath);
   promise.then(
     (resolved) => {
-      mergePrefetchedElements(store, rscPath, resolved);
+      mergePrefetchedElements(prefetchedElementsCache, rscPath, resolved);
     },
     () => {
       // TODO a negative ttl, so a route that answers with a document location
       // is not fetched again on every hover
-      if (cache.get(key) === entry) {
-        cache.delete(key);
+      if (prefetchCache.get(key) === entry) {
+        prefetchCache.delete(key);
       }
-      releasePrefetchedElements(store, rscPath);
+      releasePrefetchedElements(prefetchedElementsCache, rscPath);
     },
   );
 };

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -26,21 +26,6 @@ export const has404FromElements = (elements: Record<string, unknown>) =>
 export const isMetaKey = (key: string) =>
   key === ROUTE_ID || key === HAS404_ID || key === IS_STATIC_ID;
 
-export const getServerRedirect = (
-  elements: Record<string, unknown>,
-  route: RouteProps,
-): RouteProps | undefined => {
-  const serverRoute = getRouteFromElements(elements);
-  if (
-    serverRoute &&
-    (serverRoute.path !== route.path ||
-      (!isStaticFromElements(elements) && serverRoute.query !== route.query))
-  ) {
-    return serverRoute;
-  }
-  return undefined;
-};
-
 // the client owned router state; the server's ROUTE_ID owns the path
 export const ROUTER_STATE_ID = Symbol('waku-router-state');
 
@@ -86,13 +71,16 @@ export const resolveServerRedirect = (
   fallbackPath: string,
 ): { route: RouteProps; url: URL } => {
   const stateUrl = new URL(routerState.url, window.location.href);
-  const redirect = routerState.failure
+  const serverRoute = routerState.failure
     ? undefined
-    : getServerRedirect(elements, {
-        path: routerState.requested[0],
-        query: routerState.requested[1],
-        hash: '',
-      });
+    : getRouteFromElements(elements as Record<string, unknown>);
+  const redirect =
+    serverRoute &&
+    (serverRoute.path !== routerState.requested[0] ||
+      (!isStaticFromElements(elements as Record<string, unknown>) &&
+        serverRoute.query !== routerState.requested[1]))
+      ? serverRoute
+      : undefined;
   if (redirect && redirect.path !== '/404') {
     return { route: redirect, url: getRouteUrl(redirect) };
   }

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -73,11 +73,11 @@ export const resolveServerRedirect = (
   const stateUrl = new URL(routerState.url, window.location.href);
   const serverRoute = routerState.failure
     ? undefined
-    : getRouteFromElements(elements as Record<string, unknown>);
+    : getRouteFromElements(elements);
   const redirect =
     serverRoute &&
     (serverRoute.path !== routerState.requested[0] ||
-      (!isStaticFromElements(elements as Record<string, unknown>) &&
+      (!isStaticFromElements(elements) &&
         serverRoute.query !== routerState.requested[1]))
       ? serverRoute
       : undefined;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -140,9 +140,6 @@ type Prefetch = {
   ): void;
 };
 
-const parseRouteFromLocation = (): RouteProps =>
-  parseRoute(new URL(window.location.href));
-
 const commitHistory = (url: URL, mode: 'push' | 'replace' | null): void => {
   if (window.location.href === url.href) {
     return;
@@ -256,11 +253,6 @@ const resolveRouteHref = <Path extends RoutePath>(
     import.meta.env.WAKU_CONFIG_BASE_PATH,
   );
 
-const resolveRouteUrl = <Path extends RoutePath>(
-  to: RouteHref | BuildRouteHrefTarget<Path>,
-  resolveCodec: ReturnType<typeof useResolveSearchCodec>,
-): URL => new URL(resolveRouteHref(to, resolveCodec), window.location.href);
-
 /**
  * Current route fields plus navigation helpers (`push`, `replace`, `reload`,
  * `back`, `forward`, `prefetch`).
@@ -280,7 +272,10 @@ export function useRouter() {
       to: RouteHref | BuildRouteHrefTarget<RoutePath>,
       options?: NavigateOptions,
     ) => {
-      const url = resolveRouteUrl(to, resolveCodec);
+      const url = new URL(
+        resolveRouteHref(to, resolveCodec),
+        window.location.href,
+      );
       return dispatchChangeRoute(changeRoute, parseRoute(url), {
         shouldScroll: options?.scroll ?? shouldScrollByDefault(url),
         history,
@@ -305,11 +300,12 @@ export function useRouter() {
     [navigate],
   ) as Navigate;
   const reload = useCallback(async () => {
-    await dispatchChangeRoute(changeRoute, parseRouteFromLocation(), {
+    const url = new URL(window.location.href);
+    await dispatchChangeRoute(changeRoute, parseRoute(url), {
       shouldScroll: true,
       refetch: true,
       history: 'replace',
-      url: new URL(window.location.href), // reloading moves nothing
+      url, // reloading moves nothing
     });
   }, [changeRoute]);
   const back = useCallback(() => {
@@ -323,7 +319,10 @@ export function useRouter() {
       to: RouteHref | BuildRouteHrefTarget<RoutePath>,
       options?: PrefetchOptions,
     ) => {
-      const url = resolveRouteUrl(to, resolveCodec);
+      const url = new URL(
+        resolveRouteHref(to, resolveCodec),
+        window.location.href,
+      );
       prefetchRoute(parseRoute(url), options);
     },
     [prefetchRoute, resolveCodec],
@@ -712,6 +711,11 @@ function renderError(message: string) {
   );
 }
 
+/**
+ * Catches render errors from its children and shows a fallback page. Used by
+ * the default root layout; apps can wrap their own root with it too. Followable
+ * navigation failures are handled inside the router before this boundary.
+ */
 export class ErrorBoundary extends Component<
   { children: ReactNode },
   { error?: unknown }
@@ -774,13 +778,13 @@ const FollowError = ({
       routerState !== dispatched.from &&
       !routerState.failure
     ) {
-      const landed =
+      const sameRequest =
         routerState.requested[0] === dispatched.route.path &&
         routerState.requested[1] === dispatched.route.query;
-      const arrived = landed
+      const followCompleted = sameRequest
         ? dispatched.route.path === routePath
         : routerState.url === dispatched.url;
-      if (arrived) {
+      if (followCompleted) {
         reset();
       } else {
         fail(error, new Error('detected a navigation loop', { cause: error }));
@@ -911,6 +915,12 @@ const preloadRouteModules = (path: string) => {
   });
 };
 
+/**
+ * Renders a named slice slot from the current RSC elements. With `lazy`, the
+ * first visit fetches the slice if it is missing or mutable; later visits reuse
+ * an immutable copy. The lazy `fallback` is shown only while the slot is absent
+ * from the elements map (it does not reappear on a later refetch — see FIXME).
+ */
 export function Slice({
   id,
   children,
@@ -955,11 +965,9 @@ export function Slice({
   return <Slot id={slotId}>{children}</Slot>;
 }
 
-const defaultRouteInterceptor = (route: RouteProps) => route;
-
 const InnerRouter = ({
   fallbackRoute,
-  routeInterceptor = defaultRouteInterceptor,
+  routeInterceptor,
 }: {
   fallbackRoute: RouteProps;
   routeInterceptor: ((route: RouteProps) => RouteProps | false) | undefined;
@@ -1067,7 +1075,7 @@ const InnerRouter = ({
     }
   }, [refetch, addToStaticPathSet, routeFallback]);
 
-  // state, not a ref: it is read during render (passed through context)
+  // starts empty so hydration matches; filled when a lazy Slice fetches
   const [fetchingSlices] = useState(() => new Set<SliceId>());
   const pendingNavigationRef = useRef<AbortController | null>(null);
 
@@ -1162,7 +1170,7 @@ const InnerRouter = ({
     [routeFallback, refetch, mergeElements, addToStaticPathSet],
   );
 
-  const applyChangeRouteData = useCallback(
+  const changeRouteFromServer = useCallback(
     async (routeData: unknown, isStatic: unknown) => {
       if (!routeData) {
         return;
@@ -1194,14 +1202,14 @@ const InnerRouter = ({
     const listener = (elements: Record<string, unknown>) => {
       addToStaticPathSet(elements);
       const { [ROUTE_ID]: routeData, [IS_STATIC_ID]: isStatic } = elements;
-      applyChangeRouteData(routeData, isStatic).catch((err) => {
+      changeRouteFromServer(routeData, isStatic).catch((err) => {
         if (!isFollowable(err)) {
           console.error('Error while handling route updates:', err);
         }
       });
     };
     return registerCallServerElementsListener(listener);
-  }, [applyChangeRouteData, addToStaticPathSet]);
+  }, [changeRouteFromServer, addToStaticPathSet]);
 
   const prefetchRoute: PrefetchRoute = useCallback((route, options) => {
     preloadRouteModules(route.path);
@@ -1222,9 +1230,9 @@ const InnerRouter = ({
 
   useEffect(() => {
     const callback = () => {
-      const popped = parseRouteFromLocation();
-      const nextRoute = routeInterceptor(popped);
-      if (!nextRoute) {
+      const popped = parseRoute(new URL(window.location.href));
+      const nextRoute = routeInterceptor ? routeInterceptor(popped) : popped;
+      if (nextRoute === false) {
         return;
       }
       startTransition(() => {
@@ -1285,7 +1293,7 @@ const InnerRouter = ({
  * browser location.
  */
 export function Router({
-  initialRoute = parseRouteFromLocation(),
+  initialRoute = parseRoute(new URL(window.location.href)),
   unstable_routeInterceptor,
 }: {
   initialRoute?: RouteProps;

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1232,7 +1232,7 @@ const InnerRouter = ({
     const callback = () => {
       const popped = parseRoute(new URL(window.location.href));
       const nextRoute = routeInterceptor ? routeInterceptor(popped) : popped;
-      if (nextRoute === false) {
+      if (!nextRoute) {
         return;
       }
       startTransition(() => {


### PR DESCRIPTION
Inline one-line helpers, name prefetch maps by role, and document Slice and ErrorBoundary without changing router behavior.