### PR TITLE
bugfix: Improve request validation for server action

### DIFF
--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -126,14 +126,24 @@ function validateServerActionRequest(req: Request) {
     if (origin === 'null') {
       throw createCustomError('Forbidden', { status: 403 });
     }
-    const requestOrigin = new URL(req.url).origin;
+
+    const requestUrl = new URL(req.url);
     let originUrl: URL;
     try {
       originUrl = new URL(origin);
     } catch {
       throw createCustomError('Forbidden', { status: 403 });
     }
-    if (originUrl.origin !== requestOrigin) {
+
+    if (
+      requestUrl.protocol === 'https:' &&
+      originUrl.origin !== requestUrl.origin
+    ) {
+      throw createCustomError('Forbidden', { status: 403 });
+    } else if (
+      requestUrl.protocol === 'http:' &&
+      originUrl.host !== requestUrl.host
+    ) {
       throw createCustomError('Forbidden', { status: 403 });
     }
   } else if (req.headers.get('sec-fetch-site') === 'cross-site') {

--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -126,7 +126,6 @@ function validateServerActionRequest(req: Request) {
     if (origin === 'null') {
       throw createCustomError('Forbidden', { status: 403 });
     }
-
     const requestUrl = new URL(req.url);
     let originUrl: URL;
     try {
@@ -134,12 +133,8 @@ function validateServerActionRequest(req: Request) {
     } catch {
       throw createCustomError('Forbidden', { status: 403 });
     }
-
-    // Reject if the request's origin is different from the request URL's origin.
     if (
       originUrl.origin !== requestUrl.origin &&
-      // Only allow same-host requests upgrading from http to https (e.g. behind a reverse proxy),
-      // but not the other way around
       !(
         requestUrl.protocol === 'http:' &&
         originUrl.protocol === 'https:' &&

--- a/packages/waku/src/lib/utils/request.ts
+++ b/packages/waku/src/lib/utils/request.ts
@@ -135,14 +135,16 @@ function validateServerActionRequest(req: Request) {
       throw createCustomError('Forbidden', { status: 403 });
     }
 
+    // Reject if the request's origin is different from the request URL's origin.
     if (
-      requestUrl.protocol === 'https:' &&
-      originUrl.origin !== requestUrl.origin
-    ) {
-      throw createCustomError('Forbidden', { status: 403 });
-    } else if (
-      requestUrl.protocol === 'http:' &&
-      originUrl.host !== requestUrl.host
+      originUrl.origin !== requestUrl.origin &&
+      // Only allow same-host requests upgrading from http to https (e.g. behind a reverse proxy),
+      // but not the other way around
+      !(
+        requestUrl.protocol === 'http:' &&
+        originUrl.protocol === 'https:' &&
+        originUrl.host === requestUrl.host
+      )
     ) {
       throw createCustomError('Forbidden', { status: 403 });
     }

--- a/packages/waku/tests/request.test.ts
+++ b/packages/waku/tests/request.test.ts
@@ -17,8 +17,12 @@ const getStatus = async (promise: Promise<unknown>) => {
   }
 };
 
-const makeRequest = (headers: HeadersInit = {}, init: RequestInit = {}) =>
-  new Request('https://app.test/RSC/F/foo/bar.txt', {
+const makeRequest = (
+  headers: HeadersInit = {},
+  init: RequestInit = {},
+  protocol = 'https',
+) =>
+  new Request(`${protocol}://app.test/RSC/F/foo/bar.txt`, {
     method: 'POST',
     body: '[]',
     headers,
@@ -41,6 +45,38 @@ describe('getInput server action request validation', () => {
     const input = await makeInput(makeRequest({ origin: 'https://app.test' }));
 
     expect(input.type).toBe('call');
+  });
+
+  it('accepts same-origin server function requests over HTTP', async () => {
+    const input = await makeInput(
+      makeRequest({ origin: 'http://app.test' }, {}, 'http'),
+    );
+
+    expect(input.type).toBe('call');
+  });
+
+  it('accepts an HTTPS origin when a reverse proxy forwards over HTTP', async () => {
+    const input = await makeInput(
+      makeRequest({ origin: 'https://app.test' }, {}, 'http'),
+    );
+
+    expect(input.type).toBe('call');
+  });
+
+  it('rejects an HTTPS origin from another host for an HTTP request URL', async () => {
+    await expect(
+      getStatus(
+        makeInput(makeRequest({ origin: 'https://evil.test' }, {}, 'http')),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('rejects an HTTP origin for an HTTPS request URL', async () => {
+    await expect(
+      getStatus(
+        makeInput(makeRequest({ origin: 'http://app.test' }, {}, 'https')),
+      ),
+    ).resolves.toBe(403);
   });
 
   it('rejects server function requests with non-POST methods', async () => {

--- a/packages/waku/tests/request.test.ts
+++ b/packages/waku/tests/request.test.ts
@@ -41,8 +41,10 @@ const makeInput = (req: Request) =>
   );
 
 describe('getInput server action request validation', () => {
-  it('accepts same-origin server function requests', async () => {
-    const input = await makeInput(makeRequest({ origin: 'https://app.test' }));
+  it('accepts same-origin server function requests over HTTPS', async () => {
+    const input = await makeInput(
+      makeRequest({ origin: 'https://app.test' }, {}, 'https'),
+    );
 
     expect(input.type).toBe('call');
   });
@@ -63,20 +65,45 @@ describe('getInput server action request validation', () => {
     expect(input.type).toBe('call');
   });
 
-  it('rejects an HTTPS origin from another host for an HTTP request URL', async () => {
-    await expect(
-      getStatus(
-        makeInput(makeRequest({ origin: 'https://evil.test' }, {}, 'http')),
-      ),
-    ).resolves.toBe(403);
-  });
-
   it('rejects an HTTP origin for an HTTPS request URL', async () => {
     await expect(
       getStatus(
         makeInput(makeRequest({ origin: 'http://app.test' }, {}, 'https')),
       ),
     ).resolves.toBe(403);
+  });
+
+  for (const originProtocol of ['http', 'https'] as const) {
+    for (const requestProtocol of ['http', 'https'] as const) {
+      it(`rejects an ${originProtocol} origin from another host for an ${requestProtocol} request URL`, async () => {
+        const request = makeRequest(
+          { origin: `${originProtocol}://evil.test` },
+          {},
+          requestProtocol,
+        );
+        await expect(getStatus(makeInput(request))).resolves.toBe(403);
+      });
+    }
+  }
+
+  it('rejects origin in non http scheme', async () => {
+    for (const scheme of ['ftp', 'file', 'data'] as const) {
+      await expect(
+        getStatus(
+          makeInput(
+            makeRequest({ origin: `${scheme}://evil.test` }, {}, 'http'),
+          ),
+        ),
+      ).resolves.toBe(403);
+
+      await expect(
+        getStatus(
+          makeInput(
+            makeRequest({ origin: `${scheme}://evil.test` }, {}, 'https'),
+          ),
+        ),
+      ).resolves.toBe(403);
+    }
   });
 
   it('rejects server function requests with non-POST methods', async () => {


### PR DESCRIPTION
## Reasons and how to reproduce

While using SSR features, there is a `validateServerActionRequest` <https://github.com/wakujs/waku/blob/76cd032df3ab90ba6338b04fe622fc7fb06d3170/packages/waku/src/lib/utils/request.ts#L124-L141> to verify server action. When Waku itself acts as a server and serves endpoints directly, the `origin` header received in the request is taken directly from Hono. and whether it is http or https comes directly from the requesting client and hono to waku without **modification**. the check `originUrl.origin !== requestOrigin` works well in this case.

However, when Waku sits **behind a reverse proxy** (e.g. Caddy / Nginx), a very common pattern to host server, the `origin` read from the headers and the origin scheme read from new `URL(req.url).origin` DO NOT match. The header forwarded by the reverse proxy will be `https`, while the URL remains `http`. **This causes validateServerActionRequest to fail validation**, show 403/500 error on front pages.

That's

1. When accessing the server hosted by Waku directly:
   - plain server case (http)
     - `originUrl = new URL(req.headers.get('origin'))` -> `http://example.org`
     - `const requestUrl = new URL(req.url).origin` -> `http://example.org`
     - `originUrl.origin !== requestUrl.origin` -> true ✅
   - Secured by SSL
     - `originUrl = new URL(req.headers.get('origin'))` -> `https://example.org`
     - `const requestUrl = new URL(req.url).origin` -> `https://example.org`
     - `originUrl.origin === requestUrl.origin` -> true ✅
2. When putting caddy before waku
   - SSL provided by Caddy, waku still keep plain http/1.1
     - `originUrl = new URL(req.headers.get('origin'))` -> `https://example.org`
     - `const requestUrl = new URL(req.url).origin` -> `http://example.org`
     - `originUrl.origin === requestUrl.origin` -> false ❌
     - server action calls are rejected



## What I changed in this PR

Modify the validation logic so that 

1. when the scheme read from the URL is `http`, the origin is allowed to be either `http` or `https`
2. when the URL scheme is `https`, the origin must not be downgraded to `http`, preserves exact-origin validation. 

Add the necessary regression tests to verify the correctness of the logic.

## That's all

Looking for your opinions

Best,
Lanqing