### PR TITLE
fix(router): keep the navigation transition when instant cannot paint

### DIFF
--- a/docs/guides/navigation-prefetching.mdx
+++ b/docs/guides/navigation-prefetching.mdx
@@ -177,7 +177,7 @@ The `<Suspense>` boundary decides how localized the loading state is. Wrapping t
 
 Because an instant navigation commits before the server responds, it reconciles afterward: a server redirect updates the URL to the redirect target, while a not-found (404) response keeps the requested URL, so the 404 page shows at the address the user tried.
 
-An instant navigation with a cached shell commits urgently rather than inside a React transition, since a transition would suppress the immediate skeleton. A custom `unstable_startTransition` therefore does not run for that cache commit. When the shell is not cached, navigation waits for the response and uses the custom transition to commit the destination. `useNavigationStatus_UNSTABLE()` does not report `pending` for instant links; when the cache commit is available, the shell itself is the pending state.
+An instant navigation that can commit from cache, or that needs no fetch, commits urgently rather than inside a React transition, since a transition would suppress the immediate skeleton. A custom `unstable_startTransition` therefore does not run for that commit. When the shell is not cached, navigation waits for the response and uses the custom transition to commit the destination; `useNavigationStatus_UNSTABLE()` reports `pending` for that wait. When the cache commit is available, the shell itself is the pending state.
 
 ## Pending UI
 
@@ -224,7 +224,7 @@ export const PendingLink = <Path extends RoutePath>({
 
 Use `PendingLink` where a link needs an indicator. Keep the indicator non-interactive and `aria-hidden` (as above) so it does not affect the link's accessible name or introduce a nested interactive target.
 
-`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>` because the status belongs to the nearest link. It does not observe programmatic navigation, browser back and forward, instant navigation, or a link with a custom transition. Called outside any `<Link>`, the hook returns an empty object (not `{ pending: false }`).
+`useNavigationStatus_UNSTABLE()` must be called from a Client Component rendered inside the `<Link>` because the status belongs to the nearest link. It does not observe programmatic navigation, browser back and forward, or a link with a custom transition. Instant links report `pending` when they fall back to waiting for a response; a cache commit does not, because the shell itself is the pending state. Called outside any `<Link>`, the hook returns an empty object (not `{ pending: false }`).
 
 ## Observe Route Changes
 

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -336,13 +336,22 @@ const useResolveSearchCodec = () => {
   );
 };
 
+const canPaintInstantOverlay = (
+  follows: number,
+  routeSlotId: string,
+  resolvedElements: Record<string, unknown>,
+  prefetchedElements: Record<string, unknown> | null | undefined,
+) =>
+  !follows &&
+  canCommitInstantly(routeSlotId, resolvedElements, prefetchedElements);
+
 const dispatchChangeRoute = (
   changeRoute: ChangeRoute,
   route: RouteProps,
   options: ChangeRouteOptions,
   startTransitionFn: (fn: TransitionFunction) => void = startTransition,
 ): Promise<void> => {
-  if (options.instant) {
+  if (options.instant && !options.startTransition) {
     // skip the outer wrap until changeRoute knows it will actually paint
     return changeRoute(route, {
       ...options,
@@ -1281,10 +1290,10 @@ const InnerRouter = ({
       // would deprioritise the paint that unstable_instant exists to deliver
       if (
         options.pendingTransition &&
-        !options.startTransition &&
         shouldRefetch &&
         !staticPathSetRef.current!.has(nextRoute.path) &&
-        !canCommitInstantly(
+        !canPaintInstantOverlay(
+          options.follows ?? 0,
           getRouteSlotId(nextRoute.path),
           resolvedElementsRef.current,
           prefetchManagerRef.current!.getElements(
@@ -1294,7 +1303,6 @@ const InnerRouter = ({
       ) {
         const schedule = options.pendingTransition;
         // React's startTransition runs fn now, so cancel still happens in this turn.
-        // A custom startTransition never takes this branch.
         return new Promise<void>((resolve, reject) => {
           schedule(async () => {
             try {
@@ -1400,9 +1408,9 @@ const InnerRouter = ({
         });
         const prefetchedElements = prefetchManager.getElements(rscPath);
         const instant =
-          !attempt.follows &&
           !!options.instant &&
-          canCommitInstantly(
+          canPaintInstantOverlay(
+            attempt.follows,
             getRouteSlotId(attempt.route.path),
             resolvedElementsRef.current,
             prefetchedElements,

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -263,6 +263,7 @@ type ChangeRouteOptions = {
   instant?: boolean | undefined;
   follows?: number | undefined;
   startTransition?: ((fn: TransitionFunction) => void) | undefined;
+  pendingTransition?: ((fn: TransitionFunction) => void) | undefined;
 };
 
 type ChangeRoute = (
@@ -342,8 +343,11 @@ const dispatchChangeRoute = (
   startTransitionFn: (fn: TransitionFunction) => void = startTransition,
 ): Promise<void> => {
   if (options.instant) {
-    // instant paints from the cache; a transition would hold that back
-    return changeRoute(route, options);
+    // skip the outer wrap until changeRoute knows it will actually paint
+    return changeRoute(route, {
+      ...options,
+      pendingTransition: startTransitionFn,
+    });
   }
   if (options.startTransition) {
     return changeRoute(route, options);
@@ -1267,16 +1271,50 @@ const InnerRouter = ({
 
   const changeRoute: ChangeRoute = useCallback(
     async function changeRoute(nextRoute, options) {
+      const settledRoute = getSettledRoute(
+        resolvedElementsRef.current,
+        routeFallback,
+      );
+      const shouldRefetch =
+        options.refetch ?? !isSameRscRoute(nextRoute, settledRoute);
+      // a navigation that commits synchronously must not be wrapped: a transition
+      // would deprioritise the paint that unstable_instant exists to deliver
+      if (
+        options.pendingTransition &&
+        !options.startTransition &&
+        shouldRefetch &&
+        !staticPathSetRef.current!.has(nextRoute.path) &&
+        !canCommitInstantly(
+          getRouteSlotId(nextRoute.path),
+          resolvedElementsRef.current,
+          prefetchManagerRef.current!.getElements(
+            encodeRoutePath(nextRoute.path),
+          ),
+        )
+      ) {
+        const schedule = options.pendingTransition;
+        // React's startTransition runs fn now, so cancel still happens in this turn.
+        // A custom startTransition never takes this branch.
+        return new Promise<void>((resolve, reject) => {
+          schedule(async () => {
+            try {
+              await changeRoute(nextRoute, {
+                ...options,
+                pendingTransition: undefined,
+              });
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          });
+        });
+      }
       cancelPendingNavigation();
       setNavigationError(undefined);
       if (import.meta.hot) {
         // A route navigation retires the previous Minimal refetch target.
         registerRscReloadListener(() => {}, { replace: true });
       }
-      const settledRoute = getSettledRoute(
-        resolvedElementsRef.current,
-        routeFallback,
-      );
       const routeUrl = options.url ?? getRouteUrl(nextRoute);
       const initialAttempt: NavigationAttempt = {
         route: nextRoute,
@@ -1285,8 +1323,6 @@ const InnerRouter = ({
       };
       const requestedPathChanged =
         initialAttempt.route.path !== settledRoute.path;
-      const shouldRefetch =
-        options.refetch ?? !isSameRscRoute(nextRoute, settledRoute);
       const makeStateForAttempt = (
         attempt: NavigationAttempt,
         history: HistoryIntent,

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -3521,6 +3521,188 @@ describe('Router integration', () => {
     }
   });
 
+  test('instant Link still pending when it cannot paint from cache', async () => {
+    const navigation = createDeferred<Record<string, unknown>>();
+    const refetch = vi.fn<RefetchInner>(() => navigation.promise);
+    installRefetch(refetch);
+    window.history.replaceState({}, '', '/one');
+
+    const PendingProbe = () => {
+      const { pending } = useNavigationStatus();
+      return pending ? (
+        <div data-testid="pending">Pending</div>
+      ) : (
+        <div data-testid="not-pending">Idle</div>
+      );
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/one', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/one')]: (
+          <>
+            <h1>Page 1</h1>
+            <Link to="/two" unstable_instant>
+              Go to two
+              <PendingProbe />
+            </Link>
+          </>
+        ),
+        [unstable_getRouteSlotId('/two')]: <h1>Page 2</h1>,
+        [ROUTE_ID]: ['/one', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+
+    try {
+      const has = (testid: string) =>
+        view.container.querySelector(`[data-testid="${testid}"]`) !== null;
+
+      expect(has('not-pending')).toBe(true);
+
+      const link = Array.from(view.container.querySelectorAll('a')).find(
+        (anchor) => anchor.textContent?.includes('Go to two'),
+      ) as HTMLAnchorElement | undefined;
+      if (!link) {
+        throw new Error('expected link');
+      }
+      await act(async () => {
+        link.dispatchEvent(
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            button: 0,
+          }),
+        );
+      });
+      await flush();
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(has('pending')).toBe(true);
+      expect(has('not-pending')).toBe(false);
+      expect(view.container.textContent).toContain('Page 1');
+
+      await act(async () => {
+        navigation.resolve({
+          [unstable_getRouteSlotId('/two')]: <h1>Page 2</h1>,
+          [ROUTE_ID]: ['/two', ''],
+          [IS_STATIC_ID]: false,
+        });
+        await flush();
+      });
+
+      expect(view.container.textContent).toContain('Page 2');
+      expect(has('pending')).toBe(false);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test('instant hash-only Link does not fetch and lands on the hash', async () => {
+    window.history.replaceState({}, '', '/one');
+
+    const PendingProbe = () => {
+      const { pending } = useNavigationStatus();
+      return pending ? (
+        <div data-testid="pending">Pending</div>
+      ) : (
+        <div data-testid="not-pending">Idle</div>
+      );
+    };
+
+    const view = await renderRouter(
+      { initialRoute: { path: '/one', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/one')]: (
+          <>
+            <h1>Page 1</h1>
+            <Link to="/one#target" unstable_instant>
+              Jump
+              <PendingProbe />
+            </Link>
+          </>
+        ),
+        [ROUTE_ID]: ['/one', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+
+    try {
+      const has = (testid: string) =>
+        view.container.querySelector(`[data-testid="${testid}"]`) !== null;
+
+      expect(has('not-pending')).toBe(true);
+
+      const link = Array.from(view.container.querySelectorAll('a')).find(
+        (anchor) => anchor.textContent?.includes('Jump'),
+      ) as HTMLAnchorElement | undefined;
+      if (!link) {
+        throw new Error('expected link');
+      }
+      await act(async () => {
+        link.dispatchEvent(
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            button: 0,
+          }),
+        );
+      });
+      await flush();
+
+      expect(has('pending')).toBe(false);
+      expect(has('not-pending')).toBe(true);
+      expect(window.location.hash).toBe('#target');
+      expect(getRefetchMock()).not.toHaveBeenCalled();
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test('superseding an uncached instant navigation settles both promises', async () => {
+    const slow = createDeferred<Record<string, unknown>>();
+    const refetch = vi
+      .fn<RefetchInner>()
+      .mockImplementationOnce(() => slow.promise)
+      .mockResolvedValueOnce({
+        [ROUTE_ID]: ['/next', ''],
+        [IS_STATIC_ID]: false,
+      });
+    installRefetch(refetch);
+
+    const capture = { router: null as RouterApi | null };
+    const Probe = makeProbe(capture);
+    const view = await renderRouter(
+      { initialRoute: { path: '/start', query: '', hash: '' } },
+      {
+        [unstable_getRouteSlotId('/start')]: <Probe />,
+        [unstable_getRouteSlotId('/next')]: <Probe />,
+        [ROUTE_ID]: ['/start', ''],
+        [IS_STATIC_ID]: false,
+      },
+    );
+
+    try {
+      if (!capture.router) {
+        throw new Error('router not initialized');
+      }
+
+      await act(async () => {
+        const superseded = capture.router!.push('/slow', {
+          unstable_instant: true,
+        });
+        await Promise.resolve();
+        const active = capture.router!.push('/next');
+        await Promise.all([superseded, active]);
+      });
+
+      expect(capture.router.path).toBe('/next');
+    } finally {
+      slow.resolve({ [ROUTE_ID]: ['/slow', ''], [IS_STATIC_ID]: false });
+      view.unmount();
+    }
+  });
+
   test('instant nav reuses a prefetched response as data source and base', async () => {
     const refetch = vi.fn<RefetchInner>(async () => ({
       [ROUTE_ID]: ['/next', ''],


### PR DESCRIPTION
A Link asked to commit instantly still wraps in useTransition when there is no cached shell, so pending status and stay-put behaviour are not lost on a cache miss. The wrap is skipped when the navigation will commit without waiting, so settledRoute and shouldRefetch are computed before cancelPendingNavigation on every navigation.