### PR TITLE
refactor(router): simplify redirect and 404 handling

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -165,11 +165,11 @@ export const PostButton = () => {
 
 Both return a promise that resolves once the navigation you asked for has been handled: after the response when the route needs one, right away when it does not, such as a static route already loaded once or the route you are already on, and also when a newer navigation supersedes it.
 
-It does not wait for a follow. Anything your page throws while rendering, such as a late `unstable_notFound()` or `unstable_redirect()`, is followed by a navigation of its own that starts after this promise has settled.
+When a fetch redirects to another route or needs the custom 404 page, the same navigation fetches that destination before it resolves. Anything your page throws later while rendering, such as a late `unstable_notFound()` or `unstable_redirect()`, is followed by a navigation of its own after this promise has settled.
 
-A missing route depends on who answers the request. A Waku server sends the 404 page as the response, so the promise resolves and the route you land on is `/404`. Where no Waku server answers, such as a static export or a CDN serving its own 404, the request fails and the client fetches the 404 page itself: there the promise **rejects** and the 404 page arrives from a second navigation.
+A missing route depends on who answers the request. A Waku server can send the 404 page as the first response. Where the first request instead reports a missing route, the client fetches the custom 404 page itself. In both cases, the promise resolves with the `/404` route while the address bar keeps the URL that was requested. Without a custom 404 route, the promise rejects and the built-in Not Found page is shown.
 
-The promise also rejects when the navigation fails outright, and when a redirect hands the page to the browser, which it does whether the redirect was thrown while rendering or resolved before rendering started. A redirect to a route of this app is different: the server answers it with the destination, and the promise resolves there. Catch it if you call these programmatically, or an auth redirect at the fetch layer will surface as an unhandled rejection. It does not wait for React to finish rendering the destination, so the address bar may still show the previous URL when it resolves.
+The promise also rejects when the navigation fails outright and when a redirect hands the page to the browser. A redirect to a route of this app is different: the client follows it and the promise resolves with that destination. Catch failures when you call these methods programmatically. Navigation failures are rendered through `ErrorBoundary`. The promise does not wait for React to finish rendering the destination, so the address bar may still show the previous URL when it resolves.
 
 When the shell is cached, the layout and the `Loading...` fallback appear with no round trip, and the post's content streams into the fallback once the server responds. When the shell is **not** cached, the navigation falls back to normal behavior: the current page stays put until the response arrives, so there is no blank flash.
 
@@ -247,7 +247,7 @@ export const NavigationLogger = () => {
 
 The effect runs for the initial route and whenever the current route fields change. It does not run again for `reload()` or navigation to the same URL, and it does not observe the start of a navigation. Instant navigation commits the requested route before reconciliation, so a redirected instant navigation logs the optimistic route and then the reconciled one; keep the previous value if you only want landings.
 
-Catch the promises returned by programmatic `push`, `replace`, and `reload` calls to handle their direct errors. There is no global failure callback for `<Link>` or browser back and forward; failed navigations still surface through `ErrorBoundary` from `waku/router/client` (or your own boundary around the router). Do not treat promise resolution as a committed-route signal: a newer navigation can supersede the request, and redirects or other follows may continue after it settles. Observe the route fields above when you need the destination that was committed.
+Catch the promises returned by programmatic `push`, `replace`, and `reload` calls to handle fetch errors. There is no global failure callback for `<Link>` or browser back and forward; failed navigations surface through `ErrorBoundary` from `waku/router/client` (or your own boundary around the router). Do not treat promise resolution as a committed-route signal: a newer navigation can supersede the request, and a render-time redirect or 404 can start another navigation after it settles. Observe the route fields above when you need the destination that was committed.
 
 ## Custom Transitions
 

--- a/packages/waku/src/router/client-utils/error-route.ts
+++ b/packages/waku/src/router/client-utils/error-route.ts
@@ -6,6 +6,7 @@ import {
 import {
   getRouteUrl,
   isInsideBase,
+  isSameRscRoute,
   parseRedirectUrl,
   parseRoute,
   redactCredentials,
@@ -59,4 +60,53 @@ export const resolveErrorRoute = (
     return { type: 'route', target, url: requestedUrl };
   }
   return { type: 'none' };
+};
+
+type FollowDecision =
+  | { type: 'follow'; target: RouteProps; url: URL }
+  | { type: 'leave'; url: URL }
+  | { type: 'stop'; error: unknown }
+  | { type: 'none' };
+
+export const decideFollow = (
+  error: unknown,
+  requested: {
+    route: Pick<RouteProps, 'path' | 'query'>;
+    url: URL;
+    follows: number;
+  },
+  options: { has404: boolean; maxFollows: number },
+): FollowDecision => {
+  const errorRoute = resolveErrorRoute(error, requested.url, options.has404);
+  if (errorRoute.type === 'none') {
+    return { type: 'none' };
+  }
+  if (errorRoute.type === 'unfollowable') {
+    return {
+      type: 'stop',
+      error: new Error(`cannot follow a redirect to ${errorRoute.location}`, {
+        cause: error,
+      }),
+    };
+  }
+  if (errorRoute.type === 'leave') {
+    return { type: 'leave', url: errorRoute.url };
+  }
+  const { target, url } = errorRoute;
+  if (
+    isSameRscRoute(target, requested.route) &&
+    url.href === requested.url.href
+  ) {
+    return {
+      type: 'stop',
+      error: new Error('detected a navigation loop', { cause: error }),
+    };
+  }
+  if (requested.follows >= options.maxFollows) {
+    return {
+      type: 'stop',
+      error: new Error('too many redirect or 404 follows', { cause: error }),
+    };
+  }
+  return { type: 'follow', target, url };
 };

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -35,12 +35,8 @@ export type RouterState = {
   readonly requested: readonly [path: string, query: string];
   readonly history: 'push' | 'replace' | null;
   readonly scroll: { readonly pathChanged: boolean } | null;
-  readonly followCount: number;
-  // set when the fetch never landed, so the route id is stale
-  readonly failure?: {
-    readonly error: unknown;
-    readonly committedHash: string;
-  };
+  readonly follows: number;
+  readonly failedFrom?: RouteProps;
 };
 
 export const getRouterState = (
@@ -55,14 +51,14 @@ export const makeRouterState = (
     history: 'push' | 'replace' | null;
     scroll: boolean;
     pathChanged: boolean;
-    followCount: number;
+    follows: number;
   },
 ): RouterState => ({
   url: url.pathname + url.search + url.hash,
   requested: [route.path, route.query],
   history: options.history,
   scroll: options.scroll ? { pathChanged: options.pathChanged } : null,
-  followCount: options.followCount,
+  follows: options.follows,
 });
 
 export const resolveServerRedirect = (
@@ -71,9 +67,17 @@ export const resolveServerRedirect = (
   fallbackPath: string,
 ): { route: RouteProps; url: URL } => {
   const stateUrl = new URL(routerState.url, window.location.href);
-  const serverRoute = routerState.failure
-    ? undefined
-    : getRouteFromElements(elements);
+  if (routerState.failedFrom) {
+    return {
+      route: {
+        path: routerState.requested[0],
+        query: stateUrl.searchParams.toString(),
+        hash: stateUrl.hash,
+      },
+      url: stateUrl,
+    };
+  }
+  const serverRoute = getRouteFromElements(elements);
   const redirect =
     serverRoute &&
     (serverRoute.path !== routerState.requested[0] ||
@@ -86,8 +90,7 @@ export const resolveServerRedirect = (
   }
   return {
     route: {
-      path:
-        redirect?.path ?? getRouteFromElements(elements)?.path ?? fallbackPath,
+      path: redirect?.path ?? serverRoute?.path ?? fallbackPath,
       query: stateUrl.searchParams.toString(),
       hash: stateUrl.hash,
     },
@@ -95,10 +98,6 @@ export const resolveServerRedirect = (
   };
 };
 
-/**
- * A failed navigation keeps the hash still on screen, unlike the route the
- * router paints, which takes its hash from the requested url.
- */
 export const getSettledRoute = (
   elements: Record<string | symbol, unknown>,
   fallback: RouteProps,
@@ -107,13 +106,10 @@ export const getSettledRoute = (
   if (!routerState) {
     return fallback;
   }
-  if (routerState.failure) {
-    return {
-      ...(getRouteFromElements(elements) ?? fallback),
-      hash: routerState.failure.committedHash,
-    };
-  }
-  return resolveServerRedirect(elements, routerState, fallback.path).route;
+  return (
+    routerState.failedFrom ??
+    resolveServerRedirect(elements, routerState, fallback.path).route
+  );
 };
 
 export const canCommitInstantly = (

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1283,7 +1283,8 @@ const InnerRouter = ({
         url: routeUrl,
         follows: options.follows ?? 0,
       };
-      const pathChanged = initialAttempt.route.path !== settledRoute.path;
+      const requestedPathChanged =
+        initialAttempt.route.path !== settledRoute.path;
       const shouldRefetch =
         options.refetch ?? !isSameRscRoute(nextRoute, settledRoute);
       const makeStateForAttempt = (
@@ -1293,7 +1294,8 @@ const InnerRouter = ({
         makeRouterState(attempt.route, attempt.url, {
           history,
           scroll: options.shouldScroll,
-          pathChanged,
+          pathChanged:
+            requestedPathChanged || attempt.route.path !== settledRoute.path,
           follows: attempt.follows,
         });
       const controller = new AbortController();
@@ -1518,7 +1520,7 @@ const InnerRouter = ({
         history: outcome.history,
         scroll: options.shouldScroll,
         pathChanged:
-          pathChanged || destination.route.path !== settledRoute.path,
+          requestedPathChanged || destination.route.path !== settledRoute.path,
         follows: attempt.follows,
       });
       commit(

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -39,7 +39,7 @@ import {
   useElementsPromise_UNSTABLE as useElementsPromise,
   useMergeElements_UNSTABLE as useMergeElements,
 } from '../minimal/client.js';
-import { isFollowable, resolveErrorRoute } from './client-utils/error-route.js';
+import { decideFollow, isFollowable } from './client-utils/error-route.js';
 import {
   type PrefetchOptions,
   createPrefetchManager,
@@ -114,10 +114,10 @@ type NavigateOptions = {
  * Resolves once the requested navigation has been handled: after its response
  * when the route needs one, right away when it does not, and when a newer
  * navigation supersedes it. Rejects when the navigation fails, when a redirect
- * hands the page to the browser, and when a missing route gets no answer from a
- * Waku server (a Waku server sends the 404 page instead, which resolves). Never
- * waits for a follow, and does not wait for React to render, so the address bar
- * may still show the previous URL.
+ * hands the page to the browser, and when no custom 404 route can answer a
+ * missing route. A redirect or 404 received while fetching is followed before
+ * this resolves. It does not wait for React to render, so the address bar may
+ * still show the previous URL.
  */
 type Navigate = {
   (to: RouteHref, options?: NavigateOptions): Promise<void>;
@@ -216,7 +216,7 @@ const abortable = <T,>(
   });
 };
 
-const fetchRoute = (
+const fetchRouteElements = (
   rscPath: string,
   rscParams: URLSearchParams,
   {
@@ -261,7 +261,7 @@ type ChangeRouteOptions = {
   history: 'push' | 'replace' | null;
   url?: URL | undefined;
   instant?: boolean | undefined;
-  isFollow?: boolean | undefined;
+  follows?: number | undefined;
   startTransition?: ((fn: TransitionFunction) => void) | undefined;
 };
 
@@ -269,6 +269,43 @@ type ChangeRoute = (
   route: RouteProps,
   options: ChangeRouteOptions,
 ) => Promise<void>;
+
+type HistoryIntent = ChangeRouteOptions['history'];
+
+type NavigationAttempt = {
+  route: RouteProps;
+  url: URL;
+  follows: number;
+};
+
+type NavigationOutcome =
+  | {
+      type: 'landed';
+      attempt: NavigationAttempt;
+      history: HistoryIntent;
+      elements: Elements;
+      instant: boolean;
+    }
+  | {
+      type: 'static';
+      attempt: NavigationAttempt;
+      history: HistoryIntent;
+    }
+  | {
+      type: 'left';
+      attempt: NavigationAttempt;
+      history: HistoryIntent;
+      url: URL;
+      error: unknown;
+    }
+  | {
+      type: 'failed';
+      attempt: NavigationAttempt;
+      history: HistoryIntent;
+      error: unknown;
+      restoreBase: boolean;
+    }
+  | { type: 'superseded' };
 
 type PrefetchRoute = (route: RouteProps, options?: PrefetchOptions) => void;
 
@@ -713,7 +750,6 @@ export function Link<Path extends RoutePath>({
     if (url.href !== window.location.href) {
       const route = parseRoute(url);
       preloadRouteModules(route.path);
-      // a click has no caller to reject to; the boundary shows the failure
       dispatchChangeRoute(
         changeRoute,
         route,
@@ -801,9 +837,8 @@ function renderError(message: string) {
 }
 
 /**
- * Catches render errors from its children and shows a fallback page. Used by
- * the default root layout; apps can wrap their own root with it too. Followable
- * navigation failures are handled inside the router before this boundary.
+ * Catches errors from its children and shows a fallback page. Used by the
+ * default root layout; apps can wrap their own root with it too.
  */
 export class ErrorBoundary extends Component<
   { children: ReactNode },
@@ -861,12 +896,7 @@ const FollowError = ({
       return;
     }
     const dispatched = dispatchedRef.current;
-    if (
-      dispatched &&
-      routerState &&
-      routerState !== dispatched.from &&
-      !routerState.failure
-    ) {
+    if (dispatched && routerState && routerState !== dispatched.from) {
       const sameRequest =
         routerState.requested[0] === dispatched.route.path &&
         routerState.requested[1] === dispatched.route.query;
@@ -885,47 +915,40 @@ const FollowError = ({
     const stateUrl = routerState
       ? new URL(routerState.url, window.location.href)
       : new URL(window.location.href);
-    const errorRoute = resolveErrorRoute(error, stateUrl, has404);
-    if (errorRoute.type === 'none') {
-      return;
-    }
-    if (errorRoute.type === 'unfollowable') {
-      fail(
-        error,
-        new Error(`cannot follow a redirect to ${errorRoute.location}`, {
-          cause: error,
-        }),
-      );
-      return;
-    }
-    if (errorRoute.type === 'leave') {
-      // every leave replaces, so a navigation that already wrote its url does
-      // not stack an entry the reader never saw. An action leave drops the
-      // page it was on, which a form post without javascript would have kept
-      if (leftRef.current !== errorRoute.url.href) {
-        // dev replays the effect, and firefox cancels a navigation that is
-        // replaced while the first is still in flight
-        leftRef.current = errorRoute.url.href;
-        window.location.replace(errorRoute.url.href);
-      }
-      return;
-    }
-    const { target, url } = errorRoute;
     const requested = routerState?.requested;
     const caught = requested
       ? { path: requested[0], query: requested[1] }
       : parseRoute(stateUrl);
-    if (isSameRscRoute(target, caught) && url.href === stateUrl.href) {
-      fail(error, new Error('detected a navigation loop', { cause: error }));
+    const follows = routerState?.follows ?? 0;
+    const decision = decideFollow(
+      error,
+      { route: caught, url: stateUrl, follows },
+      {
+        has404,
+        maxFollows: MAX_FOLLOWS_PER_NAVIGATION,
+      },
+    );
+    if (decision.type === 'none') {
       return;
     }
-    if ((routerState?.followCount ?? 0) >= MAX_FOLLOWS_PER_NAVIGATION) {
-      fail(
-        error,
-        new Error('too many redirect or 404 follows', { cause: error }),
-      );
+    if (decision.type === 'stop') {
+      fail(error, decision.error);
       return;
     }
+    if (decision.type === 'leave') {
+      // every leave replaces, so a navigation that already wrote its url does
+      // not stack an entry the reader never saw. An action leave drops the
+      // page it was on, which a form post without javascript would have kept
+      if (leftRef.current !== decision.url.href) {
+        // dev replays the effect, and firefox cancels a navigation that is
+        // replaced while the first is still in flight
+        leftRef.current = decision.url.href;
+        window.location.replace(decision.url.href);
+      }
+      return;
+    }
+    const { target, url } = decision;
+    const nextFollows = follows + 1;
     dispatchedRef.current = {
       route: target,
       url: url.pathname + url.search + url.hash,
@@ -938,10 +961,17 @@ const FollowError = ({
           : target.path !== caught.path,
         history: 'replace',
         url,
-        isFollow: true,
         refetch: true,
+        follows: nextFollows,
       }).catch((err: unknown) => {
-        fail(error, err);
+        const rejected = decideFollow(
+          err,
+          { route: target, url, follows: nextFollows },
+          { has404, maxFollows: MAX_FOLLOWS_PER_NAVIGATION },
+        );
+        if (rejected.type !== 'leave') {
+          fail(error, err);
+        }
       });
     });
   });
@@ -1134,6 +1164,9 @@ const InnerRouter = ({
   } | null>(null);
   // starts empty so hydration matches the server, then the effect fills it
   const [restoredHash, setRestoredHash] = useState('');
+  const [navigationError, setNavigationError] = useState<{
+    error: unknown;
+  }>();
   useEffect(() => {
     setRestoredHash(window.location.hash || initialHashRef.current);
   }, []);
@@ -1175,7 +1208,7 @@ const InnerRouter = ({
       applied ? 'replace' : routerState.history,
     );
     appliedRef.current = routerState;
-    if (applied || !routerState.scroll || routerState.failure) {
+    if (applied || !routerState.scroll) {
       return;
     }
     const { pathChanged } = routerState.scroll;
@@ -1234,6 +1267,7 @@ const InnerRouter = ({
   const changeRoute: ChangeRoute = useCallback(
     async function changeRoute(nextRoute, options) {
       cancelPendingNavigation();
+      setNavigationError(undefined);
       if (import.meta.hot) {
         // A route navigation retires the previous Minimal refetch target.
         registerRscReloadListener(() => {}, { replace: true });
@@ -1242,23 +1276,30 @@ const InnerRouter = ({
         resolvedElementsRef.current,
         routeFallback,
       );
-      const targetUrl = options.url ?? getRouteUrl(nextRoute);
-      const routerState = makeRouterState(nextRoute, targetUrl, {
-        history: options.history,
-        scroll: options.shouldScroll,
-        pathChanged: nextRoute.path !== settledRoute.path,
-        followCount: options.isFollow
-          ? (getRouterState(resolvedElementsRef.current)?.followCount ?? 0) + 1
-          : 0,
-      });
+      const routeUrl = options.url ?? getRouteUrl(nextRoute);
+      const initialAttempt: NavigationAttempt = {
+        route: nextRoute,
+        url: routeUrl,
+        follows: options.follows ?? 0,
+      };
       const shouldRefetch =
         options.refetch ?? !isSameRscRoute(nextRoute, settledRoute);
+      const makeStateForAttempt = (
+        attempt: NavigationAttempt,
+        history: HistoryIntent,
+      ): RouterState =>
+        makeRouterState(attempt.route, attempt.url, {
+          history,
+          scroll: options.shouldScroll,
+          pathChanged: attempt.route.path !== settledRoute.path,
+          follows: attempt.follows,
+        });
       const controller = new AbortController();
       pendingNavigationRef.current = { controller };
       const commit = (
+        state: RouterState,
         update: () => void,
         transition: ChangeRouteOptions['startTransition'],
-        state = routerState,
       ) => {
         const callback = () => {
           if (controller.signal.aborted) {
@@ -1273,125 +1314,235 @@ const InnerRouter = ({
           callback();
         }
       };
-      if (staticPathSetRef.current!.has(nextRoute.path) || !shouldRefetch) {
+      const commitRoute = (
+        route: RouteProps,
+        state: RouterState,
+        transition: ChangeRouteOptions['startTransition'],
+      ) => {
         commit(
+          state,
           () => {
             void mergeElements({
-              [ROUTE_ID]: [nextRoute.path, nextRoute.query],
-              [ROUTER_STATE_ID]: routerState,
+              [ROUTE_ID]: [route.path, route.query],
+              [ROUTER_STATE_ID]: state,
             });
           },
+          transition,
+        );
+      };
+      if (staticPathSetRef.current!.has(nextRoute.path) || !shouldRefetch) {
+        commitRoute(
+          nextRoute,
+          makeStateForAttempt(initialAttempt, options.history),
           options.instant ? undefined : options.startTransition,
         );
         return;
       }
-      const rscPath = encodeRoutePath(nextRoute.path);
-      const cached = prefetchManagerRef.current!.get(rscPath, nextRoute.query);
-      cached?.onInvalidate(() => {
-        if (!controller.signal.aborted) {
-          reloadWithUrl(targetUrl);
-        }
-      });
-      const prefetchedElements =
-        prefetchManagerRef.current!.getElements(rscPath);
       const base = resolvedElementsRef.current;
-      const instant =
-        options.instant &&
-        canCommitInstantly(
-          getRouteSlotId(nextRoute.path),
-          resolvedElementsRef.current,
-          prefetchedElements,
-        );
-      const rscParams = createRscParams(nextRoute.query);
-      const dataPromise = instant
-        ? refetch(rscPath, rscParams, {
-            signal: controller.signal,
-            unstable_overlay: {
-              [ROUTER_STATE_ID]: routerState,
-              // meta is pinned, so an instant nav has to carry it or it goes stale
-              [ROUTE_ID]: [nextRoute.path, nextRoute.query],
-              [IS_STATIC_ID]: isStaticFromElements(resolvedElementsRef.current),
-            },
-            unstable_swr: {
-              pin: pinForSwr(() => resolvedElementsRef.current),
-              ...(prefetchedElements ? { base: prefetchedElements } : {}),
-            },
-            onBuildIdMismatch: () => reloadWithUrl(targetUrl),
-            ...(cached ? { prefetched: cached.promise } : {}),
-          })
-        : fetchRoute(rscPath, rscParams, {
-            signal: controller.signal,
-            ...(cached ? { prefetched: cached.promise } : {}),
-            onBuildIdMismatch: () => reloadWithUrl(targetUrl),
-            base,
+      const fetchRoute = async (
+        attempt: NavigationAttempt,
+        history: HistoryIntent,
+        restoreBase: boolean,
+      ): Promise<NavigationOutcome> => {
+        if (
+          attempt.follows &&
+          staticPathSetRef.current!.has(attempt.route.path)
+        ) {
+          return { type: 'static', attempt, history };
+        }
+        const rscPath = encodeRoutePath(attempt.route.path);
+        const prefetchManager = prefetchManagerRef.current!;
+        const cached = prefetchManager.get(rscPath, attempt.route.query);
+        cached?.onInvalidate(() => {
+          if (!controller.signal.aborted) {
+            reloadWithUrl(attempt.url);
+          }
+        });
+        const prefetchedElements = prefetchManager.getElements(rscPath);
+        const instant =
+          !attempt.follows &&
+          !!options.instant &&
+          canCommitInstantly(
+            getRouteSlotId(attempt.route.path),
+            resolvedElementsRef.current,
+            prefetchedElements,
+          );
+        const rscParams = createRscParams(attempt.route.query);
+        let elements: Elements;
+        try {
+          elements = await (instant
+            ? refetch(rscPath, rscParams, {
+                signal: controller.signal,
+                unstable_overlay: {
+                  [ROUTER_STATE_ID]: makeStateForAttempt(attempt, history),
+                  // meta is pinned, so an instant nav has to carry it or it goes stale
+                  [ROUTE_ID]: [attempt.route.path, attempt.route.query],
+                  [IS_STATIC_ID]: isStaticFromElements(
+                    resolvedElementsRef.current,
+                  ),
+                },
+                unstable_swr: {
+                  pin: pinForSwr(() => resolvedElementsRef.current),
+                  ...(prefetchedElements ? { base: prefetchedElements } : {}),
+                },
+                onBuildIdMismatch: () => reloadWithUrl(attempt.url),
+                ...(cached ? { prefetched: cached.promise } : {}),
+              })
+            : fetchRouteElements(rscPath, rscParams, {
+                signal: controller.signal,
+                ...(cached ? { prefetched: cached.promise } : {}),
+                onBuildIdMismatch: () => reloadWithUrl(attempt.url),
+                base,
+              }));
+        } catch (error) {
+          if (controller.signal.aborted) {
+            return { type: 'superseded' };
+          }
+          const decision = decideFollow(error, attempt, {
+            has404,
+            maxFollows: MAX_FOLLOWS_PER_NAVIGATION,
           });
-      try {
-        const resolved = await dataPromise;
-        if (controller.signal.aborted) {
-          return;
+          if (decision.type === 'leave') {
+            return {
+              type: 'left',
+              attempt,
+              history,
+              url: decision.url,
+              error,
+            };
+          }
+          if (decision.type !== 'follow') {
+            return {
+              type: 'failed',
+              attempt,
+              history,
+              error: decision.type === 'stop' ? decision.error : error,
+              restoreBase: restoreBase || instant,
+            };
+          }
+          if (instant) {
+            // the paint already wrote this url, so the follow replaces it
+            commitHistory(attempt.url, history);
+          }
+          return fetchRoute(
+            {
+              route: decision.target,
+              url: decision.url,
+              follows: attempt.follows + 1,
+            },
+            instant ? history && 'replace' : history,
+            restoreBase || instant,
+          );
         }
-        if (instant) {
-          addToStaticPathSet(resolved);
-          pendingNavigationRef.current = null;
-        } else {
-          commit(() => {
-            const current = resolvedElementsRef.current;
-            const update: Elements = {};
-            const responseRoute = getRouteFromElements(resolved) ?? nextRoute;
-            const routeSlotId = getRouteSlotId(responseRoute.path);
-            const routeEtagId = ETAG_ID_PREFIX + routeSlotId;
-            const rscRouteChanged = !isSameRscRoute(
-              responseRoute,
-              settledRoute,
-            );
-            // A server action can merge newer values while this request waits.
-            for (const [key, value] of Object.entries(resolved)) {
-              if (
-                (rscRouteChanged &&
-                  (key === routeSlotId || key === routeEtagId)) ||
-                (Object.hasOwn(current, key) === Object.hasOwn(base, key) &&
-                  current[key] === base[key])
-              ) {
-                update[key] = value;
-              }
-            }
-            Object.assign(update, {
-              ...(ROUTE_ID in resolved
-                ? { [ROUTE_ID]: resolved[ROUTE_ID] }
-                : {}),
-              ...(HAS404_ID in resolved
-                ? { [HAS404_ID]: resolved[HAS404_ID] }
-                : {}),
-              ...(IS_STATIC_ID in resolved
-                ? { [IS_STATIC_ID]: resolved[IS_STATIC_ID] }
-                : {}),
-              [ROUTER_STATE_ID]: routerState,
-            });
-            void mergeElements(update);
-          }, options.startTransition || startTransition);
-        }
-      } catch (e) {
-        if (controller.signal.aborted) {
-          return;
-        }
-        const failureState: RouterState = {
-          ...routerState,
-          history: null,
-          failure: { error: e, committedHash: settledRoute.hash },
-        };
-        commit(
-          () => {
-            // write the url now; an unrecoverable rethrow discards the commit
-            commitHistory(targetUrl, routerState.history);
-            void mergeElements({
-              [ROUTER_STATE_ID]: failureState,
-            });
-          },
-          options.startTransition,
-          failureState,
-        );
-        throw e;
+        return controller.signal.aborted
+          ? { type: 'superseded' }
+          : { type: 'landed', attempt, history, elements, instant };
+      };
+      const outcome = await fetchRoute(initialAttempt, options.history, false);
+      if (outcome.type === 'superseded') {
+        return;
       }
+      if (outcome.type === 'static') {
+        commitRoute(
+          outcome.attempt.route,
+          makeStateForAttempt(outcome.attempt, outcome.history),
+          options.startTransition || startTransition,
+        );
+        return;
+      }
+      if (outcome.type === 'left') {
+        commitHistory(outcome.attempt.url, outcome.history);
+        pendingNavigationRef.current = null;
+        window.location.replace(outcome.url.href);
+        throw outcome.error;
+      }
+      if (outcome.type === 'failed') {
+        const { error } = outcome;
+        const showError = () => {
+          if (controller.signal.aborted) {
+            return;
+          }
+          commitHistory(outcome.attempt.url, outcome.history);
+          const failureState: RouterState = {
+            ...makeRouterState(outcome.attempt.route, outcome.attempt.url, {
+              history: null,
+              scroll: false,
+              pathChanged: false,
+              follows: outcome.attempt.follows,
+            }),
+            failedFrom: settledRoute,
+          };
+          void mergeElements({
+            ...(outcome.restoreBase
+              ? {
+                  [ROUTE_ID]: base[ROUTE_ID],
+                  [IS_STATIC_ID]: base[IS_STATIC_ID],
+                }
+              : {}),
+            [ROUTER_STATE_ID]: failureState,
+          });
+          pendingNavigationRef.current = null;
+          setNavigationError({ error });
+        };
+        if (options.startTransition) {
+          options.startTransition(showError);
+        } else {
+          showError();
+        }
+        throw error;
+      }
+      const { attempt, elements } = outcome;
+      if (outcome.instant) {
+        addToStaticPathSet(elements);
+        pendingNavigationRef.current = null;
+        return;
+      }
+      const destination = resolveServerRedirect(
+        elements,
+        makeStateForAttempt(attempt, outcome.history),
+        attempt.route.path,
+      );
+      const finalState = makeRouterState(destination.route, destination.url, {
+        history: outcome.history,
+        scroll: options.shouldScroll,
+        pathChanged: destination.route.path !== settledRoute.path,
+        follows: attempt.follows,
+      });
+      commit(
+        finalState,
+        () => {
+          const current = resolvedElementsRef.current;
+          const update: Elements = {};
+          const responseRoute =
+            getRouteFromElements(elements) ?? destination.route;
+          const routeSlotId = getRouteSlotId(responseRoute.path);
+          const routeEtagId = ETAG_ID_PREFIX + routeSlotId;
+          const rscRouteChanged = !isSameRscRoute(responseRoute, settledRoute);
+          // A server action can merge newer values while this request waits.
+          for (const [key, value] of Object.entries(elements)) {
+            if (
+              (rscRouteChanged &&
+                (key === routeSlotId || key === routeEtagId)) ||
+              (Object.hasOwn(current, key) === Object.hasOwn(base, key) &&
+                current[key] === base[key])
+            ) {
+              update[key] = value;
+            }
+          }
+          Object.assign(update, {
+            ...(ROUTE_ID in elements ? { [ROUTE_ID]: elements[ROUTE_ID] } : {}),
+            ...(HAS404_ID in elements
+              ? { [HAS404_ID]: elements[HAS404_ID] }
+              : {}),
+            ...(IS_STATIC_ID in elements
+              ? { [IS_STATIC_ID]: elements[IS_STATIC_ID] }
+              : {}),
+            [ROUTER_STATE_ID]: finalState,
+          });
+          void mergeElements(update);
+        },
+        options.startTransition || startTransition,
+      );
     },
     [
       routeFallback,
@@ -1399,6 +1550,7 @@ const InnerRouter = ({
       mergeElements,
       addToStaticPathSet,
       cancelPendingNavigation,
+      has404,
     ],
   );
 
@@ -1496,8 +1648,8 @@ const InnerRouter = ({
     };
   }, [changeRoute, routeInterceptor, routeFallback]);
 
-  const routeElement = routerState?.failure ? (
-    <ThrowError error={routerState.failure.error} />
+  const routeElement = navigationError ? (
+    <ThrowError error={navigationError.error} />
   ) : (
     <Slot id={getRouteSlotId(currentRoute.path)} />
   );

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -1435,6 +1435,7 @@ const InnerRouter = ({
           if (
             // A render-time follow may be retrying the route whose slot threw.
             initialAttempt.follows === 0 &&
+            isSameRscRoute(decision.target, attempt.route) &&
             isSameRscRoute(decision.target, settledRoute)
           ) {
             return {
@@ -1516,7 +1517,8 @@ const InnerRouter = ({
       const finalState = makeRouterState(destination.route, destination.url, {
         history: outcome.history,
         scroll: options.shouldScroll,
-        pathChanged,
+        pathChanged:
+          pathChanged || destination.route.path !== settledRoute.path,
         follows: attempt.follows,
       });
       commit(

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -287,7 +287,7 @@ type NavigationOutcome =
       instant: boolean;
     }
   | {
-      type: 'static';
+      type: 'reused';
       attempt: NavigationAttempt;
       history: HistoryIntent;
     }
@@ -761,6 +761,7 @@ export function Link<Path extends RoutePath>({
           startTransition: unstable_startTransition,
         },
         startTransition,
+        // a click has no caller to reject to; the boundary shows the failure
       ).catch(() => {});
     } else if (url.hash && scroll !== false) {
       scrollToHash(url.hash, 'auto', false);
@@ -1282,6 +1283,7 @@ const InnerRouter = ({
         url: routeUrl,
         follows: options.follows ?? 0,
       };
+      const pathChanged = initialAttempt.route.path !== settledRoute.path;
       const shouldRefetch =
         options.refetch ?? !isSameRscRoute(nextRoute, settledRoute);
       const makeStateForAttempt = (
@@ -1291,7 +1293,7 @@ const InnerRouter = ({
         makeRouterState(attempt.route, attempt.url, {
           history,
           scroll: options.shouldScroll,
-          pathChanged: attempt.route.path !== settledRoute.path,
+          pathChanged,
           follows: attempt.follows,
         });
       const controller = new AbortController();
@@ -1345,10 +1347,10 @@ const InnerRouter = ({
         restoreBase: boolean,
       ): Promise<NavigationOutcome> => {
         if (
-          attempt.follows &&
+          attempt.follows > 0 &&
           staticPathSetRef.current!.has(attempt.route.path)
         ) {
-          return { type: 'static', attempt, history };
+          return { type: 'reused', attempt, history };
         }
         const rscPath = encodeRoutePath(attempt.route.path);
         const prefetchManager = prefetchManagerRef.current!;
@@ -1424,15 +1426,24 @@ const InnerRouter = ({
             // the paint already wrote this url, so the follow replaces it
             commitHistory(attempt.url, history);
           }
-          return fetchRoute(
-            {
-              route: decision.target,
-              url: decision.url,
-              follows: attempt.follows + 1,
-            },
-            instant ? history && 'replace' : history,
-            restoreBase || instant,
-          );
+          const nextAttempt = {
+            route: decision.target,
+            url: decision.url,
+            follows: attempt.follows + 1,
+          };
+          const nextHistory = instant && history !== null ? 'replace' : history;
+          if (
+            // A render-time follow may be retrying the route whose slot threw.
+            initialAttempt.follows === 0 &&
+            isSameRscRoute(decision.target, settledRoute)
+          ) {
+            return {
+              type: 'reused',
+              attempt: nextAttempt,
+              history: nextHistory,
+            };
+          }
+          return fetchRoute(nextAttempt, nextHistory, restoreBase || instant);
         }
         return controller.signal.aborted
           ? { type: 'superseded' }
@@ -1442,7 +1453,7 @@ const InnerRouter = ({
       if (outcome.type === 'superseded') {
         return;
       }
-      if (outcome.type === 'static') {
+      if (outcome.type === 'reused') {
         commitRoute(
           outcome.attempt.route,
           makeStateForAttempt(outcome.attempt, outcome.history),
@@ -1505,7 +1516,7 @@ const InnerRouter = ({
       const finalState = makeRouterState(destination.route, destination.url, {
         history: outcome.history,
         scroll: options.shouldScroll,
-        pathChanged: destination.route.path !== settledRoute.path,
+        pathChanged,
         follows: attempt.follows,
       });
       commit(

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -6251,16 +6251,51 @@ describe('Router integration', () => {
       .spyOn(window, 'scrollTo')
       .mockImplementation(() => {});
     const { view, refetch, capture, router } = await renderFollowRouter({
-      responses: [{ reject: { status: 307, location: '/start#missing' } }],
+      responses: [
+        { reject: { status: 307, location: '/start#missing' } },
+        { resolve: { [ROUTE_ID]: ['/start', ''], [IS_STATIC_ID]: false } },
+      ],
     });
     try {
       await act(async () => {
         await router.push('/next');
         await flush();
       });
-      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(refetch).toHaveBeenCalledTimes(2);
       expect(capture.router).toMatchObject({
         path: '/start',
+        hash: '#missing',
+      });
+      expect(scrollToSpy).toHaveBeenCalledWith({
+        left: 0,
+        top: 0,
+        behavior: 'instant',
+      });
+    } finally {
+      scrollToSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('a query-only fetch redirect to another path resets scroll', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [
+        { reject: { status: 307, location: '/detail#missing' } },
+        { resolve: { [ROUTE_ID]: ['/detail', ''], [IS_STATIC_ID]: false } },
+      ],
+      slots: ['/detail'],
+    });
+    try {
+      await act(async () => {
+        await router.push('/start?page=2', { scroll: true });
+        await flush();
+      });
+      expect(refetch).toHaveBeenCalledTimes(2);
+      expect(capture.router).toMatchObject({
+        path: '/detail',
         hash: '#missing',
       });
       expect(scrollToSpy).toHaveBeenCalledWith({

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -6893,6 +6893,61 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('a query-only redirect to a known static path resets scroll', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const redirect = createCustomError('redirect', {
+      status: 307,
+      location: '/detail#missing',
+    });
+    const refetch = vi
+      .fn<RefetchInner>()
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/start', 'page=1'],
+        [IS_STATIC_ID]: false,
+      })
+      .mockRejectedValueOnce(redirect);
+    installRefetch(refetch);
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const view = await renderRouter(
+      { initialRoute: { path: '/detail', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/detail')]: <Probe />,
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [ROUTE_ID]: ['/detail', ''],
+        [IS_STATIC_ID]: true,
+      },
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/start?page=1');
+        await flush();
+      });
+      scrollToSpy.mockClear();
+
+      await act(async () => {
+        await capture.router!.push('/start?page=2', { scroll: true });
+        await flush();
+      });
+
+      expect(refetch).toHaveBeenCalledTimes(2);
+      expect(capture.router).toMatchObject({
+        path: '/detail',
+        hash: '#missing',
+      });
+      expect(scrollToSpy).toHaveBeenCalledWith({
+        left: 0,
+        top: 0,
+        behavior: 'instant',
+      });
+    } finally {
+      scrollToSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('a redirect that lands on a missing route goes to the 404 route', async () => {
     const { view, refetch, capture, router } = await renderFollowRouter({
       responses: [

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -6230,6 +6230,50 @@ describe('Router integration', () => {
     }
   });
 
+  test('a fetch redirect that only adds a hash reuses the current route', async () => {
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [{ reject: { status: 307, location: '/start#section' } }],
+    });
+    await act(async () => {
+      await router.reload();
+      await flush();
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(capture.router).toMatchObject({
+      path: '/start',
+      hash: '#section',
+    });
+    view.unmount();
+  });
+
+  test('a fetch redirect back to the current route keeps path-change scrolling', async () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => {});
+    const { view, refetch, capture, router } = await renderFollowRouter({
+      responses: [{ reject: { status: 307, location: '/start#missing' } }],
+    });
+    try {
+      await act(async () => {
+        await router.push('/next');
+        await flush();
+      });
+      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(capture.router).toMatchObject({
+        path: '/start',
+        hash: '#missing',
+      });
+      expect(scrollToSpy).toHaveBeenCalledWith({
+        left: 0,
+        top: 0,
+        behavior: 'instant',
+      });
+    } finally {
+      scrollToSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('a server redirect back to the caught query is a loop', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { StrictMode, act, use, useState } from 'react';
+import { StrictMode, act, use, useEffect, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { preloadModule } from 'react-dom';
 import { createRoot } from 'react-dom/client';
@@ -3158,7 +3158,7 @@ describe('Router integration', () => {
     }
   });
 
-  test('push writes history when refetch fails', async () => {
+  test('push writes history and renders the error when refetch fails', async () => {
     const capture = { router: null as RouterApi | null };
     const Probe = makeProbe(capture);
     const refetch = vi.fn<RefetchInner>(async () => ({}));
@@ -3167,7 +3167,15 @@ describe('Router integration', () => {
     const historyPushSpy = vi.spyOn(window.history, 'pushState');
 
     const elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
+      root: (
+        <>
+          <Probe />
+          <ErrorBoundary>
+            <Children />
+          </ErrorBoundary>
+        </>
+      ),
+      [unstable_getRouteSlotId('/start')]: <p>start</p>,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
     };
@@ -3196,7 +3204,7 @@ describe('Router integration', () => {
       });
       expect(historyPushSpy).toHaveBeenCalledTimes(1);
       expect(window.location.pathname).toBe('/next');
-      // the unrecoverable error rethrows to the app boundary
+      expect(capture.router.path).toBe('/next');
       expect(view.container.textContent).toContain(
         'Caught an unexpected error',
       );
@@ -3608,6 +3616,133 @@ describe('Router integration', () => {
     expect(window.location.pathname).toBe('/next');
 
     view.unmount();
+  });
+
+  test('a failed instant nav keeps the attempted route and settled fetch baseline', async () => {
+    window.history.replaceState({}, '', '/start?a=1#top');
+    const pending = createDeferred<Record<string, unknown>>();
+    const refetch = vi.fn<RefetchInner>(() => pending.promise);
+    installRefetch(refetch);
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const historyPushSpy = vi.spyOn(window.history, 'pushState');
+    const historyReplaceSpy = vi.spyOn(window.history, 'replaceState');
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
+      return;
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    testHoisted.elements = {
+      ...instantNavElements(),
+      [ROUTE_ID]: ['/start', 'a=1'],
+      root: (
+        <>
+          <Probe />
+          <ErrorBoundary>
+            <Children />
+          </ErrorBoundary>
+        </>
+      ),
+    };
+    const view = await renderApp(
+      <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+        <Router initialRoute={{ path: '/start', query: 'a=1', hash: '#top' }} />
+      </Unstable_SearchCodecsProvider>,
+    );
+    try {
+      historyPushSpy.mockClear();
+      historyReplaceSpy.mockClear();
+      let navigation: Promise<void> | undefined;
+      await act(async () => {
+        navigation = capture.router!.push('/next?b=2#bottom', {
+          unstable_instant: true,
+        });
+        await flush();
+      });
+      expect(capture.router).toMatchObject({
+        path: '/next',
+        query: 'b=2',
+        hash: '#bottom',
+      });
+      scrollToSpy.mockClear();
+
+      await act(async () => {
+        pending.reject(new Error('offline'));
+        await expect(navigation).rejects.toThrow('offline');
+        await flush();
+      });
+
+      expect(capture.router).toMatchObject({
+        path: '/next',
+        query: 'b=2',
+        hash: '#bottom',
+      });
+      expect(window.location.pathname).toBe('/next');
+      expect(window.location.search).toBe('?b=2');
+      expect(window.location.hash).toBe('#bottom');
+      expect(historyPushSpy).toHaveBeenCalledTimes(1);
+      expect(historyReplaceSpy).not.toHaveBeenCalled();
+      expect(scrollToSpy).not.toHaveBeenCalled();
+      expect(view.container.textContent).toContain(
+        'Caught an unexpected error',
+      );
+
+      refetch.mockResolvedValueOnce({
+        [ROUTE_ID]: ['/start', 'b=2'],
+        [IS_STATIC_ID]: false,
+      });
+      await act(async () => {
+        await capture.router!.push('/start?b=2').catch(() => {});
+        await flush();
+      });
+      expect(refetch).toHaveBeenCalledTimes(2);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      historyPushSpy.mockRestore();
+      historyReplaceSpy.mockRestore();
+      scrollToSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
+  test('a fetch redirect after an instant paint replaces its history entry', async () => {
+    const refetch = vi.fn<RefetchInner>();
+    refetch
+      .mockRejectedValueOnce(
+        createCustomError('moved', { status: 307, location: '/final' }),
+      )
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/final', ''],
+        [IS_STATIC_ID]: false,
+      });
+    installRefetch(refetch);
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        ...instantNavElements(),
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/next')]: <Probe />,
+        [unstable_getRouteSlotId('/final')]: <Probe />,
+      },
+    );
+    try {
+      const lengthBefore = window.history.length;
+
+      await act(async () => {
+        await capture.router!.push('/next', { unstable_instant: true });
+        await flush();
+      });
+
+      expect(refetch).toHaveBeenCalledTimes(2);
+      expect(capture.router?.path).toBe('/final');
+      expect(window.location.pathname).toBe('/final');
+      expect(window.history.length).toBe(lengthBefore + 1);
+    } finally {
+      view.unmount();
+    }
   });
 
   test('a redirect after the url already moved replaces instead of pushing', async () => {
@@ -4957,7 +5092,9 @@ describe('Router integration', () => {
     );
     try {
       await act(async () => {
-        await capture.router!.push('/moved').catch(() => {});
+        await expect(capture.router!.push('/moved')).rejects.toThrow(
+          'cannot follow a redirect to javascript:alert(1)',
+        );
         await flush();
         await flush();
       });
@@ -5582,6 +5719,117 @@ describe('Router integration', () => {
     }
   }, 20_000);
 
+  test('a redirect cycle that throws after each commit stops at the hop limit', async () => {
+    const refetch = vi.fn<RefetchInner>(((rscPath: string) => {
+      const path = rscPath === unstable_encodeRoutePath('/a') ? '/a' : '/b';
+      const next = path === '/a' ? '/b' : '/a';
+      const error = createCustomError('moved', {
+        status: 307,
+        location: next,
+      });
+      const DelayedRedirect = () => {
+        const [shouldThrow, setShouldThrow] = useState(false);
+        useEffect(() => setShouldThrow(true), []);
+        if (shouldThrow) {
+          throw error;
+        }
+        return <p>{path}</p>;
+      };
+      return Promise.resolve({
+        [unstable_getRouteSlotId(path)]: <DelayedRedirect />,
+        [ROUTE_ID]: [path, ''],
+        [IS_STATIC_ID]: false,
+      });
+    }) as never);
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    testHoisted.elements = {
+      root: (
+        <>
+          <Probe />
+          <Children />
+        </>
+      ),
+      [unstable_getRouteSlotId('/start')]: <p>start</p>,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+      </ErrorBoundary>,
+    );
+    try {
+      await act(async () => {
+        await capture.router!.push('/a');
+        for (let i = 0; i < 160; i += 1) {
+          await flush();
+        }
+      });
+
+      expect(view.container.textContent).toContain(
+        'too many redirect or 404 follows',
+      );
+      expect(refetch).toHaveBeenCalledTimes(21);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  }, 20_000);
+
+  test('a fetch redirect cycle stops at the hop limit', async () => {
+    const refetch = vi.fn<RefetchInner>();
+    for (let index = 0; index < 40; index += 1) {
+      refetch.mockRejectedValueOnce(
+        createCustomError('follow-error', {
+          status: 307,
+          location: index % 2 === 0 ? '/b' : '/a',
+        }),
+      );
+    }
+    installRefetch(refetch);
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/a')]: <Probe />,
+      [unstable_getRouteSlotId('/b')]: <Probe />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Unstable_SearchCodecsProvider searchCodecs={[postsSearchCodec]}>
+          <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+        </Unstable_SearchCodecsProvider>
+      </ErrorBoundary>,
+    );
+    try {
+      await act(async () => {
+        await expect(capture.router!.push('/a')).rejects.toThrow(
+          'too many redirect or 404 follows',
+        );
+        await flush();
+      });
+      expect(refetch).toHaveBeenCalledTimes(21);
+      expect(view.container.textContent).toContain(
+        'too many redirect or 404 follows',
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
+  });
+
   test('an instant redirect scrolls when the visible navigation changed paths', async () => {
     const scrollToSpy = vi
       .spyOn(window, 'scrollTo')
@@ -5846,7 +6094,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('push rejects on a 404 response and the follow lands after', async () => {
+  test('push resolves after the 404 follow lands', async () => {
     const { view, refetch, capture, router } = await renderFollowRouter({
       responses: [
         { reject: { status: 404 } },
@@ -5856,20 +6104,15 @@ describe('Router integration', () => {
       meta: { [HAS404_ID]: true },
     });
     let callsWhenSettled = 0;
-    let rejected = false;
     const record = () => {
       callsWhenSettled = refetch.mock.calls.length;
     };
     await act(async () => {
-      await router.push('/missing').then(record, () => {
-        rejected = true;
-        record();
-      });
+      await router.push('/missing').then(record);
       await flush();
       await flush();
     });
-    expect(rejected).toBe(true);
-    expect(callsWhenSettled).toBe(1);
+    expect(callsWhenSettled).toBe(2);
     expect(refetch).toHaveBeenCalledTimes(2);
     expect(capture.router!.path).toBe('/404');
     view.unmount();
@@ -6090,8 +6333,16 @@ describe('Router integration', () => {
     installRefetch(refetch);
 
     testHoisted.elements = {
-      [unstable_getRouteSlotId('/start')]: <Probe />,
-      [unstable_getRouteSlotId('/404')]: <Probe />,
+      root: (
+        <>
+          <Probe />
+          <ErrorBoundary>
+            <Children />
+          </ErrorBoundary>
+        </>
+      ),
+      [unstable_getRouteSlotId('/start')]: <p>start</p>,
+      [unstable_getRouteSlotId('/404')]: <p>404</p>,
       [ROUTE_ID]: ['/start', ''],
       [IS_STATIC_ID]: false,
       [HAS404_ID]: true,
@@ -6108,7 +6359,9 @@ describe('Router integration', () => {
     );
     try {
       await act(async () => {
-        await capture.router!.push('/missing').catch(() => {});
+        await expect(capture.router!.push('/missing')).rejects.toThrow(
+          'detected a navigation loop',
+        );
         for (let i = 0; i < 8; i += 1) {
           await flush();
         }
@@ -6116,6 +6369,7 @@ describe('Router integration', () => {
 
       // one request for /missing, one for /404, then it gives up
       expect(refetch).toHaveBeenCalledTimes(2);
+      expect(capture.router?.path).toBe('/404');
       expect(view.container.textContent).toContain(
         'detected a navigation loop',
       );
@@ -6610,7 +6864,7 @@ describe('Router integration', () => {
     view.unmount();
   });
 
-  test('a 404 error on navigation without a 404 route rejects', async () => {
+  test('a 404 navigation without a 404 route renders Not Found', async () => {
     const { view, refetch, router } = await renderFollowRouter({
       responses: [{ reject: { status: 404 } }],
       meta: { [HAS404_ID]: false },
@@ -6621,7 +6875,54 @@ describe('Router integration', () => {
       await flush();
     });
     expect(refetch).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe('/missing');
+    expect(view.container.textContent).toContain('Not Found');
     view.unmount();
+  });
+
+  test('a navigation after the built-in Not Found page recovers', async () => {
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const refetch = vi.fn<RefetchInner>();
+    refetch
+      .mockRejectedValueOnce(createCustomError('nf', { status: 404 }))
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/other', ''],
+        [IS_STATIC_ID]: false,
+      });
+    installRefetch(refetch);
+    testHoisted.elements = {
+      [unstable_getRouteSlotId('/start')]: <Probe />,
+      [unstable_getRouteSlotId('/other')]: <div>other page</div>,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <ErrorBoundary>
+        <Router initialRoute={{ path: '/start', query: '', hash: '' }} />
+      </ErrorBoundary>,
+    );
+    try {
+      await act(async () => {
+        await expect(capture.router!.push('/missing')).rejects.toBeTruthy();
+        await flush();
+      });
+      expect(view.container.textContent).toContain('Not Found');
+
+      await act(async () => {
+        await capture.router!.push('/other');
+        await flush();
+      });
+      expect(view.container.textContent).toContain('other page');
+      expect(view.container.textContent).not.toContain('Not Found');
+      expect(window.location.pathname).toBe('/other');
+    } finally {
+      consoleErrorSpy.mockRestore();
+      view.unmount();
+    }
   });
 
   test('custom 404 handling without a /404 page keeps Not Found fallback', async () => {
@@ -7683,6 +7984,71 @@ describe('Router integration', () => {
       expect(view.container.textContent).toContain('Page 2');
       expect(window.location.pathname).toBe('/two');
     } finally {
+      view.unmount();
+    }
+  });
+
+  test('a delayed failure commit cannot replace a newer navigation', async () => {
+    const customCommits: Array<() => void> = [];
+    const customTransition = vi.fn((fn: () => void) => {
+      customCommits.push(fn);
+    });
+    const refetch = vi
+      .fn<RefetchInner>()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/other', ''],
+        [IS_STATIC_ID]: false,
+      });
+    installRefetch(refetch);
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    testHoisted.elements = {
+      root: (
+        <>
+          <Probe />
+          <ErrorBoundary>
+            <Children />
+          </ErrorBoundary>
+        </>
+      ),
+      [unstable_getRouteSlotId('/start')]: (
+        <Link to="/broken" unstable_startTransition={customTransition}>
+          broken
+        </Link>
+      ),
+      [unstable_getRouteSlotId('/other')]: <div>other page</div>,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const view = await renderApp(
+      <Router initialRoute={{ path: '/start', query: '', hash: '' }} />,
+    );
+    try {
+      await act(async () => {
+        view.container.querySelector('a')?.click();
+        await flush();
+      });
+      expect(customTransition).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await capture.router!.push('/other');
+        await flush();
+      });
+      await act(async () => {
+        customCommits[0]?.();
+        await flush();
+      });
+
+      expect(view.container.textContent).toContain('other page');
+      expect(view.container.textContent).not.toContain(
+        'Caught an unexpected error',
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
       view.unmount();
     }
   });

--- a/packages/waku/tests/router-error-route.test.ts
+++ b/packages/waku/tests/router-error-route.test.ts
@@ -1,7 +1,10 @@
 /** @vitest-environment happy-dom */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createCustomError } from '../src/lib/utils/custom-errors.js';
-import { resolveErrorRoute } from '../src/router/client-utils/error-route.js';
+import {
+  decideFollow,
+  resolveErrorRoute,
+} from '../src/router/client-utils/error-route.js';
 
 beforeEach(() => {
   vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');
@@ -216,5 +219,106 @@ describe('resolveErrorRoute', () => {
     expect(resolveErrorRoute(error, requested('/docs/from'), false).type).toBe(
       'leave',
     );
+  });
+});
+
+describe('decideFollow', () => {
+  const options = { has404: false, maxFollows: 20 };
+  const at = (path: string, query = '', follows = 0) => ({
+    route: { path, query },
+    url: requested(path + (query && `?${query}`)),
+    follows,
+  });
+  const redirectTo = (location: string) =>
+    createCustomError('redirect', { status: 307, location });
+
+  test('an error that points nowhere decides nothing', () => {
+    expect(decideFollow(new Error('offline'), at('/from'), options)).toEqual({
+      type: 'none',
+    });
+  });
+
+  test('a missing route only follows when the app has a 404 route', () => {
+    const error = createCustomError('not found', { status: 404 });
+
+    expect(decideFollow(error, at('/missing'), options)).toEqual({
+      type: 'none',
+    });
+    expect(
+      decideFollow(error, at('/missing'), { ...options, has404: true }),
+    ).toEqual({
+      type: 'follow',
+      target: { path: '/404', query: '', hash: '' },
+      url: expect.any(URL),
+    });
+  });
+
+  test('a location the router cannot route to stops', () => {
+    const error = redirectTo('javascript:alert(1)');
+
+    expect(decideFollow(error, at('/from'), options)).toMatchObject({
+      type: 'stop',
+      error: {
+        message: 'cannot follow a redirect to javascript:alert(1)',
+        cause: error,
+      },
+    });
+  });
+
+  test('a redirect off the origin leaves', () => {
+    expect(
+      decideFollow(redirectTo('https://other.example/next'), at('/from'), {
+        ...options,
+        has404: true,
+      }),
+    ).toEqual({ type: 'leave', url: expect.any(URL) });
+  });
+
+  test('a redirect back to the route being fetched stops as a loop', () => {
+    expect(
+      decideFollow(redirectTo('/here'), at('/here'), options),
+    ).toMatchObject({
+      type: 'stop',
+      error: { message: 'detected a navigation loop' },
+    });
+  });
+
+  test('the same path with a different query is not a loop', () => {
+    expect(
+      decideFollow(redirectTo('/here?page=2'), at('/here'), options),
+    ).toMatchObject({
+      type: 'follow',
+      target: { path: '/here', query: 'page=2' },
+    });
+  });
+
+  test('the same path with only a different hash is not a loop', () => {
+    expect(
+      decideFollow(redirectTo('/here#section'), at('/here'), options),
+    ).toMatchObject({
+      type: 'follow',
+      target: { path: '/here', query: '', hash: '#section' },
+    });
+  });
+
+  test('the last follow inside the budget goes through and the next one stops', () => {
+    const error = redirectTo('/next');
+
+    expect(decideFollow(error, at('/from', '', 19), options).type).toBe(
+      'follow',
+    );
+    expect(decideFollow(error, at('/from', '', 20), options)).toMatchObject({
+      type: 'stop',
+      error: { message: 'too many redirect or 404 follows' },
+    });
+  });
+
+  test('a loop is reported ahead of a spent budget', () => {
+    expect(
+      decideFollow(redirectTo('/here'), at('/here', '', 20), options),
+    ).toMatchObject({
+      type: 'stop',
+      error: { message: 'detected a navigation loop' },
+    });
   });
 });

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -38,14 +38,14 @@ describe('makeRouterState', () => {
         history: 'push',
         scroll: true,
         pathChanged: true,
-        followCount: 0,
+        follows: 2,
       },
     );
     expect(routerState.url).toBe('/a?x=1#top');
     expect(routerState.requested).toEqual(['/a', 'x=1']);
     expect(routerState.history).toBe('push');
     expect(routerState.scroll).toEqual({ pathChanged: true });
-    expect(routerState.followCount).toBe(0);
+    expect(routerState.follows).toBe(2);
   });
 
   test('no scroll intent when scrolling is off', () => {
@@ -53,7 +53,7 @@ describe('makeRouterState', () => {
       history: 'replace',
       scroll: false,
       pathChanged: true,
-      followCount: 0,
+      follows: 0,
     });
     expect(routerState.scroll).toBeNull();
   });
@@ -65,7 +65,7 @@ describe('getRouterState', () => {
       history: 'push',
       scroll: false,
       pathChanged: false,
-      followCount: 0,
+      follows: 0,
     });
     expect(getRouterState(withRouterState({}, routerState))).toBe(routerState);
     expect(getRouterState({})).toBeUndefined();
@@ -73,26 +73,28 @@ describe('getRouterState', () => {
 });
 
 describe('resolveServerRedirect', () => {
-  test('a failed navigation reads no redirect from the stale route id', () => {
-    const attempt = makeRouterState(route('/missing'), urlOf('/missing'), {
-      history: 'push',
-      scroll: true,
-      pathChanged: true,
-      followCount: 0,
-    });
-    const elements = { [ROUTE_ID]: ['/a', ''] };
-
-    // the record still holds the route the client came from
-    expect(resolveServerRedirect(elements, attempt, '/f').url.pathname).toBe(
-      '/a',
+  test('a failed navigation reports the attempted route and url', () => {
+    const attempted = makeRouterState(
+      route('/next', 'b=2', '#bottom'),
+      urlOf('/next?b=2#bottom'),
+      {
+        history: null,
+        scroll: false,
+        pathChanged: false,
+        follows: 0,
+      },
     );
-    expect(
-      resolveServerRedirect(
-        elements,
-        { ...attempt, failure: { error: new Error('x'), committedHash: '' } },
-        '/f',
-      ).url.pathname,
-    ).toBe('/missing');
+    const { route: resolvedRoute, url } = resolveServerRedirect(
+      { [ROUTE_ID]: ['/start', 'a=1'] },
+      {
+        ...attempted,
+        failedFrom: route('/start', 'a=1', '#top'),
+      },
+      '/f',
+    );
+
+    expect(resolvedRoute).toEqual(route('/next', 'b=2', '#bottom'));
+    expect(url.href).toBe(urlOf('/next?b=2#bottom').href);
   });
 
   test('path from the elements, query and hash from the routerState url', () => {
@@ -103,7 +105,7 @@ describe('resolveServerRedirect', () => {
         history: 'replace',
         scroll: false,
         pathChanged: false,
-        followCount: 0,
+        follows: 0,
       },
     );
     const elements = { [ROUTE_ID]: ['/a', 'x=1'] };
@@ -121,7 +123,7 @@ describe('resolveServerRedirect', () => {
       history: 'replace',
       scroll: false,
       pathChanged: false,
-      followCount: 0,
+      follows: 0,
     });
     const elements = { [ROUTE_ID]: ['/a', ''], [IS_STATIC_ID]: true };
     const { route: resolvedRoute, url } = resolveServerRedirect(
@@ -138,7 +140,7 @@ describe('resolveServerRedirect', () => {
       history: 'push',
       scroll: false,
       pathChanged: true,
-      followCount: 0,
+      follows: 0,
     });
     const elements = { [ROUTE_ID]: ['/b', 'y=2'] };
     const { route: resolvedRoute, url } = resolveServerRedirect(
@@ -158,7 +160,7 @@ describe('resolveServerRedirect', () => {
         history: 'replace',
         scroll: false,
         pathChanged: false,
-        followCount: 0,
+        follows: 0,
       });
       const elements = { [ROUTE_ID]: ['/b', ''] };
       const { url } = resolveServerRedirect(elements, routerState, '/f');
@@ -173,7 +175,7 @@ describe('resolveServerRedirect', () => {
       history: 'replace',
       scroll: false,
       pathChanged: true,
-      followCount: 0,
+      follows: 0,
     });
     const elements = { [ROUTE_ID]: ['/404', ''] };
     const { route: resolvedRoute, url } = resolveServerRedirect(
@@ -193,61 +195,34 @@ describe('getSettledRoute', () => {
     expect(getSettledRoute({}, fallback)).toEqual(fallback);
   });
 
-  test('a failed navigation keeps the hash that is still on screen', () => {
-    const routerState = makeRouterState(route('/b'), urlOf('/b#target'), {
-      history: 'push',
-      scroll: true,
-      pathChanged: true,
-      followCount: 0,
-    });
-    const elements = withRouterState(
-      { [ROUTE_ID]: ['/a', 'x=1'] },
-      {
-        ...routerState,
-        failure: { error: new Error('x'), committedHash: '#onscreen' },
-      },
-    );
-    // the route id is the one the client came from, not the failed attempt
-    expect(getSettledRoute(elements, fallback)).toEqual({
-      path: '/a',
-      query: 'x=1',
-      hash: '#onscreen',
-    });
-  });
-
-  test('a failure with no route id falls back, still with the on screen hash', () => {
-    const routerState = makeRouterState(route('/b'), urlOf('/b'), {
-      history: 'push',
-      scroll: false,
-      pathChanged: true,
-      followCount: 0,
-    });
-    const elements = withRouterState(
-      {},
-      {
-        ...routerState,
-        failure: { error: new Error('x'), committedHash: '' },
-      },
-    );
-    expect(getSettledRoute(elements, fallback)).toEqual({
-      path: '/f',
-      query: '',
-      hash: '',
-    });
-  });
-
   test('a landed navigation resolves the server redirect', () => {
     const routerState = makeRouterState(route('/a'), urlOf('/a#top'), {
       history: 'push',
       scroll: true,
       pathChanged: true,
-      followCount: 0,
+      follows: 0,
     });
     const elements = withRouterState(
       { [ROUTE_ID]: ['/b', 'y=2'] },
       routerState,
     );
     expect(getSettledRoute(elements, fallback)).toEqual(route('/b', 'y=2'));
+  });
+
+  test('a failed navigation keeps the last settled route', () => {
+    const settledRoute = route('/a', 'x=1', '#top');
+    const routerState = makeRouterState(route('/b'), urlOf('/b?y=2#bottom'), {
+      history: null,
+      scroll: false,
+      pathChanged: false,
+      follows: 0,
+    });
+    const elements = withRouterState(
+      { [ROUTE_ID]: ['/a', 'x=1'] },
+      { ...routerState, failedFrom: settledRoute },
+    );
+
+    expect(getSettledRoute(elements, fallback)).toEqual(settledRoute);
   });
 });
 


### PR DESCRIPTION
Handle fetch-time redirects and 404s inside the navigation request.

Keep follow limits and failed route state consistent between fetch-time and render-time errors.