### PR TITLE
fix(router): support multiple instances

### DIFF
--- a/docs/guides/minimal-api.mdx
+++ b/docs/guides/minimal-api.mdx
@@ -427,7 +427,8 @@ Important behavior:
 
 - `initialRscPath` defaults to `''`.
 - `Root` is required for `Slot`, `Children`, and `useMergeElements`.
-- The client store is a module-level singleton (normally one per document), so mounting multiple `Root` instances is not supported.
+- Each `Root` owns its client store. Bare server action calls use the `Root`
+  that was most recently mounted when the request starts.
 - `Root` injects default head tags for charset, viewport, and generator.
 - For SSR or SSG, use `hydrateRoot(document, rootElement)` when `globalThis.__WAKU_HYDRATE__` is set.
 - For purely client-side rendering, use `createRoot(document).render(rootElement)`.

--- a/e2e/fixtures/router-client/src/components/multiple-routers.tsx
+++ b/e2e/fixtures/router-client/src/components/multiple-routers.tsx
@@ -29,7 +29,8 @@ const RouterFrame = ({
               <Router initialRoute={{ path, query, hash: '' }} />
             </Suspense>
           </StrictMode>,
-          frame.contentDocument,
+          // React supports Document containers, but @types/react-dom omits it.
+          frame.contentDocument as unknown as DocumentFragment,
         )}
     </>
   );

--- a/e2e/fixtures/router-client/src/components/multiple-routers.tsx
+++ b/e2e/fixtures/router-client/src/components/multiple-routers.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { StrictMode, Suspense, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Router, useRouter } from 'waku/router/client';
+
+export const NestedRouteState = () => {
+  const router = useRouter();
+  return <p data-testid="route-query">{router.query}</p>;
+};
+
+const RouterFrame = ({
+  path,
+  query,
+  testId,
+}: {
+  path: '/multiple-router' | '/other-router';
+  query: string;
+  testId: string;
+}) => {
+  const [frame, setFrame] = useState<HTMLIFrameElement | null>(null);
+  return (
+    <>
+      <iframe ref={setFrame} data-testid={testId} title={testId} />
+      {frame?.contentDocument &&
+        createPortal(
+          <StrictMode>
+            <Suspense fallback={<p>Loading router</p>}>
+              <Router initialRoute={{ path, query, hash: '' }} />
+            </Suspense>
+          </StrictMode>,
+          frame.contentDocument,
+        )}
+    </>
+  );
+};
+
+export const MultipleRouters = () => {
+  const [mounted, setMounted] = useState(false);
+  return (
+    <div>
+      <button
+        data-testid="mount-routers"
+        onClick={() => setMounted(true)}
+        type="button"
+      >
+        Mount Routers
+      </button>
+      {mounted && (
+        <>
+          <RouterFrame
+            path="/multiple-router"
+            query="name=first"
+            testId="first-router"
+          />
+          <RouterFrame
+            path="/multiple-router"
+            query="name=second"
+            testId="second-router"
+          />
+          <RouterFrame path="/multiple-router" query="" testId="third-router" />
+          <RouterFrame path="/other-router" query="" testId="fourth-router" />
+        </>
+      )}
+    </div>
+  );
+};

--- a/e2e/fixtures/router-client/src/pages/multiple-router.tsx
+++ b/e2e/fixtures/router-client/src/pages/multiple-router.tsx
@@ -1,0 +1,23 @@
+import type { PageProps } from 'waku/router';
+import { NestedRouteState } from '../components/multiple-routers.js';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default async function MultipleRouterPage({
+  query,
+}: PageProps<'/multiple-router'>) {
+  await sleep(query === 'name=first' ? 100 : 300);
+  return (
+    <div>
+      <h2>Nested Router</h2>
+      <p data-testid="server-query">{query}</p>
+      <NestedRouteState />
+    </div>
+  );
+}
+
+export const getConfig = () => {
+  return {
+    render: 'dynamic',
+  } as const;
+};

--- a/e2e/fixtures/router-client/src/pages/other-router.tsx
+++ b/e2e/fixtures/router-client/src/pages/other-router.tsx
@@ -1,0 +1,23 @@
+import type { PageProps } from 'waku/router';
+import { NestedRouteState } from '../components/multiple-routers.js';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default async function OtherRouterPage({
+  query,
+}: PageProps<'/other-router'>) {
+  await sleep(600);
+  return (
+    <div>
+      <h2>Other Nested Router</h2>
+      <p data-testid="server-query">{query}</p>
+      <NestedRouteState />
+    </div>
+  );
+}
+
+export const getConfig = () => {
+  return {
+    render: 'dynamic',
+  } as const;
+};

--- a/e2e/fixtures/router-client/src/pages/start.tsx
+++ b/e2e/fixtures/router-client/src/pages/start.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'waku';
 import { ResolveClientSuspenseButton } from '../components/client-suspense.js';
+import { MultipleRouters } from '../components/multiple-routers.js';
 import { NavIndicator } from '../components/nav-indicator.js';
 import { PushMissingButton, RouteState } from '../components/route-state.js';
 import { TransitionLink } from '../components/transition-link.js';
@@ -61,6 +62,7 @@ export default function StartPage() {
       <p>
         <ResolveClientSuspenseButton />
       </p>
+      <MultipleRouters />
       <p>
         <Link to="/trigger-not-found" data-testid="go-trigger-not-found">
           Go trigger not found

--- a/e2e/router-client.spec.ts
+++ b/e2e/router-client.spec.ts
@@ -105,6 +105,39 @@ test.describe('router-client', () => {
     await expect(page.getByTestId('route-query')).toHaveText('');
   });
 
+  test('concurrent Router mounts settle with different initial routes', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/start`);
+    await waitForHydration(page);
+
+    const requests: string[] = [];
+    page.on('request', (request) => {
+      if (
+        request.url().includes('/RSC/R/multiple-router.txt') ||
+        request.url().includes('/RSC/R/other-router.txt')
+      ) {
+        requests.push(request.url());
+      }
+    });
+
+    await page.getByTestId('mount-routers').click();
+
+    const first = page.frameLocator('[data-testid="first-router"]');
+    const second = page.frameLocator('[data-testid="second-router"]');
+    const third = page.frameLocator('[data-testid="third-router"]');
+    const fourth = page.frameLocator('[data-testid="fourth-router"]');
+    await expect(first.getByTestId('server-query')).toHaveText('name=first');
+    await expect(first.getByTestId('route-query')).toHaveText('name=first');
+    await expect(second.getByTestId('server-query')).toHaveText('name=second');
+    await expect(second.getByTestId('route-query')).toHaveText('name=second');
+    await expect(third.getByTestId('server-query')).toHaveText('');
+    await expect(third.getByTestId('route-query')).toHaveText('');
+    await expect(fourth.getByTestId('server-query')).toHaveText('');
+    await expect(fourth.getByTestId('route-query')).toHaveText('');
+    expect(requests).toHaveLength(4);
+  });
+
   test('popstate interceptor can rewrite navigation target', async ({
     page,
   }) => {

--- a/packages/waku/src/minimal/client-utils/initial-rsc-store.ts
+++ b/packages/waku/src/minimal/client-utils/initial-rsc-store.ts
@@ -33,6 +33,9 @@ export const getInitialRscEntry = (
     void initialRscEntries.shift();
   }
   initialRscEntries.push([rscPath, rscParams, elements]);
+  void elements.then(undefined, () => {
+    releaseInitialRscEntry(rscPath, rscParams, elements);
+  });
   return elements;
 };
 

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -244,15 +244,42 @@ const isAltClick = (event: MouseEvent<HTMLAnchorElement>) =>
   event.button !== 0 ||
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 
-let savedRscParams: [query: string, rscParams: URLSearchParams] | undefined;
+const createRscParams = (query: string): URLSearchParams =>
+  new URLSearchParams({ query });
 
-const createRscParams = (query: string): URLSearchParams => {
-  if (savedRscParams && savedRscParams[0] === query) {
-    return savedRscParams[1];
+// A suspended mount has no cleanup, so keep this aligned with Minimal's cache.
+const INITIAL_RSC_PARAMS_LIMIT = 32;
+const initialRscParamsCache = new Map<string, URLSearchParams>();
+
+const createInitialRscParams = (
+  rscPath: string,
+  query: string,
+): URLSearchParams => {
+  const key = JSON.stringify([rscPath, query]);
+  const cached = initialRscParamsCache.get(key);
+  if (cached) {
+    initialRscParamsCache.delete(key);
+    initialRscParamsCache.set(key, cached);
+    return cached;
   }
-  const rscParams = new URLSearchParams({ query });
-  savedRscParams = [query, rscParams];
+  const rscParams = createRscParams(query);
+  if (initialRscParamsCache.size === INITIAL_RSC_PARAMS_LIMIT) {
+    const oldest = initialRscParamsCache.keys().next().value;
+    if (oldest !== undefined) {
+      initialRscParamsCache.delete(oldest);
+    }
+  }
+  initialRscParamsCache.set(key, rscParams);
   return rscParams;
+};
+
+const releaseInitialRscParams = (rscParams: URLSearchParams) => {
+  for (const [key, cached] of initialRscParamsCache) {
+    if (cached === rscParams) {
+      initialRscParamsCache.delete(key);
+      return;
+    }
+  }
 };
 
 type ChangeRouteOptions = {
@@ -1746,9 +1773,11 @@ const InnerRouter = ({
 };
 
 /**
- * Client router root. Mount once near the app root so `useRouter`, `Link`, and
- * related hooks share navigation state. `initialRoute` defaults to the current
- * browser location.
+ * Client router root. Each instance provides navigation state to its
+ * descendants. Instances can start from different `initialRoute` values, but
+ * navigation uses the document's shared URL and history. Server action
+ * requests use the most recently mounted Minimal Root. `initialRoute` defaults
+ * to the current browser location.
  */
 export function Router({
   initialRoute = parseRoute(new URL(window.location.href)),
@@ -1764,7 +1793,12 @@ export function Router({
   unstable_routeInterceptor?: (route: RouteProps) => RouteProps | false;
 }) {
   const initialRscPath = encodeRoutePath(initialRoute.path);
-  const initialRscParams = createRscParams(initialRoute.query);
+  const [initialRscParams] = useState(() =>
+    createInitialRscParams(initialRscPath, initialRoute.query),
+  );
+  useLayoutEffect(() => {
+    releaseInitialRscParams(initialRscParams);
+  }, [initialRscParams]);
   return (
     <Root initialRscPath={initialRscPath} initialRscParams={initialRscParams}>
       <InnerRouter

--- a/packages/waku/tests/minimal-client.test.tsx
+++ b/packages/waku/tests/minimal-client.test.tsx
@@ -199,6 +199,17 @@ describe('minimal/client fetch', () => {
     expect(create).toHaveBeenCalledOnce();
   });
 
+  test('retries a rejected initial fetch', async () => {
+    const first = getInitialRscEntry('R/app.txt', undefined, () =>
+      Promise.reject(new Error('failed')),
+    );
+    await expect(first).rejects.toThrow('failed');
+    const create = vi.fn(() => Promise.resolve({}));
+
+    expect(getInitialRscEntry('R/app.txt', undefined, create)).not.toBe(first);
+    expect(create).toHaveBeenCalledOnce();
+  });
+
   test('server actions use the current fetch, not the one elements decoded with', async () => {
     // Capture the callServer baked into the fetched elements.
     let callServer: CallServer | undefined;

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -1771,6 +1771,34 @@ describe('Router integration', () => {
     view.unmount();
   });
 
+  test('keeps initial params stable until the Router commits', async () => {
+    const elements = {
+      [unstable_getRouteSlotId('/start')]: <div />,
+      [ROUTE_ID]: ['/start', ''],
+      [IS_STATIC_ID]: false,
+    };
+    const view = await renderRouterInStrictMode(
+      { initialRoute: { path: '/start', query: 'a=1', hash: '' } },
+      elements,
+    );
+    const params = vi
+      .mocked(Root)
+      .mock.calls.map(([props]) => props.initialRscParams as URLSearchParams);
+
+    expect(params.length).toBeGreaterThan(1);
+    expect(params.every((item) => item === params[0])).toBe(true);
+
+    const nextView = await renderRouter(
+      { initialRoute: { path: '/start', query: 'a=1', hash: '' } },
+      elements,
+    );
+    expect(vi.mocked(Root).mock.calls.at(-1)?.[0].initialRscParams).not.toBe(
+      params[0],
+    );
+    view.unmount();
+    nextView.unmount();
+  });
+
   test('uses route data as initial route', async () => {
     window.history.replaceState({}, '', '/missing');
 


### PR DESCRIPTION
Keep initial RSC params stable when multiple Router instances suspend with different routes or queries.

Add regression coverage to the existing router client fixture.

following #2275