### PR TITLE
breaking(minimal): remove deprecated APIs

### DIFF
--- a/e2e/fixtures/instant-nav/src/components/MinimalRefetch.tsx
+++ b/e2e/fixtures/instant-nav/src/components/MinimalRefetch.tsx
@@ -1,6 +1,28 @@
 'use client';
 
-import { useRefetch } from 'waku/minimal/client';
+import { useCallback } from 'react';
+import {
+  unstable_fetchRsc as fetchRsc,
+  unstable_registerRscReloadListener as registerRscReloadListener,
+  useMergeElements_UNSTABLE as useMergeElements,
+} from 'waku/minimal/client';
+
+const useRefetch = () => {
+  const mergeElements = useMergeElements();
+  return useCallback(
+    (rscPath: string, rscParams?: unknown) => {
+      const refetch = () => mergeElements(fetchRsc(rscPath, rscParams));
+      registerRscReloadListener(
+        () => {
+          void refetch();
+        },
+        { replace: true },
+      );
+      return refetch();
+    },
+    [mergeElements],
+  );
+};
 
 export function MinimalRefetch() {
   const refetch = useRefetch();

--- a/e2e/fixtures/minimal-examples/package.json
+++ b/e2e/fixtures/minimal-examples/package.json
@@ -16,7 +16,7 @@
     "react-dom": "~19.2.8",
     "react-server-dom-webpack": "~19.2.8",
     "waku": "latest",
-    "waku-jotai": "^0.5.0"
+    "waku-jotai": "^0.6.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.17",

--- a/e2e/fixtures/waku-jotai-integration/package.json
+++ b/e2e/fixtures/waku-jotai-integration/package.json
@@ -14,7 +14,7 @@
     "react-dom": "~19.2.8",
     "react-server-dom-webpack": "~19.2.8",
     "waku": "latest",
-    "waku-jotai": "^0.5.0"
+    "waku-jotai": "^0.6.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.17",

--- a/packages/waku/src/minimal/client-utils/fetch-store.ts
+++ b/packages/waku/src/minimal/client-utils/fetch-store.ts
@@ -20,19 +20,7 @@ export type FetchRscInputTransformer = (
   rscPath: string,
   rscParams: unknown,
 ) => readonly [rscPath: string, rscParams: unknown];
-export type LegacyFetchRscInputTransformer = (
-  rscPath: string,
-  rscParams: unknown,
-  prefetchOnly: boolean,
-) => readonly [rscPath: string, rscParams: unknown, prefetchOnly: boolean];
-export type CompatibleFetchRscInputTransformer = (
-  rscPath: string,
-  rscParams: unknown,
-  prefetchOnly: false,
-) =>
-  | ReturnType<FetchRscInputTransformer>
-  | ReturnType<LegacyFetchRscInputTransformer>;
-type FetchRscInputTransformers = Set<CompatibleFetchRscInputTransformer>;
+type FetchRscInputTransformers = Set<FetchRscInputTransformer>;
 
 type CallServerElementsListeners = Set<
   (elements: Record<string, unknown>) => void

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -33,10 +33,8 @@ import {
   fetchRscStore,
 } from './client-utils/fetch-store.js';
 import type {
-  CompatibleFetchRscInputTransformer,
   FetchEnhancer,
   FetchRscInputTransformer,
-  LegacyFetchRscInputTransformer,
   SetElements,
 } from './client-utils/fetch-store.js';
 
@@ -260,11 +258,6 @@ type MergeElementsOptions = {
   };
 };
 
-type RefetchOptions = MergeElementsOptions & {
-  signal?: AbortSignal;
-  onBuildIdMismatch?: () => void;
-};
-
 const getFetchFn = (): typeof fetch => {
   let fetchFn = fetch;
   const enhancers = fetchRscStore[FETCH_ENHANCERS];
@@ -362,7 +355,7 @@ const applyInputTransformers = (
   const fetchRscInputTransformers = fetchRscStore[FETCH_RSC_INPUT_TRANSFORMERS];
   if (fetchRscInputTransformers) {
     for (const transformFetchRscInput of fetchRscInputTransformers) {
-      [rscPath, rscParams] = transformFetchRscInput(rscPath, rscParams, false);
+      [rscPath, rscParams] = transformFetchRscInput(rscPath, rscParams);
     }
   }
   return [rscPath, rscParams];
@@ -465,17 +458,6 @@ export const unstable_registerFetchEnhancer = (
  */
 export function unstable_registerFetchRscInputTransformer(
   transformFetchRscInput: FetchRscInputTransformer,
-): Unregister;
-/**
- * @deprecated Use a two-argument transformer that returns the transformed RSC
- * path and params. The third argument is always `false`, and the third return
- * value is ignored.
- */
-export function unstable_registerFetchRscInputTransformer(
-  transformFetchRscInput: LegacyFetchRscInputTransformer,
-): Unregister;
-export function unstable_registerFetchRscInputTransformer(
-  transformFetchRscInput: CompatibleFetchRscInputTransformer,
 ): Unregister {
   const fetchRscInputTransformers = (fetchRscStore[
     FETCH_RSC_INPUT_TRANSFORMERS
@@ -719,44 +701,6 @@ export const Slot_UNSTABLE = ({
     <ChildrenContextProvider value={children}>
       {element as ReactNode}
     </ChildrenContextProvider>
-  );
-};
-
-/** @deprecated Use `Root_UNSTABLE`. */
-export const Root = Root_UNSTABLE;
-/** @deprecated Use `Slot_UNSTABLE`. */
-export const Slot = Slot_UNSTABLE;
-/** @deprecated Use `Children_UNSTABLE`. */
-export const Children = Children_UNSTABLE;
-/**
- * @deprecated Define a hook with `unstable_fetchRsc` and
- * `useMergeElements_UNSTABLE` instead.
- */
-export const useRefetch = () => {
-  const mergeElements = useMergeElements_UNSTABLE();
-  return useCallback(
-    (rscPath: string, rscParams?: unknown, options?: RefetchOptions) => {
-      const refetch = () => {
-        const { unstable_overlay, unstable_swr, ...fetchOptions } =
-          options ?? {};
-        const elements = unstable_fetchRsc(rscPath, rscParams, {
-          ...fetchOptions,
-          ...(unstable_swr?.base ? { unstable_base: unstable_swr.base } : {}),
-        });
-        return mergeElements(elements, {
-          ...(unstable_overlay ? { unstable_overlay } : {}),
-          ...(unstable_swr ? { unstable_swr } : {}),
-        });
-      };
-      unstable_registerRscReloadListener(
-        () => {
-          void refetch();
-        },
-        { replace: true },
-      );
-      return refetch();
-    },
-    [mergeElements],
   );
 };
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+// Test probes expose hook values and state setters to their test cases.
 
 import { StrictMode, Suspense, act, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -25,7 +26,7 @@ import {
   unstable_registerFetchEnhancer,
   unstable_registerFetchRscInputTransformer,
   useElementsPromise_UNSTABLE,
-  useRefetch,
+  useMergeElements_UNSTABLE,
 } from '../src/minimal/client.js';
 
 type CallServer = (funcId: string, args: unknown[]) => Promise<unknown>;
@@ -58,6 +59,25 @@ const resolvedThenable = <T,>(value: T): Promise<T> =>
     status: 'fulfilled' as const,
     value,
   });
+
+const useRefetch = () => {
+  const mergeElements = useMergeElements_UNSTABLE();
+  return (
+    rscPath: string,
+    rscParams?: unknown,
+    options?: Parameters<typeof mergeElements>[1],
+  ) =>
+    mergeElements(
+      unstable_fetchRsc(rscPath, rscParams, {
+        ...(options?.unstable_swr?.base
+          ? { unstable_base: options.unstable_swr.base }
+          : {}),
+      }),
+      options,
+    );
+};
+
+type Refetch = ReturnType<typeof useRefetch>;
 
 // The client store is a module singleton; reset it between tests.
 const clientStore = fetchRscStore as unknown as Record<string, unknown>;
@@ -405,21 +425,6 @@ describe('minimal/client input transformer', () => {
     ]);
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain('rewritten');
   });
-
-  test('supports the deprecated transformer signature', async () => {
-    const fetchMock = vi.fn<typeof fetch>(async () => new Response('{}'));
-    track(unstable_registerFetchEnhancer(() => fetchMock));
-    const transform = vi.fn(
-      (_rscPath: string, _rscParams: unknown, prefetchOnly: boolean) =>
-        ['R/legacy.txt', { x: 1 }, prefetchOnly] as const,
-    );
-    track(unstable_registerFetchRscInputTransformer(transform));
-
-    await unstable_fetchRsc('R/original.txt', undefined);
-
-    expect(transform).toHaveBeenCalledWith('R/original.txt', undefined, false);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('legacy');
-  });
 });
 
 describe('minimal/client eager merge', () => {
@@ -430,11 +435,13 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let mountExtra: () => void = () => {};
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
       const [extra, setExtra] = useState(false);
+      // eslint-disable-next-line react-hooks/globals
       mountExtra = () => setExtra(true);
       return extra ? <Slot id="extra" /> : null;
     };
@@ -484,11 +491,13 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let mountExtra: () => void = () => {};
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
       const [extra, setExtra] = useState(false);
+      // eslint-disable-next-line react-hooks/globals
       mountExtra = () => setExtra(true);
       return extra ? <Slot id="extra" /> : null;
     };
@@ -531,8 +540,9 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
       return null;
     };
@@ -589,10 +599,12 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
+      // eslint-disable-next-line react-hooks/globals
       elementsPromise = useElementsPromise_UNSTABLE();
       return null;
     };
@@ -644,10 +656,12 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
+      // eslint-disable-next-line react-hooks/globals
       elementsPromise = useElementsPromise_UNSTABLE();
       return null;
     };
@@ -682,10 +696,12 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
+      // eslint-disable-next-line react-hooks/globals
       elementsPromise = useElementsPromise_UNSTABLE();
       return null;
     };
@@ -726,10 +742,12 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
+      // eslint-disable-next-line react-hooks/globals
       elementsPromise = useElementsPromise_UNSTABLE();
       return null;
     };
@@ -786,10 +804,12 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
+      // eslint-disable-next-line react-hooks/globals
       elementsPromise = useElementsPromise_UNSTABLE();
       return null;
     };
@@ -841,10 +861,12 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
+      // eslint-disable-next-line react-hooks/globals
       elementsPromise = useElementsPromise_UNSTABLE();
       return null;
     };
@@ -890,10 +912,12 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
+      // eslint-disable-next-line react-hooks/globals
       elementsPromise = useElementsPromise_UNSTABLE();
       return null;
     };
@@ -964,10 +988,12 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
+      // eslint-disable-next-line react-hooks/globals
       elementsPromise = useElementsPromise_UNSTABLE();
       return null;
     };
@@ -1024,11 +1050,13 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let mountExtra: () => void = () => {};
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
       const [extra, setExtra] = useState(false);
+      // eslint-disable-next-line react-hooks/globals
       mountExtra = () => setExtra(true);
       return extra ? (
         <>
@@ -1117,11 +1145,13 @@ describe('minimal/client eager merge', () => {
     );
     stubFetch();
 
-    let refetch: ReturnType<typeof useRefetch> | undefined;
+    let refetch: Refetch | undefined;
     let mountExtra: () => void = () => {};
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
       const [extra, setExtra] = useState(false);
+      // eslint-disable-next-line react-hooks/globals
       mountExtra = () => setExtra(true);
       return extra ? <Slot id="extra" /> : null;
     };
@@ -1159,12 +1189,13 @@ describe('minimal/client refetch scenarios', () => {
   // No-router scenario tests for refetch's merge behavior.
   const mount = async (
     initial: Record<string, unknown>,
-    ui: (refetchRef: { current?: ReturnType<typeof useRefetch> }) => ReactNode,
+    ui: (refetchRef: { current?: Refetch }) => ReactNode,
   ) => {
     mocks.createFromFetch.mockReturnValueOnce(resolvedThenable(initial));
     stubFetch();
-    const refetchRef: { current?: ReturnType<typeof useRefetch> } = {};
+    const refetchRef: { current?: Refetch } = {};
     const Probe = () => {
+      // eslint-disable-next-line react-hooks/immutability
       refetchRef.current = useRefetch();
       return null;
     };
@@ -1246,8 +1277,10 @@ describe('minimal/client refetch scenarios', () => {
     let mountExtra = () => {};
     const view = await mount({ _value: null, main: 'M1' }, (ref) => {
       const Holder = () => {
+        // eslint-disable-next-line react-hooks/immutability
         ref.current = useRefetch();
         const [extra, setExtra] = useState(false);
+        // eslint-disable-next-line react-hooks/globals
         mountExtra = () => setExtra(true);
         return extra ? (
           <Suspense fallback={<span>loading</span>}>

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment happy-dom
-// Test probes expose hook values and state setters to their test cases.
 
-import { StrictMode, Suspense, act, useState } from 'react';
+import { StrictMode, Suspense, act, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 import {
@@ -438,11 +437,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let mountExtra: () => void = () => {};
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
+      const refetchValue = useRefetch();
       const [extra, setExtra] = useState(false);
-      // eslint-disable-next-line react-hooks/globals
-      mountExtra = () => setExtra(true);
+      useEffect(() => {
+        refetch = refetchValue;
+        mountExtra = () => setExtra(true);
+      });
       return extra ? <Slot id="extra" /> : null;
     };
 
@@ -494,11 +494,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let mountExtra: () => void = () => {};
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
+      const refetchValue = useRefetch();
       const [extra, setExtra] = useState(false);
-      // eslint-disable-next-line react-hooks/globals
-      mountExtra = () => setExtra(true);
+      useEffect(() => {
+        refetch = refetchValue;
+        mountExtra = () => setExtra(true);
+      });
       return extra ? <Slot id="extra" /> : null;
     };
 
@@ -542,8 +543,10 @@ describe('minimal/client eager merge', () => {
 
     let refetch: Refetch | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
+      const refetchValue = useRefetch();
+      useEffect(() => {
+        refetch = refetchValue;
+      });
       return null;
     };
 
@@ -602,10 +605,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
-      // eslint-disable-next-line react-hooks/globals
-      elementsPromise = useElementsPromise_UNSTABLE();
+      const refetchValue = useRefetch();
+      const elementsPromiseValue = useElementsPromise_UNSTABLE();
+      useEffect(() => {
+        refetch = refetchValue;
+        elementsPromise = elementsPromiseValue;
+      });
       return null;
     };
 
@@ -659,10 +664,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
-      // eslint-disable-next-line react-hooks/globals
-      elementsPromise = useElementsPromise_UNSTABLE();
+      const refetchValue = useRefetch();
+      const elementsPromiseValue = useElementsPromise_UNSTABLE();
+      useEffect(() => {
+        refetch = refetchValue;
+        elementsPromise = elementsPromiseValue;
+      });
       return null;
     };
 
@@ -699,10 +706,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
-      // eslint-disable-next-line react-hooks/globals
-      elementsPromise = useElementsPromise_UNSTABLE();
+      const refetchValue = useRefetch();
+      const elementsPromiseValue = useElementsPromise_UNSTABLE();
+      useEffect(() => {
+        refetch = refetchValue;
+        elementsPromise = elementsPromiseValue;
+      });
       return null;
     };
 
@@ -745,10 +754,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
-      // eslint-disable-next-line react-hooks/globals
-      elementsPromise = useElementsPromise_UNSTABLE();
+      const refetchValue = useRefetch();
+      const elementsPromiseValue = useElementsPromise_UNSTABLE();
+      useEffect(() => {
+        refetch = refetchValue;
+        elementsPromise = elementsPromiseValue;
+      });
       return null;
     };
 
@@ -807,10 +818,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
-      // eslint-disable-next-line react-hooks/globals
-      elementsPromise = useElementsPromise_UNSTABLE();
+      const refetchValue = useRefetch();
+      const elementsPromiseValue = useElementsPromise_UNSTABLE();
+      useEffect(() => {
+        refetch = refetchValue;
+        elementsPromise = elementsPromiseValue;
+      });
       return null;
     };
 
@@ -864,10 +877,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
-      // eslint-disable-next-line react-hooks/globals
-      elementsPromise = useElementsPromise_UNSTABLE();
+      const refetchValue = useRefetch();
+      const elementsPromiseValue = useElementsPromise_UNSTABLE();
+      useEffect(() => {
+        refetch = refetchValue;
+        elementsPromise = elementsPromiseValue;
+      });
       return null;
     };
 
@@ -915,10 +930,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
-      // eslint-disable-next-line react-hooks/globals
-      elementsPromise = useElementsPromise_UNSTABLE();
+      const refetchValue = useRefetch();
+      const elementsPromiseValue = useElementsPromise_UNSTABLE();
+      useEffect(() => {
+        refetch = refetchValue;
+        elementsPromise = elementsPromiseValue;
+      });
       return null;
     };
 
@@ -991,10 +1008,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let elementsPromise: Promise<Record<string, unknown>> | undefined;
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
-      // eslint-disable-next-line react-hooks/globals
-      elementsPromise = useElementsPromise_UNSTABLE();
+      const refetchValue = useRefetch();
+      const elementsPromiseValue = useElementsPromise_UNSTABLE();
+      useEffect(() => {
+        refetch = refetchValue;
+        elementsPromise = elementsPromiseValue;
+      });
       return null;
     };
 
@@ -1053,11 +1072,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let mountExtra: () => void = () => {};
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
+      const refetchValue = useRefetch();
       const [extra, setExtra] = useState(false);
-      // eslint-disable-next-line react-hooks/globals
-      mountExtra = () => setExtra(true);
+      useEffect(() => {
+        refetch = refetchValue;
+        mountExtra = () => setExtra(true);
+      });
       return extra ? (
         <>
           <Suspense fallback={<span>[S]</span>}>
@@ -1148,11 +1168,12 @@ describe('minimal/client eager merge', () => {
     let refetch: Refetch | undefined;
     let mountExtra: () => void = () => {};
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
+      const refetchValue = useRefetch();
       const [extra, setExtra] = useState(false);
-      // eslint-disable-next-line react-hooks/globals
-      mountExtra = () => setExtra(true);
+      useEffect(() => {
+        refetch = refetchValue;
+        mountExtra = () => setExtra(true);
+      });
       return extra ? <Slot id="extra" /> : null;
     };
 
@@ -1195,8 +1216,10 @@ describe('minimal/client refetch scenarios', () => {
     stubFetch();
     const refetchRef: { current?: Refetch } = {};
     const Probe = () => {
-      // eslint-disable-next-line react-hooks/immutability
-      refetchRef.current = useRefetch();
+      const refetch = useRefetch();
+      useEffect(() => {
+        refetchRef.current = refetch;
+      });
       return null;
     };
     const container = document.createElement('div');
@@ -1277,11 +1300,12 @@ describe('minimal/client refetch scenarios', () => {
     let mountExtra = () => {};
     const view = await mount({ _value: null, main: 'M1' }, (ref) => {
       const Holder = () => {
-        // eslint-disable-next-line react-hooks/immutability
-        ref.current = useRefetch();
+        const refetch = useRefetch();
         const [extra, setExtra] = useState(false);
-        // eslint-disable-next-line react-hooks/globals
-        mountExtra = () => setExtra(true);
+        useEffect(() => {
+          ref.current = refetch;
+          mountExtra = () => setExtra(true);
+        });
         return extra ? (
           <Suspense fallback={<span>loading</span>}>
             <Slot id="extra" />

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+// Test components expose hook values to their test cases.
 
 // Proves the per-slot cache-validator carry/replay lives in the minimal layer
 // (router-agnostic), driving the real minimal Root.
@@ -23,7 +24,7 @@ import {
   Root_UNSTABLE as Root,
   unstable_fetchRsc as fetchRsc,
   unstable_isImmutableElement as isImmutableElement,
-  useRefetch,
+  useMergeElements_UNSTABLE,
 } from '../src/minimal/client.js';
 import { unstable_buildElements as buildElements } from '../src/minimal/server.js';
 
@@ -47,6 +48,25 @@ const flush = async () => {
     await new Promise<void>((resolve) => setTimeout(resolve));
   });
 };
+
+const useRefetch = () => {
+  const mergeElements = useMergeElements_UNSTABLE();
+  return (
+    rscPath: string,
+    rscParams?: unknown,
+    options?: Parameters<typeof mergeElements>[1],
+  ) =>
+    mergeElements(
+      fetchRsc(rscPath, rscParams, {
+        ...(options?.unstable_swr?.base
+          ? { unstable_base: options.unstable_swr.base }
+          : {}),
+      }),
+      options,
+    );
+};
+
+type Refetch = ReturnType<typeof useRefetch>;
 
 const renderApp = async (element: ReactElement) => {
   const container = document.createElement('div');
@@ -123,8 +143,9 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
       page: <div>a</div>,
       [`${ETAG_ID_PREFIX}page`]: IMMUTABLE_ETAG,
     };
-    let refetch!: ReturnType<typeof useRefetch>;
+    let refetch!: Refetch;
     const Capture = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
       return null;
     };
@@ -161,8 +182,9 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
       page: <div>a</div>,
       [`${ETAG_ID_PREFIX}page`]: 'etag-page',
     };
-    let refetch!: ReturnType<typeof useRefetch>;
+    let refetch!: Refetch;
     const Capture = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
       return null;
     };
@@ -250,8 +272,9 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
       page: <div>a</div>,
       [`${ETAG_ID_PREFIX}page`]: IMMUTABLE_ETAG,
     };
-    let refetch!: ReturnType<typeof useRefetch>;
+    let refetch!: Refetch;
     const Capture = () => {
+      // eslint-disable-next-line react-hooks/globals
       refetch = useRefetch();
       return null;
     };

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -1,9 +1,8 @@
 // @vitest-environment happy-dom
-// Test components expose hook values to their test cases.
 
 // Proves the per-slot cache-validator carry/replay lives in the minimal layer
 // (router-agnostic), driving the real minimal Root.
-import { act } from 'react';
+import { act, useEffect } from 'react';
 import type { ReactElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -145,8 +144,10 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     };
     let refetch!: Refetch;
     const Capture = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
+      const refetchValue = useRefetch();
+      useEffect(() => {
+        refetch = refetchValue;
+      });
       return null;
     };
     const view = await renderApp(
@@ -184,8 +185,10 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     };
     let refetch!: Refetch;
     const Capture = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
+      const refetchValue = useRefetch();
+      useEffect(() => {
+        refetch = refetchValue;
+      });
       return null;
     };
     const view = await renderApp(
@@ -274,8 +277,10 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     };
     let refetch!: Refetch;
     const Capture = () => {
-      // eslint-disable-next-line react-hooks/globals
-      refetch = useRefetch();
+      const refetchValue = useRefetch();
+      useEffect(() => {
+        refetch = refetchValue;
+      });
       return null;
     };
     const view = await renderApp(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,8 +463,8 @@ importers:
         specifier: latest
         version: link:../../../packages/waku
       waku-jotai:
-        specifier: ^0.5.0
-        version: 0.5.0(jotai@2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(waku@packages+waku)
+        specifier: ^0.6.0
+        version: 0.6.0(jotai@2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(waku@packages+waku)
     devDependencies:
       '@types/react':
         specifier: ^19.2.17
@@ -1200,8 +1200,8 @@ importers:
         specifier: latest
         version: link:../../../packages/waku
       waku-jotai:
-        specifier: ^0.5.0
-        version: 0.5.0(jotai@2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(waku@packages+waku)
+        specifier: ^0.6.0
+        version: 0.6.0(jotai@2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(waku@packages+waku)
     devDependencies:
       '@types/react':
         specifier: ^19.2.17
@@ -6785,12 +6785,12 @@ packages:
       jsdom:
         optional: true
 
-  waku-jotai@0.5.0:
-    resolution: {integrity: sha512-hA9w7rdgYKdrKzzd/yxbFzIkEHIHcG8n0/sjJcTVwD5o7NFKhcYli5Eh2sx0Mrk5KoG/YJz8/6DfSesLvuhTPA==}
+  waku-jotai@0.6.0:
+    resolution: {integrity: sha512-Egi8veW63C4Szh1LaUwTYDPScGTBw4geSH5nFpbfUzs2MhfSYFprj/+afyz0+VVxt4D3kyLR/4DAW4YFoLrMgw==}
     peerDependencies:
       jotai: '>=2.20.0'
       react: '>=19.0.0'
-      waku: '>=1.0.0-beta.4'
+      waku: '>=1.0.0-beta.9'
 
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
@@ -12641,7 +12641,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  waku-jotai@0.5.0(jotai@2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(waku@packages+waku):
+  waku-jotai@0.6.0(jotai@2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(waku@packages+waku):
     dependencies:
       jotai: 2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8


### PR DESCRIPTION
Remove the stable component aliases, useRefetch, and the legacy fetch transformer signature after downstream users migrated.