### PR TITLE
fix(minimal): support multiple roots

### DIFF
--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -516,16 +516,17 @@ The Minimal API exposes fetching and merging separately. Define a hook for the b
 import { useCallback, useTransition } from 'react';
 import {
   unstable_fetchRsc as fetchRsc,
-  unstable_registerRscReloadListener as registerRscReloadListener,
   useMergeElements_UNSTABLE as useMergeElements,
+  useRscReloadListener_UNSTABLE as useRscReloadListener,
 } from 'waku/minimal/client';
 
 const useRefetch = () => {
   const mergeElements = useMergeElements();
+  const registerRscReloadListener = useRscReloadListener();
   return useCallback(
     (rscPath: string, rscParams?: unknown) => {
       const refetch = () => mergeElements(fetchRsc(rscPath, rscParams));
-      registerRscReloadListener(
+      registerRscReloadListener?.(
         () => {
           void refetch();
         },
@@ -533,7 +534,7 @@ const useRefetch = () => {
       );
       return refetch();
     },
-    [mergeElements],
+    [mergeElements, registerRscReloadListener],
   );
 };
 

--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -517,16 +517,16 @@ import { useCallback, useTransition } from 'react';
 import {
   unstable_fetchRsc as fetchRsc,
   useMergeElements_UNSTABLE as useMergeElements,
-  useRscReloadListener_UNSTABLE as useRscReloadListener,
+  useRegisterRscReloadListener_UNSTABLE as useRegisterRscReloadListener,
 } from 'waku/minimal/client';
 
 const useRefetch = () => {
   const mergeElements = useMergeElements();
-  const registerRscReloadListener = useRscReloadListener();
+  const registerRscReloadListener = useRegisterRscReloadListener();
   return useCallback(
     (rscPath: string, rscParams?: unknown) => {
       const refetch = () => mergeElements(fetchRsc(rscPath, rscParams));
-      registerRscReloadListener?.(
+      registerRscReloadListener(
         () => {
           void refetch();
         },

--- a/e2e/fixtures/instant-nav/src/components/MinimalRefetch.tsx
+++ b/e2e/fixtures/instant-nav/src/components/MinimalRefetch.tsx
@@ -3,16 +3,17 @@
 import { useCallback } from 'react';
 import {
   unstable_fetchRsc as fetchRsc,
-  unstable_registerRscReloadListener as registerRscReloadListener,
   useMergeElements_UNSTABLE as useMergeElements,
+  useRscReloadListener_UNSTABLE as useRscReloadListener,
 } from 'waku/minimal/client';
 
 const useRefetch = () => {
   const mergeElements = useMergeElements();
+  const registerRscReloadListener = useRscReloadListener();
   return useCallback(
     (rscPath: string, rscParams?: unknown) => {
       const refetch = () => mergeElements(fetchRsc(rscPath, rscParams));
-      registerRscReloadListener(
+      registerRscReloadListener?.(
         () => {
           void refetch();
         },
@@ -20,7 +21,7 @@ const useRefetch = () => {
       );
       return refetch();
     },
-    [mergeElements],
+    [mergeElements, registerRscReloadListener],
   );
 };
 

--- a/e2e/fixtures/instant-nav/src/components/MinimalRefetch.tsx
+++ b/e2e/fixtures/instant-nav/src/components/MinimalRefetch.tsx
@@ -4,16 +4,16 @@ import { useCallback } from 'react';
 import {
   unstable_fetchRsc as fetchRsc,
   useMergeElements_UNSTABLE as useMergeElements,
-  useRscReloadListener_UNSTABLE as useRscReloadListener,
+  useRegisterRscReloadListener_UNSTABLE as useRegisterRscReloadListener,
 } from 'waku/minimal/client';
 
 const useRefetch = () => {
   const mergeElements = useMergeElements();
-  const registerRscReloadListener = useRscReloadListener();
+  const registerRscReloadListener = useRegisterRscReloadListener();
   return useCallback(
     (rscPath: string, rscParams?: unknown) => {
       const refetch = () => mergeElements(fetchRsc(rscPath, rscParams));
-      registerRscReloadListener?.(
+      registerRscReloadListener(
         () => {
           void refetch();
         },

--- a/e2e/fixtures/minimal-examples/src/components/Counter.tsx
+++ b/e2e/fixtures/minimal-examples/src/components/Counter.tsx
@@ -3,16 +3,17 @@
 import { useCallback, useState } from 'react';
 import {
   unstable_fetchRsc as fetchRsc,
-  unstable_registerRscReloadListener as registerRscReloadListener,
   useMergeElements_UNSTABLE as useMergeElements,
+  useRscReloadListener_UNSTABLE as useRscReloadListener,
 } from 'waku/minimal/client';
 
 const useRefetch = () => {
   const mergeElements = useMergeElements();
+  const registerRscReloadListener = useRscReloadListener();
   return useCallback(
     (rscPath: string) => {
       const refetch = () => mergeElements(fetchRsc(rscPath));
-      registerRscReloadListener(
+      registerRscReloadListener?.(
         () => {
           void refetch();
         },
@@ -20,7 +21,7 @@ const useRefetch = () => {
       );
       return refetch();
     },
-    [mergeElements],
+    [mergeElements, registerRscReloadListener],
   );
 };
 

--- a/e2e/fixtures/minimal-examples/src/components/Counter.tsx
+++ b/e2e/fixtures/minimal-examples/src/components/Counter.tsx
@@ -4,16 +4,16 @@ import { useCallback, useState } from 'react';
 import {
   unstable_fetchRsc as fetchRsc,
   useMergeElements_UNSTABLE as useMergeElements,
-  useRscReloadListener_UNSTABLE as useRscReloadListener,
+  useRegisterRscReloadListener_UNSTABLE as useRegisterRscReloadListener,
 } from 'waku/minimal/client';
 
 const useRefetch = () => {
   const mergeElements = useMergeElements();
-  const registerRscReloadListener = useRscReloadListener();
+  const registerRscReloadListener = useRegisterRscReloadListener();
   return useCallback(
     (rscPath: string) => {
       const refetch = () => mergeElements(fetchRsc(rscPath));
-      registerRscReloadListener?.(
+      registerRscReloadListener(
         () => {
           void refetch();
         },

--- a/e2e/fixtures/rsc-basic/src/components/MultipleRootAction.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/MultipleRootAction.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { useEffect, useLayoutEffect, useState } from 'react';
-import { useRscReloadListener_UNSTABLE as useRscReloadListener } from 'waku/minimal/client';
+import { useRegisterRscReloadListener_UNSTABLE as useRegisterRscReloadListener } from 'waku/minimal/client';
 import { updateContent } from './ServerPing/actions.js';
 
 type RootName = 'first' | 'second' | 'third';
 
 export const MultipleRootAction = ({ name }: { name: RootName }) => {
-  const registerRscReloadListener = useRscReloadListener();
+  const registerRscReloadListener = useRegisterRscReloadListener();
   const [ownsHmr, setOwnsHmr] = useState(false);
   useLayoutEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
     return searchParams.get('descendant-hmr') === name || ownsHmr
-      ? registerRscReloadListener?.(
+      ? registerRscReloadListener(
           () => {
             (
               globalThis as typeof globalThis & {

--- a/e2e/fixtures/rsc-basic/src/components/MultipleRootAction.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/MultipleRootAction.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { useRscReloadListener_UNSTABLE as useRscReloadListener } from 'waku/minimal/client';
 import { updateContent } from './ServerPing/actions.js';
 
@@ -9,21 +9,23 @@ type RootName = 'first' | 'second' | 'third';
 export const MultipleRootAction = ({ name }: { name: RootName }) => {
   const registerRscReloadListener = useRscReloadListener();
   const [ownsHmr, setOwnsHmr] = useState(false);
+  useLayoutEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    return searchParams.get('descendant-hmr') === name || ownsHmr
+      ? registerRscReloadListener?.(
+          () => {
+            (
+              globalThis as typeof globalThis & {
+                __WAKU_TEST_HMR_TARGET__?: RootName;
+              }
+            ).__WAKU_TEST_HMR_TARGET__ = name;
+          },
+          { replace: true },
+        )
+      : undefined;
+  }, [name, ownsHmr, registerRscReloadListener]);
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
-    const unregister =
-      searchParams.get('descendant-hmr') === name || ownsHmr
-        ? registerRscReloadListener?.(
-            () => {
-              (
-                globalThis as typeof globalThis & {
-                  __WAKU_TEST_HMR_TARGET__?: RootName;
-                }
-              ).__WAKU_TEST_HMR_TARGET__ = name;
-            },
-            { replace: true },
-          )
-        : undefined;
     const next =
       name === 'first'
         ? 'second'
@@ -37,8 +39,7 @@ export const MultipleRootAction = ({ name }: { name: RootName }) => {
         }
       ).__WAKU_MOUNT_ROOT__?.(next);
     }
-    return unregister;
-  }, [name, ownsHmr, registerRscReloadListener]);
+  }, [name]);
   return (
     <>
       <button onClick={() => updateContent()}>Update content</button>

--- a/e2e/fixtures/rsc-basic/src/components/MultipleRootAction.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/MultipleRootAction.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRscReloadListener_UNSTABLE as useRscReloadListener } from 'waku/minimal/client';
+import { updateContent } from './ServerPing/actions.js';
+
+type RootName = 'first' | 'second' | 'third';
+
+export const MultipleRootAction = ({ name }: { name: RootName }) => {
+  const registerRscReloadListener = useRscReloadListener();
+  const [ownsHmr, setOwnsHmr] = useState(false);
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const unregister =
+      searchParams.get('descendant-hmr') === name || ownsHmr
+        ? registerRscReloadListener?.(
+            () => {
+              (
+                globalThis as typeof globalThis & {
+                  __WAKU_TEST_HMR_TARGET__?: RootName;
+                }
+              ).__WAKU_TEST_HMR_TARGET__ = name;
+            },
+            { replace: true },
+          )
+        : undefined;
+    const next =
+      name === 'first'
+        ? 'second'
+        : name === 'second' && searchParams.has('three-roots')
+          ? 'third'
+          : undefined;
+    if (next) {
+      (
+        globalThis as typeof globalThis & {
+          __WAKU_MOUNT_ROOT__?: (name: RootName) => void;
+        }
+      ).__WAKU_MOUNT_ROOT__?.(next);
+    }
+    return unregister;
+  }, [name, ownsHmr, registerRscReloadListener]);
+  return (
+    <>
+      <button onClick={() => updateContent()}>Update content</button>
+      <button onClick={() => setOwnsHmr(true)}>
+        {ownsHmr ? 'Owns HMR' : 'Own HMR'}
+      </button>
+    </>
+  );
+};

--- a/e2e/fixtures/rsc-basic/src/components/ServerPing/actions.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ServerPing/actions.tsx
@@ -17,3 +17,5 @@ export const wrap = async (node: ReactNode) => {
 export const getData = async () => {
   return <span className="server-data">Server Data</span>;
 };
+
+export const updateContent = async () => 'update-content';

--- a/e2e/fixtures/rsc-basic/src/waku.client.tsx
+++ b/e2e/fixtures/rsc-basic/src/waku.client.tsx
@@ -4,7 +4,20 @@ import { unstable_defaultRootOptions as defaultRootOptions } from 'waku/client';
 import {
   Root_UNSTABLE as Root,
   Slot_UNSTABLE as Slot,
+  unstable_registerRscReloadListener as registerRscReloadListener,
 } from 'waku/minimal/client';
+
+registerRscReloadListener(() => {
+  (
+    globalThis as typeof globalThis & {
+      __WAKU_ROOTLESS_HMR_LISTENER__?: boolean;
+    }
+  ).__WAKU_ROOTLESS_HMR_LISTENER__ = true;
+});
+
+const multipleRoots = new URLSearchParams(window.location.search).has(
+  'multiple-roots',
+);
 
 const rootElement = (
   <StrictMode>
@@ -14,4 +27,55 @@ const rootElement = (
   </StrictMode>
 );
 
-createRoot(document, defaultRootOptions).render(rootElement);
+if (multipleRoots) {
+  type RootName = 'first' | 'second' | 'third';
+  const mounted = new Set<RootName>();
+  const mountRoot = (name: RootName) => {
+    if (mounted.has(name)) {
+      return;
+    }
+    mounted.add(name);
+    const container = document.createElement('div');
+    container.dataset.testid = `${name}-root`;
+    document.body.appendChild(container);
+    const reactRoot = createRoot(container, defaultRootOptions);
+    let initialRscParams: unknown;
+    const renderRoot = () => {
+      reactRoot.render(
+        <StrictMode>
+          <Root initialRscPath={name} initialRscParams={initialRscParams}>
+            <Slot id="Content" />
+          </Root>
+        </StrictMode>,
+      );
+    };
+    renderRoot();
+    if (name !== 'first') {
+      const unmount = document.createElement('button');
+      unmount.dataset.testid = `unmount-${name}-root`;
+      unmount.textContent = `Unmount ${name} root`;
+      unmount.addEventListener('click', () => reactRoot.unmount());
+      document.body.appendChild(unmount);
+    }
+    if (name === 'second') {
+      const rerender = document.createElement('button');
+      rerender.dataset.testid = 'rerender-second-root';
+      rerender.textContent = 'Rerender second root';
+      rerender.addEventListener('click', () => {
+        initialRscParams = {};
+        renderRoot();
+      });
+      document.body.appendChild(rerender);
+    }
+  };
+  const global = globalThis as typeof globalThis & {
+    __WAKU_MOUNT_ROOT__?: (name: RootName) => void;
+  };
+  global.__WAKU_MOUNT_ROOT__ = mountRoot;
+  mountRoot('first');
+  if (new URLSearchParams(window.location.search).has('simultaneous-roots')) {
+    mountRoot('second');
+  }
+} else {
+  createRoot(document, defaultRootOptions).render(rootElement);
+}

--- a/e2e/fixtures/rsc-basic/src/waku.client.tsx
+++ b/e2e/fixtures/rsc-basic/src/waku.client.tsx
@@ -15,6 +15,13 @@ registerRscReloadListener(() => {
   ).__WAKU_ROOTLESS_HMR_LISTENER__ = true;
 });
 
+registerRscReloadListener(() => {}, { replace: true });
+(
+  globalThis as typeof globalThis & {
+    __WAKU_ROOTLESS_HMR_REPLACEMENT_REGISTERED__?: boolean;
+  }
+).__WAKU_ROOTLESS_HMR_REPLACEMENT_REGISTERED__ = true;
+
 const multipleRoots = new URLSearchParams(window.location.search).has(
   'multiple-roots',
 );

--- a/e2e/fixtures/rsc-basic/src/waku.server.tsx
+++ b/e2e/fixtures/rsc-basic/src/waku.server.tsx
@@ -1,5 +1,6 @@
 import adapter from 'waku/adapters/default';
 import App from './components/App.js';
+import { MultipleRootAction } from './components/MultipleRootAction.js';
 
 const BUILD_MATADATA_KEY = 'metadata-key';
 const BUILD_MATADATA_VALUE = 'metadata-value';
@@ -7,6 +8,23 @@ const BUILD_MATADATA_VALUE = 'metadata-value';
 export default adapter({
   handleRequest: async (input, { renderRsc, loadBuildMetadata }) => {
     if (input.type === 'rsc') {
+      if (
+        input.rscPath === 'first' ||
+        input.rscPath === 'second' ||
+        input.rscPath === 'third'
+      ) {
+        return renderRsc(
+          {
+            Content: (
+              <div>
+                <p>{input.rscPath}</p>
+                <MultipleRootAction name={input.rscPath} />
+              </div>
+            ),
+          },
+          { etags: { Content: input.rscPath } },
+        );
+      }
       return renderRsc({
         App: (
           <App
@@ -19,7 +37,10 @@ export default adapter({
     }
     if (input.type === 'call') {
       const value = await input.fn(...input.args);
-      return renderRsc({}, { value });
+      return renderRsc(
+        value === 'update-content' ? { Content: <p>updated content</p> } : {},
+        { value },
+      );
     }
     return 'fallback';
   },

--- a/e2e/hot-reload.dev.spec.ts
+++ b/e2e/hot-reload.dev.spec.ts
@@ -191,6 +191,28 @@ test.describe('hot reload', () => {
     await expect(page.getByText('Fixed Page')).toBeVisible();
   });
 
+  test('router owns the replaceable HMR target', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/`);
+    await waitForHydration(page);
+
+    const requests = await page.evaluate(() => {
+      const urls: string[] = [];
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (...args) => {
+        urls.push(String(args[0]));
+        return originalFetch(...args);
+      };
+      try {
+        globalThis.__WAKU_REFETCH_RSC__?.();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+      return urls;
+    });
+
+    expect(requests).toEqual([]);
+  });
+
   test('css modules', async ({ page }) => {
     await page.goto(`http://localhost:${port}/css-modules`);
     await waitForHydration(page);

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -35,6 +35,256 @@ test.describe(`rsc-basic`, () => {
     ).toHaveText('2');
   });
 
+  test(
+    'deprecated additive HMR listeners can register before Root mounts',
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(`http://localhost:${port}/`);
+      await expect(page.getByTestId('app-name')).toHaveText('Waku');
+
+      const called = await page.evaluate(() => {
+        globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((listener) =>
+          listener(),
+        );
+        return (
+          globalThis as typeof globalThis & {
+            __WAKU_ROOTLESS_HMR_LISTENER__?: boolean;
+          }
+        ).__WAKU_ROOTLESS_HMR_LISTENER__;
+      });
+
+      expect(called).toBe(true);
+    },
+  );
+
+  test('server actions target the default minimal root', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/?multiple-roots`);
+    await expect(page.getByTestId('first-root')).toContainText('first');
+    await expect(page.getByTestId('second-root')).toContainText('second');
+    await page
+      .getByTestId('first-root')
+      .getByRole('button', { name: 'Update content' })
+      .click();
+    await expect(page.getByTestId('second-root')).toContainText(
+      'updated content',
+    );
+    await page.getByTestId('unmount-second-root').click();
+    await page
+      .getByTestId('first-root')
+      .getByRole('button', { name: 'Update content' })
+      .click();
+    await expect(page.getByTestId('first-root')).toContainText(
+      'updated content',
+    );
+  });
+
+  test('simultaneously suspended Roots settle independently', async ({
+    page,
+  }) => {
+    await page.goto(
+      `http://localhost:${port}/?multiple-roots&simultaneous-roots`,
+    );
+    await expect(page.getByTestId('first-root')).toContainText('first');
+    await expect(page.getByTestId('second-root')).toContainText('second');
+  });
+
+  test(
+    'unmounting the default Root restores the previous HMR target',
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(`http://localhost:${port}/?multiple-roots`);
+      await expect(page.getByTestId('first-root')).toContainText('first');
+      await expect(page.getByTestId('second-root')).toContainText('second');
+      await page.getByTestId('unmount-second-root').click();
+
+      const requests = await page.evaluate(async () => {
+        const urls: string[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (...args) => {
+          urls.push(String(args[0]));
+          return originalFetch(...args);
+        };
+        try {
+          globalThis.__WAKU_REFETCH_RSC__?.();
+          await Promise.resolve();
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+        return urls;
+      });
+
+      expect(requests).toContain('/RSC/first.txt');
+    },
+  );
+
+  test(
+    'HMR clears cached etags from every Root',
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(`http://localhost:${port}/?multiple-roots`);
+      await expect(page.getByTestId('second-root')).toContainText('second');
+      await page.evaluate(() => globalThis.__WAKU_REFETCH_RSC__?.());
+      await page.getByTestId('unmount-second-root').click();
+
+      const actionRequest = page.waitForRequest(
+        (request) =>
+          request.method() === 'POST' &&
+          new URL(request.url()).pathname.startsWith('/RSC/'),
+      );
+      await page
+        .getByTestId('first-root')
+        .getByRole('button', { name: 'Update content' })
+        .click();
+
+      expect((await actionRequest).headers()['x-waku-etags']).toBe('{}');
+    },
+  );
+
+  test(
+    "unmounting the default Root restores the previous Root's descendant HMR target",
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(
+        `http://localhost:${port}/?multiple-roots&descendant-hmr=first`,
+      );
+      await expect(page.getByTestId('first-root')).toContainText('first');
+      await expect(page.getByTestId('second-root')).toContainText('second');
+      await page.getByTestId('unmount-second-root').click();
+
+      const called = await page.evaluate(() => {
+        globalThis.__WAKU_REFETCH_RSC__?.();
+        return (
+          globalThis as typeof globalThis & {
+            __WAKU_TEST_HMR_TARGET__?: string;
+          }
+        ).__WAKU_TEST_HMR_TARGET__;
+      });
+
+      expect(called).toBe('first');
+    },
+  );
+
+  test(
+    'a non-default Root can own its HMR target',
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(`http://localhost:${port}/?multiple-roots`);
+      await expect(page.getByTestId('second-root')).toContainText('second');
+      await page
+        .getByTestId('first-root')
+        .getByRole('button', { name: 'Own HMR', exact: true })
+        .click();
+      await expect(
+        page
+          .getByTestId('first-root')
+          .getByRole('button', { name: 'Owns HMR' }),
+      ).toBeVisible();
+      await page.getByTestId('unmount-second-root').click();
+
+      const called = await page.evaluate(() => {
+        globalThis.__WAKU_REFETCH_RSC__?.();
+        return (
+          globalThis as typeof globalThis & {
+            __WAKU_TEST_HMR_TARGET__?: string;
+          }
+        ).__WAKU_TEST_HMR_TARGET__;
+      });
+
+      expect(called).toBe('first');
+    },
+  );
+
+  test(
+    "unmounting a Root with a descendant HMR target restores the previous Root's target",
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(
+        `http://localhost:${port}/?multiple-roots&descendant-hmr=second`,
+      );
+      await expect(page.getByTestId('second-root')).toContainText('second');
+      await page.getByTestId('unmount-second-root').click();
+
+      const requests = await page.evaluate(async () => {
+        const urls: string[] = [];
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (...args) => {
+          urls.push(String(args[0]));
+          return originalFetch(...args);
+        };
+        try {
+          globalThis.__WAKU_REFETCH_RSC__?.();
+          await Promise.resolve();
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+        return urls;
+      });
+
+      expect(requests).toContain('/RSC/first.txt');
+    },
+  );
+
+  test(
+    'unmounting a middle Root preserves earlier HMR ownership',
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(
+        `http://localhost:${port}/?multiple-roots&three-roots&descendant-hmr=first`,
+      );
+      await expect(page.getByTestId('third-root')).toContainText('third');
+      await page.getByTestId('unmount-second-root').click();
+      await page.getByTestId('unmount-third-root').click();
+
+      const called = await page.evaluate(() => {
+        globalThis.__WAKU_REFETCH_RSC__?.();
+        return (
+          globalThis as typeof globalThis & {
+            __WAKU_TEST_HMR_TARGET__?: string;
+          }
+        ).__WAKU_TEST_HMR_TARGET__;
+      });
+
+      expect(called).toBe('first');
+    },
+  );
+
+  test(
+    'rerendering a Root preserves its descendant HMR target',
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(`http://localhost:${port}/?multiple-roots`);
+      await expect(page.getByTestId('second-root')).toContainText('second');
+      await page.evaluate(() => {
+        const previous = globalThis.__WAKU_REFETCH_RSC__;
+        const listeners = globalThis.__WAKU_RSC_RELOAD_LISTENERS__;
+        const replacement = () => {
+          (
+            globalThis as typeof globalThis & {
+              __WAKU_TEST_HMR_TARGET__?: boolean;
+            }
+          ).__WAKU_TEST_HMR_TARGET__ = true;
+        };
+        const index = previous && listeners?.indexOf(previous);
+        if (listeners && typeof index === 'number' && index !== -1) {
+          listeners.splice(index, 1, replacement);
+        }
+        globalThis.__WAKU_REFETCH_RSC__ = replacement;
+      });
+
+      await page.getByTestId('rerender-second-root').click();
+      const called = await page.evaluate(() => {
+        globalThis.__WAKU_REFETCH_RSC__?.();
+        return (
+          globalThis as typeof globalThis & {
+            __WAKU_TEST_HMR_TARGET__?: boolean;
+          }
+        ).__WAKU_TEST_HMR_TARGET__;
+      });
+
+      expect(called).toBe(true);
+    },
+  );
+
   test('index.html', async ({ request }) => {
     const res = await request.get(`http://localhost:${port}/`);
     expect(await res.text()).toContain('name="test-custom-index-html"');

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -57,6 +57,26 @@ test.describe(`rsc-basic`, () => {
     },
   );
 
+  test(
+    'deprecated replacement HMR listeners can register before Root mounts',
+    { tag: '@dev' },
+    async ({ page }) => {
+      await page.goto(`http://localhost:${port}/`);
+      await expect(page.getByTestId('app-name')).toHaveText('Waku');
+
+      const registered = await page.evaluate(
+        () =>
+          (
+            globalThis as typeof globalThis & {
+              __WAKU_ROOTLESS_HMR_REPLACEMENT_REGISTERED__?: boolean;
+            }
+          ).__WAKU_ROOTLESS_HMR_REPLACEMENT_REGISTERED__,
+      );
+
+      expect(registered).toBe(true);
+    },
+  );
+
   test('server actions target the default minimal root', async ({ page }) => {
     await page.goto(`http://localhost:${port}/?multiple-roots`);
     await expect(page.getByTestId('first-root')).toContainText('first');

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -137,6 +137,32 @@ test.describe(`rsc-basic`, () => {
     },
   );
 
+  test('HMR reloads every mounted Root', { tag: '@dev' }, async ({ page }) => {
+    await page.goto(`http://localhost:${port}/?multiple-roots`);
+    await expect(page.getByTestId('first-root')).toContainText('first');
+    await expect(page.getByTestId('second-root')).toContainText('second');
+
+    const requests = await page.evaluate(() => {
+      const urls: string[] = [];
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (...args) => {
+        urls.push(String(args[0]));
+        return originalFetch(...args);
+      };
+      try {
+        globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((listener) =>
+          listener(),
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+      return urls;
+    });
+
+    expect(requests).toContain('/RSC/first.txt');
+    expect(requests).toContain('/RSC/second.txt');
+  });
+
   test(
     'HMR clears cached etags from every Root',
     { tag: '@dev' },

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -19,6 +19,11 @@ import { error, info } from '@actions/core';
 import { test as basicTest, expect } from '@playwright/test';
 import type { ConsoleMessage, Page } from '@playwright/test';
 
+declare global {
+  var __WAKU_RSC_RELOAD_LISTENERS__: (() => void)[] | undefined;
+  var __WAKU_REFETCH_RSC__: (() => void) | undefined;
+}
+
 const execAsync = promisify(exec);
 
 export const FETCH_ERROR_MESSAGES = {

--- a/packages/waku/src/minimal/client-utils/fetch-store.ts
+++ b/packages/waku/src/minimal/client-utils/fetch-store.ts
@@ -1,17 +1,6 @@
-import type { Etags } from '../../lib/utils/etags.js';
-
-export const ENTRY = 'e';
-export const SET_ELEMENTS = 's';
 export const FETCH_ENHANCERS = 'f';
 export const FETCH_RSC_INPUT_TRANSFORMERS = 't';
 export const CALL_SERVER_ELEMENTS_LISTENERS = 'l';
-export const CACHED_ETAGS = 'c';
-
-export type SetElements = (
-  updater: (
-    prev: Promise<Record<string | symbol, unknown>>,
-  ) => Promise<Record<string | symbol, unknown>>,
-) => void;
 
 export type FetchEnhancer = (fetchFn: typeof fetch) => typeof fetch;
 type FetchEnhancers = Set<FetchEnhancer>;
@@ -27,16 +16,9 @@ type CallServerElementsListeners = Set<
 >;
 
 export type FetchRscStore = {
-  [ENTRY]?: [
-    rscPath: string,
-    rscParams: unknown,
-    elementsPromise: Promise<Record<string, unknown>>,
-  ];
-  [SET_ELEMENTS]?: SetElements;
   [FETCH_ENHANCERS]?: FetchEnhancers;
   [FETCH_RSC_INPUT_TRANSFORMERS]?: FetchRscInputTransformers;
   [CALL_SERVER_ELEMENTS_LISTENERS]?: CallServerElementsListeners;
-  [CACHED_ETAGS]?: Etags;
 };
 
 // Internal module-level RSC store. This module is intentionally absent from the

--- a/packages/waku/src/minimal/client-utils/initial-rsc-store.ts
+++ b/packages/waku/src/minimal/client-utils/initial-rsc-store.ts
@@ -1,0 +1,51 @@
+type Elements = Record<string | symbol, unknown>;
+
+type InitialRscEntry = [
+  rscPath: string,
+  rscParams: unknown,
+  elements: Promise<Elements>,
+];
+
+// An abandoned suspended render has no cleanup, so this cache must be bounded.
+const INITIAL_RSC_ENTRY_LIMIT = 32;
+const initialRscEntries: InitialRscEntry[] = [];
+
+export const clearInitialRscEntries = (): void => {
+  initialRscEntries.length = 0;
+};
+
+export const getInitialRscEntry = (
+  rscPath: string,
+  rscParams: unknown,
+  create: () => Promise<Elements>,
+): Promise<Elements> => {
+  const index = initialRscEntries.findIndex(
+    (item) => item[0] === rscPath && item[1] === rscParams,
+  );
+  if (index !== -1) {
+    const entry = initialRscEntries[index]!;
+    initialRscEntries.splice(index, 1);
+    initialRscEntries.push(entry);
+    return entry[2];
+  }
+  const elements = create();
+  if (initialRscEntries.length === INITIAL_RSC_ENTRY_LIMIT) {
+    void initialRscEntries.shift();
+  }
+  initialRscEntries.push([rscPath, rscParams, elements]);
+  return elements;
+};
+
+export const releaseInitialRscEntry = (
+  rscPath: string,
+  rscParams: unknown,
+  elements: Promise<Elements>,
+): void => {
+  const index = initialRscEntries.findIndex(
+    (item) =>
+      item[0] === rscPath && item[1] === rscParams && item[2] === elements,
+  );
+  if (index !== -1) {
+    initialRscEntries.splice(index, 1);
+  }
+};

--- a/packages/waku/src/minimal/client-utils/root-store.ts
+++ b/packages/waku/src/minimal/client-utils/root-store.ts
@@ -2,6 +2,8 @@ import type { Etags } from '../../lib/utils/etags.js';
 
 type Elements = Record<string | symbol, unknown>;
 
+export type CallServerElementsListener = (elements: Elements) => void;
+
 export type SetElements = (
   updater: (prev: Promise<Elements>) => Promise<Elements>,
 ) => void;
@@ -9,6 +11,7 @@ export type SetElements = (
 export type RootStore = {
   setElements: SetElements;
   etags: Etags;
+  listeners: Set<CallServerElementsListener>;
 };
 
 const mountedRootStores: RootStore[] = [];

--- a/packages/waku/src/minimal/client-utils/root-store.ts
+++ b/packages/waku/src/minimal/client-utils/root-store.ts
@@ -1,0 +1,33 @@
+import type { Etags } from '../../lib/utils/etags.js';
+
+type Elements = Record<string | symbol, unknown>;
+
+export type SetElements = (
+  updater: (prev: Promise<Elements>) => Promise<Elements>,
+) => void;
+
+export type RootStore = {
+  setElements: SetElements;
+  etags: Etags;
+};
+
+const mountedRootStores: RootStore[] = [];
+
+export const getDefaultRootStore = (): RootStore | undefined =>
+  mountedRootStores.at(-1);
+
+export const clearRootCachedEtags = (): void => {
+  mountedRootStores.forEach((store) => {
+    store.etags = {};
+  });
+};
+
+export const registerRootStore = (store: RootStore) => {
+  mountedRootStores.push(store);
+  return () => {
+    const index = mountedRootStores.lastIndexOf(store);
+    if (index !== -1) {
+      mountedRootStores.splice(index, 1);
+    }
+  };
+};

--- a/packages/waku/src/minimal/client-utils/rsc-reload.ts
+++ b/packages/waku/src/minimal/client-utils/rsc-reload.ts
@@ -116,7 +116,13 @@ export const registerDefaultRscReloadListener: RegisterRscReloadListener = (
   }
   const store = getDefaultRootStore();
   if (!store) {
-    throw new Error('Missing Root component');
+    const registered = createRscReloadListener(listener);
+    setActiveRscReloadListener(registered);
+    return () => {
+      if (globalThis.__WAKU_REFETCH_RSC__ === registered) {
+        activateDefaultRscReloadListener();
+      }
+    };
   }
   return registerRootRscReloadListener(store, listener, options);
 };

--- a/packages/waku/src/minimal/client-utils/rsc-reload.ts
+++ b/packages/waku/src/minimal/client-utils/rsc-reload.ts
@@ -1,0 +1,122 @@
+import { clearInitialRscEntries } from './initial-rsc-store.js';
+import { clearRootCachedEtags, getDefaultRootStore } from './root-store.js';
+import type { RootStore } from './root-store.js';
+
+type Unregister = () => void;
+
+export type RegisterRscReloadListener = (
+  listener: () => void,
+  options?: { replace?: boolean },
+) => Unregister;
+
+type RootReload = {
+  fallback: () => void;
+  replacement?: () => void;
+};
+
+const rootReloads = new WeakMap<RootStore, RootReload>();
+
+const setActiveRscReloadListener = (listener: (() => void) | undefined) => {
+  const listeners = (globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= []);
+  const active = globalThis.__WAKU_REFETCH_RSC__;
+  const activeIndex = active ? listeners.indexOf(active) : -1;
+  if (listener) {
+    if (activeIndex === -1) {
+      listeners.push(listener);
+    } else {
+      listeners.splice(activeIndex, 1, listener);
+    }
+  } else if (activeIndex !== -1) {
+    listeners.splice(activeIndex, 1);
+  }
+  globalThis.__WAKU_REFETCH_RSC__ = listener;
+};
+
+const activateDefaultRscReloadListener = (): void => {
+  const store = getDefaultRootStore();
+  if (!store) {
+    setActiveRscReloadListener(undefined);
+    return;
+  }
+  const reload = rootReloads.get(store);
+  setActiveRscReloadListener(reload?.replacement ?? reload?.fallback);
+};
+
+const createRscReloadListener =
+  (listener: () => void): Unregister =>
+  () => {
+    clearRootCachedEtags();
+    clearInitialRscEntries();
+    listener();
+  };
+
+const addRscReloadListener = (listener: () => void): Unregister => {
+  const listeners = (globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= []);
+  listeners.push(listener);
+  return () => {
+    const index = listeners.indexOf(listener);
+    if (index !== -1) {
+      listeners.splice(index, 1);
+    }
+  };
+};
+
+export const registerRootRscReloadListener = (
+  store: RootStore,
+  listener: () => void,
+  options?: { replace?: boolean },
+): Unregister => {
+  if (!options?.replace) {
+    return addRscReloadListener(listener);
+  }
+
+  const rootReload = rootReloads.get(store);
+  if (!rootReload) {
+    throw new Error('Missing Root component');
+  }
+  const registered = createRscReloadListener(listener);
+  rootReload.replacement = registered;
+  if (getDefaultRootStore() === store) {
+    setActiveRscReloadListener(registered);
+  }
+  return () => {
+    if (rootReload.replacement === registered) {
+      delete rootReload.replacement;
+    }
+    if (globalThis.__WAKU_REFETCH_RSC__ === registered) {
+      activateDefaultRscReloadListener();
+    }
+  };
+};
+
+export const registerRootReload = (
+  store: RootStore,
+  fallback: () => void,
+): Unregister => {
+  const rootReload: RootReload = {
+    fallback: createRscReloadListener(fallback),
+  };
+  rootReloads.set(store, rootReload);
+  activateDefaultRscReloadListener();
+  return () => {
+    rootReloads.delete(store);
+    activateDefaultRscReloadListener();
+  };
+};
+
+export const registerDefaultRscReloadListener: RegisterRscReloadListener = (
+  listener,
+  options,
+) => {
+  if (!import.meta.hot) {
+    return () => {};
+  }
+  if (!options?.replace) {
+    return addRscReloadListener(listener);
+  }
+  const store = getDefaultRootStore();
+  if (!store) {
+    throw new Error('Missing Root component');
+  }
+  return registerRootRscReloadListener(store, listener, options);
+};

--- a/packages/waku/src/minimal/client-utils/rsc-reload.ts
+++ b/packages/waku/src/minimal/client-utils/rsc-reload.ts
@@ -10,36 +10,39 @@ export type RegisterRscReloadListener = (
 ) => Unregister;
 
 type RootReload = {
-  fallback: () => void;
+  fallback?: () => void;
   replacement?: () => void;
+  mounted: boolean;
 };
 
 const rootReloads = new WeakMap<RootStore, RootReload>();
+let rootlessReplacement: (() => void) | undefined;
 
-const setActiveRscReloadListener = (listener: (() => void) | undefined) => {
+const replaceRscReloadListener = (
+  previous: (() => void) | undefined,
+  listener: (() => void) | undefined,
+) => {
   const listeners = (globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= []);
-  const active = globalThis.__WAKU_REFETCH_RSC__;
-  const activeIndex = active ? listeners.indexOf(active) : -1;
+  const index = previous ? listeners.indexOf(previous) : -1;
   if (listener) {
-    if (activeIndex === -1) {
+    if (index === -1) {
       listeners.push(listener);
     } else {
-      listeners.splice(activeIndex, 1, listener);
+      listeners.splice(index, 1, listener);
     }
-  } else if (activeIndex !== -1) {
-    listeners.splice(activeIndex, 1);
+  } else if (index !== -1) {
+    listeners.splice(index, 1);
   }
-  globalThis.__WAKU_REFETCH_RSC__ = listener;
 };
 
 const activateDefaultRscReloadListener = (): void => {
   const store = getDefaultRootStore();
   if (!store) {
-    setActiveRscReloadListener(undefined);
+    globalThis.__WAKU_REFETCH_RSC__ = rootlessReplacement;
     return;
   }
   const reload = rootReloads.get(store);
-  setActiveRscReloadListener(reload?.replacement ?? reload?.fallback);
+  globalThis.__WAKU_REFETCH_RSC__ = reload?.replacement ?? reload?.fallback;
 };
 
 const createRscReloadListener =
@@ -70,20 +73,25 @@ export const registerRootRscReloadListener = (
     return addRscReloadListener(listener);
   }
 
-  const rootReload = rootReloads.get(store);
-  if (!rootReload) {
-    throw new Error('Missing Root component');
-  }
+  const rootReload = rootReloads.get(store) ?? { mounted: false };
+  rootReloads.set(store, rootReload);
   const registered = createRscReloadListener(listener);
+  const previous = rootReload.replacement ?? rootReload.fallback;
   rootReload.replacement = registered;
+  replaceRscReloadListener(previous, registered);
   if (getDefaultRootStore() === store) {
-    setActiveRscReloadListener(registered);
+    globalThis.__WAKU_REFETCH_RSC__ = registered;
   }
   return () => {
     if (rootReload.replacement === registered) {
       delete rootReload.replacement;
-    }
-    if (globalThis.__WAKU_REFETCH_RSC__ === registered) {
+      replaceRscReloadListener(
+        registered,
+        rootReload.mounted ? rootReload.fallback : undefined,
+      );
+      if (!rootReload.mounted) {
+        rootReloads.delete(store);
+      }
       activateDefaultRscReloadListener();
     }
   };
@@ -93,13 +101,29 @@ export const registerRootReload = (
   store: RootStore,
   fallback: () => void,
 ): Unregister => {
-  const rootReload: RootReload = {
-    fallback: createRscReloadListener(fallback),
-  };
+  const rootReload = rootReloads.get(store) ?? { mounted: false };
+  const registered = createRscReloadListener(fallback);
+  rootReload.fallback = registered;
+  rootReload.mounted = true;
   rootReloads.set(store, rootReload);
+  if (rootlessReplacement) {
+    replaceRscReloadListener(rootlessReplacement, undefined);
+    rootlessReplacement = undefined;
+  }
+  const current = rootReload.replacement ?? registered;
+  const listeners = (globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= []);
+  if (!listeners.includes(current)) {
+    listeners.push(current);
+  }
   activateDefaultRscReloadListener();
   return () => {
-    rootReloads.delete(store);
+    const current = rootReload.replacement ?? rootReload.fallback;
+    replaceRscReloadListener(current, undefined);
+    rootReload.mounted = false;
+    delete rootReload.fallback;
+    if (!rootReload.replacement) {
+      rootReloads.delete(store);
+    }
     activateDefaultRscReloadListener();
   };
 };
@@ -117,9 +141,13 @@ export const registerDefaultRscReloadListener: RegisterRscReloadListener = (
   const store = getDefaultRootStore();
   if (!store) {
     const registered = createRscReloadListener(listener);
-    setActiveRscReloadListener(registered);
+    replaceRscReloadListener(rootlessReplacement, registered);
+    rootlessReplacement = registered;
+    globalThis.__WAKU_REFETCH_RSC__ = registered;
     return () => {
-      if (globalThis.__WAKU_REFETCH_RSC__ === registered) {
+      if (rootlessReplacement === registered) {
+        replaceRscReloadListener(registered, undefined);
+        rootlessReplacement = undefined;
         activateDefaultRscReloadListener();
       }
     };

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -43,7 +43,10 @@ import {
   getDefaultRootStore,
   registerRootStore,
 } from './client-utils/root-store.js';
-import type { RootStore } from './client-utils/root-store.js';
+import type {
+  CallServerElementsListener,
+  RootStore,
+} from './client-utils/root-store.js';
 import {
   registerDefaultRscReloadListener,
   registerRootReload,
@@ -419,10 +422,12 @@ export const unstable_callServerRsc = async (
         'Server action returned elements without a mounted Root component. Call mount-time actions from useEffect, not useLayoutEffect.',
       );
     }
-    const callServerElementsListeners =
-      fetchRscStore[CALL_SERVER_ELEMENTS_LISTENERS];
+    const globalListeners = fetchRscStore[CALL_SERVER_ELEMENTS_LISTENERS];
     startTransition(() => {
-      callServerElementsListeners?.forEach((listener) => {
+      globalListeners?.forEach((listener) => {
+        listener(data);
+      });
+      rootStore.listeners.forEach((listener) => {
         listener(data);
       });
       rootStore.setElements((prev) => mergeElementsPromise(prev, data));
@@ -434,11 +439,14 @@ export const unstable_callServerRsc = async (
 type Unregister = () => void;
 
 /**
- * Register a listener that runs when a server action returns new elements.
- * Returns a function that unregisters the listener.
+ * Registers a global listener that receives elements returned by server
+ * actions. Returns a function that unregisters the listener.
+ *
+ * @deprecated Use `useCallServerElementsListener_UNSTABLE` so the listener is
+ * bound to the enclosing Root.
  */
 export const unstable_registerCallServerElementsListener = (
-  listener: (elements: Elements) => void,
+  listener: CallServerElementsListener,
 ): Unregister => {
   const callServerElementsListeners = (fetchRscStore[
     CALL_SERVER_ELEMENTS_LISTENERS
@@ -546,6 +554,30 @@ const useRootStore = (): RootStore | null => {
   return store;
 };
 
+type RegisterCallServerElementsListener = (
+  listener: CallServerElementsListener,
+) => Unregister;
+
+/**
+ * Returns a Root-bound registrar for listeners that receive elements returned
+ * by server actions.
+ */
+export const useCallServerElementsListener_UNSTABLE = () => {
+  const store = useRootStore();
+  return useCallback<RegisterCallServerElementsListener>(
+    (listener) => {
+      if (store === null) {
+        return () => {};
+      }
+      store.listeners.add(listener);
+      return () => {
+        store.listeners.delete(listener);
+      };
+    },
+    [store],
+  );
+};
+
 const ElementsContext = createContext<Promise<Elements> | null>(null);
 
 /**
@@ -632,7 +664,11 @@ export const Root_UNSTABLE = ({
   );
   const [initialElements] = useState(() => getInitialRsc(...initialInput));
   const [elements, setElements] = useState(initialElements);
-  const [store] = useState(() => ({ setElements, etags: {} }));
+  const [store] = useState(() => ({
+    setElements,
+    etags: {},
+    listeners: new Set<CallServerElementsListener>(),
+  }));
   useLayoutEffect(() => {
     releaseInitialRscEntry(...initialInput, initialElements);
     const unregisterStore = registerRootStore(store);

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -8,7 +8,6 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useState,
 } from 'react';
 import type { ReactNode } from 'react';
@@ -438,12 +437,14 @@ export const unstable_callServerRsc = async (
 
 type Unregister = () => void;
 
+const noop = () => {};
+
 /**
  * Registers a global listener that receives elements returned by server
  * actions. Returns a function that unregisters the listener.
  *
- * @deprecated Use `useCallServerElementsListener_UNSTABLE` so the listener is
- * bound to the enclosing Root.
+ * @deprecated Use `useRegisterCallServerElementsListener_UNSTABLE` so the
+ * listener is bound to the enclosing Root.
  */
 export const unstable_registerCallServerElementsListener = (
   listener: CallServerElementsListener,
@@ -489,8 +490,8 @@ export function unstable_registerFetchRscInputTransformer(
 }
 
 /**
- * @deprecated Use `useRscReloadListener_UNSTABLE` so the listener is bound to
- * the enclosing Root.
+ * @deprecated Use `useRegisterRscReloadListener_UNSTABLE` so the listener is
+ * bound to the enclosing Root.
  */
 export const unstable_registerRscReloadListener =
   registerDefaultRscReloadListener;
@@ -562,12 +563,12 @@ type RegisterCallServerElementsListener = (
  * Returns a Root-bound registrar for listeners that receive elements returned
  * by server actions.
  */
-export const useCallServerElementsListener_UNSTABLE = () => {
+export const useRegisterCallServerElementsListener_UNSTABLE = () => {
   const store = useRootStore();
   return useCallback<RegisterCallServerElementsListener>(
     (listener) => {
       if (store === null) {
-        return () => {};
+        return noop;
       }
       store.listeners.add(listener);
       return () => {
@@ -629,19 +630,18 @@ export const useMergeElements_UNSTABLE = () => {
 };
 
 /**
- * Returns a Root-bound registrar for development RSC reload listeners, or
- * `undefined` outside development. Listeners coexist by default. With
+ * Returns a Root-bound registrar for development RSC reload listeners. The
+ * registrar is a no-op in production. Listeners coexist by default. With
  * `replace`, the listener owns the Root's active refetch target until it is
  * replaced or unregistered.
  */
-export const useRscReloadListener_UNSTABLE = () => {
+export const useRegisterRscReloadListener_UNSTABLE = () => {
   const store = useRootStore();
-  return useMemo<RegisterRscReloadListener | undefined>(
-    () =>
+  return useCallback<RegisterRscReloadListener>(
+    (listener, options) =>
       import.meta.hot && store !== null
-        ? (listener, options) =>
-            registerRootRscReloadListener(store, listener, options)
-        : undefined,
+        ? registerRootRscReloadListener(store, listener, options)
+        : noop,
     [store],
   );
 };

--- a/packages/waku/src/minimal/client.tsx
+++ b/packages/waku/src/minimal/client.tsx
@@ -7,6 +7,8 @@ import {
   use,
   useCallback,
   useEffect,
+  useLayoutEffect,
+  useMemo,
   useState,
 } from 'react';
 import type { ReactNode } from 'react';
@@ -24,19 +26,30 @@ import { consumeInitialRscEntry } from '../lib/utils/initial-rsc.js';
 import { setupDebugChannel } from '../lib/utils/react-debug-channel.js';
 import { encodeFuncId, encodeRscPath } from '../lib/utils/rsc-path.js';
 import {
-  CACHED_ETAGS,
   CALL_SERVER_ELEMENTS_LISTENERS,
-  ENTRY,
   FETCH_ENHANCERS,
   FETCH_RSC_INPUT_TRANSFORMERS,
-  SET_ELEMENTS,
   fetchRscStore,
 } from './client-utils/fetch-store.js';
 import type {
   FetchEnhancer,
   FetchRscInputTransformer,
-  SetElements,
 } from './client-utils/fetch-store.js';
+import {
+  getInitialRscEntry,
+  releaseInitialRscEntry,
+} from './client-utils/initial-rsc-store.js';
+import {
+  getDefaultRootStore,
+  registerRootStore,
+} from './client-utils/root-store.js';
+import type { RootStore } from './client-utils/root-store.js';
+import {
+  registerDefaultRscReloadListener,
+  registerRootReload,
+  registerRootRscReloadListener,
+} from './client-utils/rsc-reload.js';
+import type { RegisterRscReloadListener } from './client-utils/rsc-reload.js';
 
 const { createFromFetch, encodeReply, createTemporaryReferenceSet } =
   RSDWClient;
@@ -89,8 +102,8 @@ const collectCachedEtags = (elements: Elements): Etags => {
   return etags;
 };
 
-const updateCachedEtags = (elements: Elements): void => {
-  fetchRscStore[CACHED_ETAGS] = collectCachedEtags(elements);
+const updateCachedEtags = (store: RootStore, elements: Elements): void => {
+  store.etags = collectCachedEtags(elements);
 };
 
 export const unstable_isImmutableElement = (
@@ -269,28 +282,18 @@ const getFetchFn = (): typeof fetch => {
   return fetchFn;
 };
 
-const getSetElements = (): SetElements => {
-  const setElements = fetchRscStore[SET_ELEMENTS];
-  if (!setElements) {
-    throw new Error('Missing Root component');
-  }
-  return setElements;
-};
-
 const requestRsc = (
   fetchFn: typeof fetch,
   rscPath: string,
   rscParams: unknown,
   temporaryReferences: ReturnType<typeof createTemporaryReferenceSet>,
   signal: AbortSignal | undefined,
-  etagsOverride?: Etags,
+  etags?: Etags,
 ): Promise<Response> => {
   const url = BASE_RSC_PATH + encodeRscPath(rscPath);
   const init: RequestInit = {
     headers: {
-      [ETAGS_HEADER]: serializeClientEtags(
-        etagsOverride ?? fetchRscStore[CACHED_ETAGS] ?? {},
-      ),
+      [ETAGS_HEADER]: serializeClientEtags(etags ?? {}),
     },
   };
   if (signal) {
@@ -401,19 +404,28 @@ export const unstable_callServerRsc = async (
   funcId: string,
   args: unknown[],
 ) => {
+  const rootStore = getDefaultRootStore();
   const rscPath = encodeFuncId(funcId);
   const rscParams =
     args.length === 1 && args[0] instanceof URLSearchParams ? args[0] : args;
-  const { _value: value, ...data } = await fetchRscElements(rscPath, rscParams);
+  const { _value: value, ...data } = await fetchRscElements(
+    rscPath,
+    rscParams,
+    { etags: rootStore?.etags ?? {} },
+  );
   if (Object.keys(data).length) {
-    const setElements = getSetElements();
+    if (!rootStore) {
+      throw new Error(
+        'Server action returned elements without a mounted Root component. Call mount-time actions from useEffect, not useLayoutEffect.',
+      );
+    }
     const callServerElementsListeners =
       fetchRscStore[CALL_SERVER_ELEMENTS_LISTENERS];
     startTransition(() => {
       callServerElementsListeners?.forEach((listener) => {
         listener(data);
       });
-      setElements((prev) => mergeElementsPromise(prev, data));
+      rootStore.setElements((prev) => mergeElementsPromise(prev, data));
     });
   }
   return value;
@@ -469,48 +481,11 @@ export function unstable_registerFetchRscInputTransformer(
 }
 
 /**
- * Registers an RSC reload listener used by development HMR. Listeners coexist
- * by default. With `replace`, it replaces the previous replaceable listener
- * and invalidates Minimal's RSC caches before calling it. Returns a function
- * that unregisters this listener.
+ * @deprecated Use `useRscReloadListener_UNSTABLE` so the listener is bound to
+ * the enclosing Root.
  */
-export const unstable_registerRscReloadListener = (
-  listener: () => void,
-  options?: { replace?: boolean },
-): Unregister => {
-  if (!import.meta.hot) {
-    return () => {};
-  }
-  const listeners = (globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= []);
-  const registered = options?.replace
-    ? () => {
-        fetchRscStore[CACHED_ETAGS] = {};
-        delete fetchRscStore[ENTRY];
-        listener();
-      }
-    : listener;
-  const previous = options?.replace
-    ? globalThis.__WAKU_REFETCH_RSC__
-    : undefined;
-  const previousIndex = previous ? listeners.indexOf(previous) : -1;
-  if (previousIndex === -1) {
-    listeners.push(registered);
-  } else {
-    listeners.splice(previousIndex, 1, registered);
-  }
-  if (options?.replace) {
-    globalThis.__WAKU_REFETCH_RSC__ = registered;
-  }
-  return () => {
-    const index = listeners.indexOf(registered);
-    if (index !== -1) {
-      listeners.splice(index, 1);
-    }
-    if (globalThis.__WAKU_REFETCH_RSC__ === registered) {
-      globalThis.__WAKU_REFETCH_RSC__ = undefined;
-    }
-  };
-};
+export const unstable_registerRscReloadListener =
+  registerDefaultRscReloadListener;
 
 const fetchRootRsc = (
   rscPath: string,
@@ -551,34 +526,93 @@ export const unstable_fetchRsc = (
 const getInitialRsc = (
   rscPath: string,
   rscParams: unknown,
-): Promise<Elements> => {
-  if (import.meta.hot) {
-    unstable_registerRscReloadListener(
-      () => {
-        const data = fetchRootRsc(rscPath, rscParams);
-        const setElements = getSetElements();
-        setElements((prev) => refreshElementsPromise(prev, data));
-      },
-      { replace: true },
-    );
-  }
-  const entry = fetchRscStore[ENTRY];
-  if (entry && entry[0] === rscPath && entry[1] === rscParams) {
-    return entry[2];
-  }
-  const data = fetchRootRsc(rscPath, rscParams);
-  fetchRscStore[ENTRY] = [rscPath, rscParams, data];
-  return data;
-};
+): Promise<Elements> =>
+  getInitialRscEntry(rscPath, rscParams, () =>
+    fetchRootRsc(rscPath, rscParams),
+  );
 
 type MergeElements = (
   elements: Elements | Promise<Elements>,
   options?: MergeElementsOptions,
 ) => Promise<Elements>;
-const MergeElementsContext = createContext<MergeElements>(() => {
-  throw new Error('Missing Root component');
-});
+
+const RootStoreContext = createContext<RootStore | null | undefined>(undefined);
+
+const useRootStore = (): RootStore | null => {
+  const store = use(RootStoreContext);
+  if (store === undefined) {
+    throw new Error('Missing Root component');
+  }
+  return store;
+};
+
 const ElementsContext = createContext<Promise<Elements> | null>(null);
+
+/**
+ * Returns a function that merges an element record or pending RSC payload into
+ * the current `Root_UNSTABLE`. A rejected payload leaves the current elements
+ * unchanged.
+ */
+export const useMergeElements_UNSTABLE = () => {
+  const store = useRootStore();
+  return useCallback<MergeElements>(
+    (data, options) => {
+      if (store === null) {
+        return Promise.resolve({});
+      }
+      const { unstable_overlay: overlay, unstable_swr: swr } = options ?? {};
+      const elements = Promise.resolve(data);
+      const elementsWithoutErrors = elements.catch(() => ({}));
+      if (swr) {
+        store.setElements((prev) =>
+          swrElementsPromise(
+            prev,
+            elementsWithoutErrors,
+            swr.pin,
+            swr.base,
+            overlay,
+          ),
+        );
+        return elements.then((resolved) => {
+          store.setElements((prev) =>
+            swrNewKeysElementsPromise(
+              prev,
+              elementsWithoutErrors,
+              resolved,
+              overlay,
+            ),
+          );
+          return resolved;
+        });
+      }
+      // the overlay lands only when the fetch succeeds
+      const elementsToMerge = overlay
+        ? mergeElementsPromise(elements, overlay).catch(() => ({}))
+        : elementsWithoutErrors;
+      store.setElements((prev) => mergeElementsPromise(prev, elementsToMerge));
+      return elements;
+    },
+    [store],
+  );
+};
+
+/**
+ * Returns a Root-bound registrar for development RSC reload listeners, or
+ * `undefined` outside development. Listeners coexist by default. With
+ * `replace`, the listener owns the Root's active refetch target until it is
+ * replaced or unregistered.
+ */
+export const useRscReloadListener_UNSTABLE = () => {
+  const store = useRootStore();
+  return useMemo<RegisterRscReloadListener | undefined>(
+    () =>
+      import.meta.hot && store !== null
+        ? (listener, options) =>
+            registerRootRscReloadListener(store, listener, options)
+        : undefined,
+    [store],
+  );
+};
 
 /**
  * Client root. Seeds the initial elements, bridges the store to React state,
@@ -593,64 +627,41 @@ export const Root_UNSTABLE = ({
   initialRscParams?: unknown;
   children: ReactNode;
 }) => {
-  const [elements, setElements] = useState(() =>
-    getInitialRsc(initialRscPath || '', initialRscParams),
+  const [initialInput] = useState(
+    () => [initialRscPath || '', initialRscParams] as const,
   );
+  const [initialElements] = useState(() => getInitialRsc(...initialInput));
+  const [elements, setElements] = useState(initialElements);
+  const [store] = useState(() => ({ setElements, etags: {} }));
+  useLayoutEffect(() => {
+    releaseInitialRscEntry(...initialInput, initialElements);
+    const unregisterStore = registerRootStore(store);
+    const unregisterReload = import.meta.hot
+      ? registerRootReload(store, () => {
+          const data = fetchRootRsc(...initialInput);
+          setElements((prev) => refreshElementsPromise(prev, data));
+        })
+      : undefined;
+    return () => {
+      unregisterStore();
+      unregisterReload?.();
+    };
+  }, [initialElements, initialInput, store]);
   useEffect(() => {
-    fetchRscStore[SET_ELEMENTS] = setElements;
-  }, []);
-  useEffect(() => {
-    elements.then(updateCachedEtags, () => {});
-  }, [elements]);
-  const mergeElements = useCallback<MergeElements>((data, options) => {
-    const { unstable_overlay: overlay, unstable_swr: swr } = options ?? {};
-    const elements = Promise.resolve(data);
-    const elementsWithoutErrors = elements.catch(() => ({}));
-    if (swr) {
-      setElements((prev) =>
-        swrElementsPromise(
-          prev,
-          elementsWithoutErrors,
-          swr.pin,
-          swr.base,
-          overlay,
-        ),
-      );
-      return elements.then((resolved) => {
-        setElements((prev) =>
-          swrNewKeysElementsPromise(
-            prev,
-            elementsWithoutErrors,
-            resolved,
-            overlay,
-          ),
-        );
-        return resolved;
-      });
-    }
-    // the overlay lands only when the fetch succeeds
-    const elementsToMerge = overlay
-      ? mergeElementsPromise(elements, overlay).catch(() => ({}))
-      : elementsWithoutErrors;
-    setElements((prev) => mergeElementsPromise(prev, elementsToMerge));
-    return elements;
-  }, []);
+    elements.then(
+      (resolved) => updateCachedEtags(store, resolved),
+      () => {},
+    );
+  }, [elements, store]);
   return (
-    <MergeElementsContext value={mergeElements}>
+    <RootStoreContext value={store}>
       <ElementsContext value={elements}>
         {DEFAULT_HTML_HEAD}
         {children}
       </ElementsContext>
-    </MergeElementsContext>
+    </RootStoreContext>
   );
 };
-
-/**
- * Returns a function that merges an element record or pending RSC payload into
- * the current `Root_UNSTABLE`. A rejected payload leaves the current elements
- * unchanged.
- */
-export const useMergeElements_UNSTABLE = () => use(MergeElementsContext);
 
 const ChildrenContext = createContext<ReactNode>(undefined);
 const ChildrenContextProvider = memo(ChildrenContext);
@@ -711,12 +722,12 @@ export const INTERNAL_ServerRoot = ({
   elementsPromise: Promise<Elements>;
   children: ReactNode;
 }) => (
-  <MergeElementsContext value={async () => ({})}>
+  <RootStoreContext value={null}>
     <ElementsContext value={elementsPromise}>
       {DEFAULT_HTML_HEAD}
       {children}
     </ElementsContext>
-  </MergeElementsContext>
+  </RootStoreContext>
 );
 
 // Expose internal APIs

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -33,8 +33,8 @@ import {
   unstable_fetchRsc as fetchRsc,
   unstable_getErrorInfo as getErrorInfo,
   unstable_isImmutableElement as isImmutableElement,
-  unstable_registerCallServerElementsListener as registerCallServerElementsListener,
   unstable_removeBase as removeBase,
+  useCallServerElementsListener_UNSTABLE as useCallServerElementsListener,
   useElementsPromise_UNSTABLE as useElementsPromise,
   useMergeElements_UNSTABLE as useMergeElements,
   useRscReloadListener_UNSTABLE as useRscReloadListener,
@@ -1644,6 +1644,7 @@ const InnerRouter = ({
     },
     [changeRoute, routeFallback],
   );
+  const registerCallServerElementsListener = useCallServerElementsListener();
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
       addToStaticPathSet(elements);
@@ -1655,7 +1656,11 @@ const InnerRouter = ({
       });
     };
     return registerCallServerElementsListener(listener);
-  }, [changeRouteFromServer, addToStaticPathSet]);
+  }, [
+    changeRouteFromServer,
+    addToStaticPathSet,
+    registerCallServerElementsListener,
+  ]);
 
   const prefetchRoute: PrefetchRoute = useCallback((route, options) => {
     preloadRouteModules(route.path);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -34,10 +34,10 @@ import {
   unstable_getErrorInfo as getErrorInfo,
   unstable_isImmutableElement as isImmutableElement,
   unstable_removeBase as removeBase,
-  useCallServerElementsListener_UNSTABLE as useCallServerElementsListener,
   useElementsPromise_UNSTABLE as useElementsPromise,
   useMergeElements_UNSTABLE as useMergeElements,
-  useRscReloadListener_UNSTABLE as useRscReloadListener,
+  useRegisterCallServerElementsListener_UNSTABLE as useRegisterCallServerElementsListener,
+  useRegisterRscReloadListener_UNSTABLE as useRegisterRscReloadListener,
 } from '../minimal/client.js';
 import { decideFollow, isFollowable } from './client-utils/error-route.js';
 import {
@@ -1167,7 +1167,7 @@ const InnerRouter = ({
 
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
-  const registerRscReloadListener = useRscReloadListener();
+  const registerRscReloadListener = useRegisterRscReloadListener();
   const [fetchingSlices] = useState(
     () => new Map<SliceId, Promise<Elements>>(),
   );
@@ -1188,7 +1188,7 @@ const InnerRouter = ({
   useEffect(() => {
     if (import.meta.hot) {
       // The listener below owns the current route, not Root's initial path.
-      registerRscReloadListener?.(() => {}, { replace: true });
+      registerRscReloadListener(() => {}, { replace: true });
     }
   }, [registerRscReloadListener]);
 
@@ -1267,7 +1267,7 @@ const InnerRouter = ({
           });
         });
       };
-      return registerRscReloadListener?.(refetchRouteOnHmr);
+      return registerRscReloadListener(refetchRouteOnHmr);
     }
   }, [
     refetch,
@@ -1323,7 +1323,7 @@ const InnerRouter = ({
       setNavigationError(undefined);
       if (import.meta.hot) {
         // A route navigation retires the previous Minimal refetch target.
-        registerRscReloadListener?.(() => {}, { replace: true });
+        registerRscReloadListener(() => {}, { replace: true });
       }
       const routeUrl = options.url ?? getRouteUrl(nextRoute);
       const initialAttempt: NavigationAttempt = {
@@ -1644,7 +1644,8 @@ const InnerRouter = ({
     },
     [changeRoute, routeFallback],
   );
-  const registerCallServerElementsListener = useCallServerElementsListener();
+  const registerCallServerElementsListener =
+    useRegisterCallServerElementsListener();
   useEffect(() => {
     const listener = (elements: Record<string, unknown>) => {
       addToStaticPathSet(elements);

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -34,10 +34,10 @@ import {
   unstable_getErrorInfo as getErrorInfo,
   unstable_isImmutableElement as isImmutableElement,
   unstable_registerCallServerElementsListener as registerCallServerElementsListener,
-  unstable_registerRscReloadListener as registerRscReloadListener,
   unstable_removeBase as removeBase,
   useElementsPromise_UNSTABLE as useElementsPromise,
   useMergeElements_UNSTABLE as useMergeElements,
+  useRscReloadListener_UNSTABLE as useRscReloadListener,
 } from '../minimal/client.js';
 import { decideFollow, isFollowable } from './client-utils/error-route.js';
 import {
@@ -1167,6 +1167,7 @@ const InnerRouter = ({
 
   const refetch = useRefetch();
   const mergeElements = useMergeElements();
+  const registerRscReloadListener = useRscReloadListener();
   const [fetchingSlices] = useState(
     () => new Map<SliceId, Promise<Elements>>(),
   );
@@ -1187,9 +1188,9 @@ const InnerRouter = ({
   useEffect(() => {
     if (import.meta.hot) {
       // The listener below owns the current route, not Root's initial path.
-      registerRscReloadListener(() => {}, { replace: true });
+      registerRscReloadListener?.(() => {}, { replace: true });
     }
-  }, []);
+  }, [registerRscReloadListener]);
 
   const routeFallback = useMemo(
     () => ({ ...initialRoute, hash: restoredHash }),
@@ -1266,7 +1267,7 @@ const InnerRouter = ({
           });
         });
       };
-      return registerRscReloadListener(refetchRouteOnHmr);
+      return registerRscReloadListener?.(refetchRouteOnHmr);
     }
   }, [
     refetch,
@@ -1276,6 +1277,7 @@ const InnerRouter = ({
     lazySliceIds,
     fetchingSlices,
     mergeElements,
+    registerRscReloadListener,
   ]);
 
   const changeRoute: ChangeRoute = useCallback(
@@ -1321,7 +1323,7 @@ const InnerRouter = ({
       setNavigationError(undefined);
       if (import.meta.hot) {
         // A route navigation retires the previous Minimal refetch target.
-        registerRscReloadListener(() => {}, { replace: true });
+        registerRscReloadListener?.(() => {}, { replace: true });
       }
       const routeUrl = options.url ?? getRouteUrl(nextRoute);
       const initialAttempt: NavigationAttempt = {
@@ -1610,6 +1612,7 @@ const InnerRouter = ({
       addToStaticPathSet,
       cancelPendingNavigation,
       has404,
+      registerRscReloadListener,
     ],
   );
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -17,6 +17,14 @@ import { getErrorInfo } from '../src/lib/utils/custom-errors.js';
 import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import { fetchRscStore } from '../src/minimal/client-utils/fetch-store.js';
 import {
+  clearInitialRscEntries,
+  getInitialRscEntry,
+} from '../src/minimal/client-utils/initial-rsc-store.js';
+import {
+  clearRootCachedEtags,
+  registerRootStore,
+} from '../src/minimal/client-utils/root-store.js';
+import {
   Root_UNSTABLE as Root,
   Slot_UNSTABLE as Slot,
   unstable_callServerRsc,
@@ -110,6 +118,7 @@ afterEach(() => {
   for (const key of Object.keys(clientStore)) {
     delete clientStore[key];
   }
+  clearInitialRscEntries();
   delete (globalThis as any).__WAKU_PREFETCHED__;
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
@@ -144,7 +153,7 @@ describe('minimal/client fetch', () => {
     expect(mocks.createFromFetch).toHaveBeenCalledTimes(2);
   });
 
-  test('Root caches its initial fetch', async () => {
+  test('Root releases its initial fetch after committing', async () => {
     mocks.createFromFetch.mockReturnValue(
       resolvedThenable({ _value: null, App: 'app' }),
     );
@@ -171,8 +180,21 @@ describe('minimal/client fetch', () => {
     act(() => firstRoot.unmount());
 
     const secondRoot = await render();
-    expect(mocks.createFromFetch).toHaveBeenCalledTimes(1);
+    expect(mocks.createFromFetch).toHaveBeenCalledTimes(2);
     act(() => secondRoot.unmount());
+  });
+
+  test('bounds uncommitted initial fetches', () => {
+    const first = getInitialRscEntry('0', undefined, () => Promise.resolve({}));
+    for (let index = 1; index <= 32; index += 1) {
+      void getInitialRscEntry(String(index), undefined, () =>
+        Promise.resolve({}),
+      );
+    }
+    const create = vi.fn(() => Promise.resolve({}));
+
+    expect(getInitialRscEntry('0', undefined, create)).not.toBe(first);
+    expect(create).toHaveBeenCalledOnce();
   });
 
   test('server actions use the current fetch, not the one elements decoded with', async () => {
@@ -362,13 +384,90 @@ describe('minimal/client server actions', () => {
 
   test('a server action returning elements throws when no Root is mounted', async () => {
     // The merge must fail loudly (not silently drop) when there is no
-    // `SET_ELEMENTS` bridge, so timing/wiring bugs surface.
+    // default Root bridge, so timing/wiring bugs surface.
     mocks.createFromFetch.mockResolvedValueOnce({ _value: 'v', foo: 'FOO' });
     stubFetch();
 
     await expect(unstable_callServerRsc('actions#do', [])).rejects.toThrow(
-      'Missing Root',
+      'Server action returned elements without a mounted Root component',
     );
+  });
+
+  test('an action response targets the Root active when it started', async () => {
+    let resolveAction: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveAction = resolve;
+      }),
+    );
+    stubFetch();
+    const firstSetElements = vi.fn();
+    const secondSetElements = vi.fn();
+    const unregisterFirst = registerRootStore({
+      setElements: firstSetElements,
+      etags: { App: 'first' },
+    });
+
+    const action = unstable_callServerRsc('actions#do', []);
+    const unregisterSecond = registerRootStore({
+      setElements: secondSetElements,
+      etags: { App: 'second' },
+    });
+    resolveAction({ _value: 'result', App: 'updated' });
+
+    try {
+      await expect(action).resolves.toBe('result');
+      expect(firstSetElements).toHaveBeenCalledOnce();
+      expect(secondSetElements).not.toHaveBeenCalled();
+    } finally {
+      unregisterSecond();
+      unregisterFirst();
+    }
+  });
+
+  test('HMR clears cached etags from every mounted Root', () => {
+    const first = { setElements: vi.fn(), etags: { App: 'first' } };
+    const second = { setElements: vi.fn(), etags: { App: 'second' } };
+    const unregisterFirst = registerRootStore(first);
+    const unregisterSecond = registerRootStore(second);
+
+    try {
+      clearRootCachedEtags();
+      expect(first.etags).toEqual({});
+      expect(second.etags).toEqual({});
+    } finally {
+      unregisterSecond();
+      unregisterFirst();
+    }
+  });
+
+  test('a descendant mount effect can call a server action', async () => {
+    mocks.createFromFetch
+      .mockResolvedValueOnce({ _value: null })
+      .mockResolvedValueOnce({ _value: 'result', App: 'updated' });
+    stubFetch();
+    let action: Promise<unknown> | undefined;
+    const ActionOnMount = () => {
+      useEffect(() => {
+        action = unstable_callServerRsc('actions#do', []);
+        void action.catch(() => {});
+      }, []);
+      return null;
+    };
+    const root = createRoot(document.createElement('div'));
+
+    try {
+      await act(async () => {
+        root.render(
+          <Root>
+            <ActionOnMount />
+          </Root>,
+        );
+      });
+      await expect(action).resolves.toBe('result');
+    } finally {
+      act(() => root.unmount());
+    }
   });
 });
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -24,6 +24,7 @@ import {
   clearRootCachedEtags,
   registerRootStore,
 } from '../src/minimal/client-utils/root-store.js';
+import type { CallServerElementsListener } from '../src/minimal/client-utils/root-store.js';
 import {
   Root_UNSTABLE as Root,
   Slot_UNSTABLE as Slot,
@@ -32,6 +33,7 @@ import {
   unstable_registerCallServerElementsListener,
   unstable_registerFetchEnhancer,
   unstable_registerFetchRscInputTransformer,
+  useCallServerElementsListener_UNSTABLE,
   useElementsPromise_UNSTABLE,
   useMergeElements_UNSTABLE,
 } from '../src/minimal/client.js';
@@ -336,13 +338,20 @@ describe('minimal/client server actions', () => {
     mocks.createFromFetch.mockReturnValueOnce(resolvedThenable({ App: 'A' }));
     stubFetch();
     const listener = vi.fn();
+    const rootListener = vi.fn();
     track(unstable_registerCallServerElementsListener(listener));
+    const Listener = () => {
+      const register = useCallServerElementsListener_UNSTABLE();
+      useEffect(() => register(rootListener), [register]);
+      return null;
+    };
 
     const container = document.createElement('div');
     const root = createRoot(container);
     await act(async () => {
       root.render(
         <Root initialRscPath="R/app.txt">
+          <Listener />
           <Suspense fallback={null}>
             <Slot id="App" />
           </Suspense>
@@ -361,6 +370,7 @@ describe('minimal/client server actions', () => {
     expect(value).toBe('result');
     expect(container.textContent).toBe('B');
     expect(listener).toHaveBeenCalledWith({ App: 'B' });
+    expect(rootListener).toHaveBeenCalledWith({ App: 'B' });
 
     act(() => root.unmount());
   });
@@ -393,7 +403,45 @@ describe('minimal/client server actions', () => {
     );
   });
 
-  test('an action response stays with its request-time Root', async () => {
+  test('an action response and listeners target its request-time Root', async () => {
+    let resolveAction: (value: Record<string, unknown>) => void = () => {};
+    mocks.createFromFetch.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveAction = resolve;
+      }),
+    );
+    stubFetch();
+    const firstSetElements = vi.fn();
+    const secondSetElements = vi.fn();
+    const firstListener = vi.fn();
+    const secondListener = vi.fn();
+    const unregisterFirst = registerRootStore({
+      setElements: firstSetElements,
+      etags: { App: 'first' },
+      listeners: new Set([firstListener]),
+    });
+
+    const action = unstable_callServerRsc('actions#do', []);
+    const unregisterSecond = registerRootStore({
+      setElements: secondSetElements,
+      etags: { App: 'second' },
+      listeners: new Set([secondListener]),
+    });
+    resolveAction({ _value: 'result', App: 'updated' });
+
+    try {
+      await expect(action).resolves.toBe('result');
+      expect(firstSetElements).toHaveBeenCalledOnce();
+      expect(secondSetElements).not.toHaveBeenCalled();
+      expect(firstListener).toHaveBeenCalledOnce();
+      expect(secondListener).not.toHaveBeenCalled();
+    } finally {
+      unregisterSecond();
+      unregisterFirst();
+    }
+  });
+
+  test('an action response is not retargeted after its Root unmounts', async () => {
     let resolveAction: (value: Record<string, unknown>) => void = () => {};
     mocks.createFromFetch.mockReturnValueOnce(
       new Promise((resolve) => {
@@ -406,6 +454,7 @@ describe('minimal/client server actions', () => {
     const unregisterFirst = registerRootStore({
       setElements: firstSetElements,
       etags: { App: 'first' },
+      listeners: new Set(),
     });
 
     const action = unstable_callServerRsc('actions#do', []);
@@ -413,6 +462,7 @@ describe('minimal/client server actions', () => {
     const unregisterSecond = registerRootStore({
       setElements: secondSetElements,
       etags: { App: 'second' },
+      listeners: new Set(),
     });
     resolveAction({ _value: 'result', App: 'updated' });
 
@@ -426,8 +476,16 @@ describe('minimal/client server actions', () => {
   });
 
   test('HMR clears cached etags from every mounted Root', () => {
-    const first = { setElements: vi.fn(), etags: { App: 'first' } };
-    const second = { setElements: vi.fn(), etags: { App: 'second' } };
+    const first = {
+      setElements: vi.fn(),
+      etags: { App: 'first' },
+      listeners: new Set<CallServerElementsListener>(),
+    };
+    const second = {
+      setElements: vi.fn(),
+      etags: { App: 'second' },
+      listeners: new Set<CallServerElementsListener>(),
+    };
     const unregisterFirst = registerRootStore(first);
     const unregisterSecond = registerRootStore(second);
 

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -33,9 +33,9 @@ import {
   unstable_registerCallServerElementsListener,
   unstable_registerFetchEnhancer,
   unstable_registerFetchRscInputTransformer,
-  useCallServerElementsListener_UNSTABLE,
   useElementsPromise_UNSTABLE,
   useMergeElements_UNSTABLE,
+  useRegisterCallServerElementsListener_UNSTABLE,
 } from '../src/minimal/client.js';
 
 type CallServer = (funcId: string, args: unknown[]) => Promise<unknown>;
@@ -341,7 +341,7 @@ describe('minimal/client server actions', () => {
     const rootListener = vi.fn();
     track(unstable_registerCallServerElementsListener(listener));
     const Listener = () => {
-      const register = useCallServerElementsListener_UNSTABLE();
+      const register = useRegisterCallServerElementsListener_UNSTABLE();
       useEffect(() => register(rootListener), [register]);
       return null;
     };

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -393,7 +393,7 @@ describe('minimal/client server actions', () => {
     );
   });
 
-  test('an action response targets the Root active when it started', async () => {
+  test('an action response stays with its request-time Root', async () => {
     let resolveAction: (value: Record<string, unknown>) => void = () => {};
     mocks.createFromFetch.mockReturnValueOnce(
       new Promise((resolve) => {
@@ -409,6 +409,7 @@ describe('minimal/client server actions', () => {
     });
 
     const action = unstable_callServerRsc('actions#do', []);
+    unregisterFirst();
     const unregisterSecond = registerRootStore({
       setElements: secondSetElements,
       etags: { App: 'second' },
@@ -421,7 +422,6 @@ describe('minimal/client server actions', () => {
       expect(secondSetElements).not.toHaveBeenCalled();
     } finally {
       unregisterSecond();
-      unregisterFirst();
     }
   });
 

--- a/packages/waku/tests/minimal-etags.test.tsx
+++ b/packages/waku/tests/minimal-etags.test.tsx
@@ -13,12 +13,11 @@ import {
   isValidEtag,
 } from '../src/lib/utils/etags.js';
 import {
-  CACHED_ETAGS,
-  ENTRY,
   FETCH_ENHANCERS,
-  SET_ELEMENTS,
   fetchRscStore,
 } from '../src/minimal/client-utils/fetch-store.js';
+import { clearInitialRscEntries } from '../src/minimal/client-utils/initial-rsc-store.js';
+import { getDefaultRootStore } from '../src/minimal/client-utils/root-store.js';
 import {
   Root_UNSTABLE as Root,
   unstable_fetchRsc as fetchRsc,
@@ -86,10 +85,8 @@ beforeEach(() => {
   vi.spyOn(globalThis, 'fetch').mockResolvedValue(
     new Response(null, { status: 200 }),
   );
-  delete fetchRscStore[ENTRY];
-  delete fetchRscStore[SET_ELEMENTS];
+  clearInitialRscEntries();
   delete fetchRscStore[FETCH_ENHANCERS];
-  delete fetchRscStore[CACHED_ETAGS];
 });
 
 afterEach(() => {
@@ -117,7 +114,7 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     );
     await flush();
 
-    const cached = fetchRscStore[CACHED_ETAGS] ?? {};
+    const cached = getDefaultRootStore()?.etags ?? {};
     expect(cached.page).toBe('etag-foo');
     expect(cached.bar).toBe('etag-bar');
     expect(cached.static).toBe(1);
@@ -171,7 +168,7 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
 
     // the _etag: key follows its slot's swr-ness through the eager merge, so a
     // pinned static slot's etag stays a concrete value and survives in the cache
-    expect(fetchRscStore[CACHED_ETAGS]?.page).toBe(IMMUTABLE_ETAG);
+    expect(getDefaultRootStore()?.etags.page).toBe(IMMUTABLE_ETAG);
 
     view.unmount();
   });
@@ -227,7 +224,6 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
   });
 
   it('a prefetch without a base claims nothing', async () => {
-    fetchRscStore[CACHED_ETAGS] = { widget: 'etag-live' };
     testHoisted.elements = { page: <div>b</div> };
     await fetchRsc('R/bar');
 
@@ -239,7 +235,6 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
   });
 
   it('a prefetch claims the etags of its base and returns the merge', async () => {
-    fetchRscStore[CACHED_ETAGS] = { widget: 'etag-live', page: 'etag-page' };
     testHoisted.elements = {
       page: <div>b</div>,
       [`${ETAG_ID_PREFIX}page`]: 'etag-page-2',
@@ -303,8 +298,8 @@ describe('minimal per-slot cache-validator (carry + replay)', () => {
     });
     await flush();
 
-    expect(fetchRscStore[CACHED_ETAGS]?.widget).toBe('etag-widget');
-    expect(fetchRscStore[CACHED_ETAGS]?.page).toBe(IMMUTABLE_ETAG);
+    expect(getDefaultRootStore()?.etags.widget).toBe('etag-widget');
+    expect(getDefaultRootStore()?.etags.page).toBe(IMMUTABLE_ETAG);
 
     view.unmount();
   });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -101,6 +101,7 @@ const testHoisted = vi.hoisted(() => ({
     | undefined
   >,
   onMerge: null as (() => void) | null,
+  legacyActionListenerRegistrations: 0,
 }));
 
 const createDeferred = <T,>() => {
@@ -438,6 +439,16 @@ vi.mock('../src/minimal/client.js', async () => {
     ),
     useMergeElements_UNSTABLE: () =>
       useMockMergeElements() ?? noopMergeElements,
+    useCallServerElementsListener_UNSTABLE: () =>
+      actual.unstable_registerCallServerElementsListener,
+    unstable_registerCallServerElementsListener: (
+      ...args: Parameters<
+        typeof actual.unstable_registerCallServerElementsListener
+      >
+    ) => {
+      testHoisted.legacyActionListenerRegistrations += 1;
+      return actual.unstable_registerCallServerElementsListener(...args);
+    },
     unstable_fetchRsc: vi.fn(
       (
         rscPath: string,
@@ -570,6 +581,7 @@ beforeEach(() => {
   testHoisted.mergeTypes.length = 0;
   testHoisted.mergeOptions.length = 0;
   testHoisted.onMerge = null;
+  testHoisted.legacyActionListenerRegistrations = 0;
   // Fresh shared request mock per test. The mocked fetch wraps it, so its
   // implementation must stay intact (do not mockReset it).
   testHoisted.inner = vi.fn(async () => ({}));
@@ -1777,10 +1789,7 @@ describe('Router integration', () => {
   });
 
   test('registers its callServer listener once, and removes it on unmount (StrictMode)', async () => {
-    // The store is a module-level singleton; 'l' is CALL_SERVER_ELEMENTS_LISTENERS.
-    // NOTE: the etags-header *fetch enhancer* ('f') is no longer owned by the
-    // router; it moved into the minimal layer (covered by the minimal
-    // carry/replay test). The router keeps only the callServer listener.
+    // The Minimal mock records Root-bound listeners in the legacy store.
     const store = fetchRscStore as unknown as Record<string, unknown>;
     delete store.l;
     const size = (key: string) =>
@@ -1798,6 +1807,7 @@ describe('Router integration', () => {
 
     // Registered exactly once despite StrictMode's mount/unmount/mount cycle.
     expect(size('l')).toBe(1);
+    expect(testHoisted.legacyActionListenerRegistrations).toBe(0);
 
     view.unmount();
 

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -439,7 +439,7 @@ vi.mock('../src/minimal/client.js', async () => {
     ),
     useMergeElements_UNSTABLE: () =>
       useMockMergeElements() ?? noopMergeElements,
-    useCallServerElementsListener_UNSTABLE: () =>
+    useRegisterCallServerElementsListener_UNSTABLE: () =>
       actual.unstable_registerCallServerElementsListener,
     unstable_registerCallServerElementsListener: (
       ...args: Parameters<


### PR DESCRIPTION
Keep initial suspension state separate from mounted Root state so multiple Minimal Roots can be used independently. Server action responses and development reload listeners stay with the Root that owns them.

Limitations:
- An in-flight server action is not moved to another Root when its Root unmounts.
- Concurrent Roots with the same initial input may issue separate requests.
- Multiple Router components are still unsupported and can be considered in a follow-up PR.