### PR TITLE
refactor(router): clarify client boundaries

### DIFF
--- a/packages/waku/src/router/client-core-utils/caches.ts
+++ b/packages/waku/src/router/client-core-utils/caches.ts
@@ -24,106 +24,64 @@ export type PrefetchHandle = Pick<PrefetchEntry, 'promise' | 'onInvalidate'>;
 export const createRscParams = (query: string): URLSearchParams =>
   new URLSearchParams({ query });
 
-export const createCaches = () => {
-  const manager = createPrefetchManager();
-  const staticPathSet = new Set<string>();
-
-  const getPrefetchedElements = (route: RouteProps): Elements | undefined =>
-    manager.getElements(encodeRoutePath(route.path));
-
-  return {
-    prefetchRoute: (route: RouteProps, options?: PrefetchOptions): void => {
-      // skip is canReuseStaticRoute at the caller, which has this root's elements
-      const rscPath = encodeRoutePath(route.path);
-      manager.prefetch(
-        rscPath,
-        route.query,
-        (base, invalidate) =>
-          fetchRsc(rscPath, createRscParams(route.query), {
-            ...(base ? { unstable_base: base } : {}),
-            onBuildIdMismatch: () => {
-              invalidate();
-              manager.clear();
-            },
-          }),
-        options,
-      );
-    },
-    hasCachedShell: (
-      route: RouteProps,
-      currentElements: Record<string, unknown>,
-    ): boolean =>
-      canCommitInstantly(
-        getRouteSlotId(route.path),
-        currentElements,
-        getPrefetchedElements(route),
-      ),
-    getPrefetchedElements,
-    getPrefetch: (route: RouteProps): PrefetchHandle | undefined =>
-      manager.get(encodeRoutePath(route.path), route.query),
-    canReuseStaticRoute: (
-      route: RouteProps,
-      currentElements: Elements,
-    ): boolean =>
-      staticPathSet.has(route.path) &&
-      getRouteSlotId(route.path) in currentElements,
-    learnStaticFromElements: (elements: Record<string, unknown>): void => {
-      const route = getRouteFromElements(elements);
-      if (route && isStaticFromElements(elements)) {
-        staticPathSet.add(route.path);
-      }
-    },
-    clear: (): void => {
-      manager.clear();
-      staticPathSet.clear();
-    },
-  };
-};
-
-export type Caches = ReturnType<typeof createCaches>;
-
-const singleton = createCaches();
+const manager = createPrefetchManager();
+const staticPathSet = new Set<string>();
 
 export const prefetchRoute = (
   route: RouteProps,
   options?: PrefetchOptions,
-): void => singleton.prefetchRoute(route, options);
+): void => {
+  // skip is canReuseStaticRoute at the caller, which has this root's elements
+  const rscPath = encodeRoutePath(route.path);
+  manager.prefetch(
+    rscPath,
+    route.query,
+    (base, invalidate) =>
+      fetchRsc(rscPath, createRscParams(route.query), {
+        ...(base ? { unstable_base: base } : {}),
+        onBuildIdMismatch: () => {
+          invalidate();
+          manager.clear();
+        },
+      }),
+    options,
+  );
+};
 
 export const hasCachedShell = (
   route: RouteProps,
   currentElements: Record<string, unknown>,
-): boolean => singleton.hasCachedShell(route, currentElements);
+): boolean =>
+  canCommitInstantly(
+    getRouteSlotId(route.path),
+    currentElements,
+    getPrefetchedElements(route),
+  );
 
 export const getPrefetchedElements = (
   route: RouteProps,
-): Elements | undefined => singleton.getPrefetchedElements(route);
+): Elements | undefined => manager.getElements(encodeRoutePath(route.path));
 
 export const getPrefetch = (route: RouteProps): PrefetchHandle | undefined =>
-  singleton.getPrefetch(route);
+  manager.get(encodeRoutePath(route.path), route.query);
 
 export const canReuseStaticRoute = (
   route: RouteProps,
   currentElements: Elements,
-): boolean => singleton.canReuseStaticRoute(route, currentElements);
+): boolean =>
+  staticPathSet.has(route.path) &&
+  getRouteSlotId(route.path) in currentElements;
 
 export const learnStaticFromElements = (
   elements: Record<string, unknown>,
-): void => singleton.learnStaticFromElements(elements);
+): void => {
+  const route = getRouteFromElements(elements);
+  if (route && isStaticFromElements(elements)) {
+    staticPathSet.add(route.path);
+  }
+};
 
 export const clearCaches = (): void => {
-  singleton.clear();
-};
-
-const registeredLazySlices = new Set<string>();
-
-export const registerLazySlice = (id: string): void => {
-  registeredLazySlices.add(id);
-};
-
-export const forEachRegisteredLazySlice = (fn: (id: string) => void): void => {
-  registeredLazySlices.forEach(fn);
-};
-
-export const clearRegisteredLazySlices = (): void => {
-  registeredLazySlices.clear();
+  manager.clear();
+  staticPathSet.clear();
 };

--- a/packages/waku/src/router/client-core-utils/hmr.ts
+++ b/packages/waku/src/router/client-core-utils/hmr.ts
@@ -1,0 +1,52 @@
+import { startTransition, useEffect } from 'react';
+import {
+  unstable_fetchRsc as fetchRsc,
+  useMergeElements_UNSTABLE as useMergeElements,
+  useRegisterRscReloadListener_UNSTABLE as useRegisterRscReloadListener,
+} from '../../minimal/client.js';
+import { encodeRoutePath } from '../isomorphic-utils/route-path.js';
+import type { RouteProps } from '../isomorphic-utils/route-path.js';
+import {
+  clearCaches,
+  createRscParams,
+  learnStaticFromElements,
+} from './caches.js';
+import { fetchSlice, forEachRegisteredLazySlice } from './slice.js';
+
+export const useHmrRefetch = ({
+  getSettledRoute,
+  onBeforeRefetch,
+}: {
+  getSettledRoute: () => RouteProps;
+  onBeforeRefetch?: () => void;
+}): void => {
+  const mergeElements = useMergeElements();
+  const registerRscReloadListener = useRegisterRscReloadListener();
+  useEffect(() => {
+    if (import.meta.hot) {
+      const refetchRouteOnHmr = () => {
+        onBeforeRefetch?.();
+        clearCaches();
+        const settledRoute = getSettledRoute();
+        startTransition(() => {
+          // the reload clears the set, so the response has to teach it again
+          void mergeElements(
+            fetchRsc(
+              encodeRoutePath(settledRoute.path),
+              createRscParams(settledRoute.query),
+            ),
+          ).then(learnStaticFromElements, () => {});
+          forEachRegisteredLazySlice((id) => {
+            fetchSlice(id, mergeElements, { replace: true });
+          });
+        });
+      };
+      return registerRscReloadListener(refetchRouteOnHmr);
+    }
+  }, [
+    getSettledRoute,
+    mergeElements,
+    onBeforeRefetch,
+    registerRscReloadListener,
+  ]);
+};

--- a/packages/waku/src/router/client-core-utils/initial-route.ts
+++ b/packages/waku/src/router/client-core-utils/initial-route.ts
@@ -1,5 +1,4 @@
 import {
-  startTransition,
   use,
   useEffect,
   useLayoutEffect,
@@ -7,22 +6,10 @@ import {
   useRef,
   useState,
 } from 'react';
-import {
-  unstable_fetchRsc as fetchRsc,
-  useElementsPromise_UNSTABLE as useElementsPromise,
-  useMergeElements_UNSTABLE as useMergeElements,
-  useRegisterRscReloadListener_UNSTABLE as useRegisterRscReloadListener,
-} from '../../minimal/client.js';
-import { encodeRoutePath } from '../isomorphic-utils/route-path.js';
+import { useElementsPromise_UNSTABLE as useElementsPromise } from '../../minimal/client.js';
 import type { RouteProps } from '../isomorphic-utils/route-path.js';
-import {
-  clearCaches,
-  createRscParams,
-  forEachRegisteredLazySlice,
-  learnStaticFromElements,
-} from './caches.js';
+import { createRscParams } from './caches.js';
 import { getRouteFromElements } from './element-meta.js';
-import { fetchSlice } from './slice.js';
 
 export const useInitialRoute = (proposed: RouteProps): RouteProps => {
   const elementsPromise = useElementsPromise();
@@ -100,42 +87,4 @@ export const useInitialRscParams = (
     releaseInitialRscParams(initialRscParams);
   }, [initialRscParams]);
   return initialRscParams;
-};
-
-export const useHmrRefetch = ({
-  getSettledRoute,
-  onBeforeRefetch,
-}: {
-  getSettledRoute: () => RouteProps;
-  onBeforeRefetch?: () => void;
-}): void => {
-  const mergeElements = useMergeElements();
-  const registerRscReloadListener = useRegisterRscReloadListener();
-  useEffect(() => {
-    if (import.meta.hot) {
-      const refetchRouteOnHmr = () => {
-        onBeforeRefetch?.();
-        clearCaches();
-        const settledRoute = getSettledRoute();
-        startTransition(() => {
-          // the reload clears the set, so the response has to teach it again
-          void mergeElements(
-            fetchRsc(
-              encodeRoutePath(settledRoute.path),
-              createRscParams(settledRoute.query),
-            ),
-          ).then(learnStaticFromElements, () => {});
-          forEachRegisteredLazySlice((id) => {
-            fetchSlice(id, mergeElements, { replace: true });
-          });
-        });
-      };
-      return registerRscReloadListener(refetchRouteOnHmr);
-    }
-  }, [
-    getSettledRoute,
-    mergeElements,
-    onBeforeRefetch,
-    registerRscReloadListener,
-  ]);
 };

--- a/packages/waku/src/router/client-core-utils/slice.tsx
+++ b/packages/waku/src/router/client-core-utils/slice.tsx
@@ -11,7 +11,6 @@ import {
   encodeSliceId,
   getSliceSlotId,
 } from '../isomorphic-utils/route-path.js';
-import { registerLazySlice } from './caches.js';
 
 type Elements = Record<string | symbol, unknown>;
 
@@ -20,6 +19,19 @@ export type SliceId = string;
 type SliceRequest = { promise: Promise<Elements>; isReplace: boolean };
 
 const fetchingSlices = new Map<SliceId, SliceRequest>();
+const registeredLazySlices = new Set<SliceId>();
+
+export const registerLazySlice = (id: SliceId): void => {
+  registeredLazySlices.add(id);
+};
+
+export const forEachRegisteredLazySlice = (fn: (id: SliceId) => void): void => {
+  registeredLazySlices.forEach(fn);
+};
+
+export const clearRegisteredLazySlices = (): void => {
+  registeredLazySlices.clear();
+};
 
 export const fetchSlice = (
   id: SliceId,

--- a/packages/waku/src/router/client-core.ts
+++ b/packages/waku/src/router/client-core.ts
@@ -9,7 +9,6 @@ export {
   hasCachedShell as unstable_hasCachedShell,
   learnStaticFromElements as unstable_learnStaticFromElements,
   prefetchRoute as unstable_prefetchRoute,
-  registerLazySlice as unstable_registerLazySlice,
 } from './client-core-utils/caches.js';
 export type {
   PrefetchHandle as Unstable_PrefetchHandle,
@@ -54,11 +53,12 @@ export {
   useSetSearch_UNSTABLE,
 } from './client-core-utils/route-hooks.js';
 
+export { useHmrRefetch as useHmrRefetch_UNSTABLE } from './client-core-utils/hmr.js';
+
 export {
-  useHmrRefetch as useHmrRefetch_UNSTABLE,
   useInitialRoute as useInitialRoute_UNSTABLE,
   useInitialRscParams as useInitialRscParams_UNSTABLE,
-} from './client-core-utils/route-state-hooks.js';
+} from './client-core-utils/initial-route.js';
 
 export {
   getRouteUrl as unstable_getRouteUrl,

--- a/packages/waku/src/router/client-utils/instant-navigation.ts
+++ b/packages/waku/src/router/client-utils/instant-navigation.ts
@@ -1,0 +1,18 @@
+import { unstable_isImmutableElement as isImmutableElement } from '../../minimal/client.js';
+import { hasCachedShell } from '../client-core-utils/caches.js';
+import { isMetaKey } from '../client-core-utils/element-meta.js';
+import type { RouteProps } from '../isomorphic-utils/route-path.js';
+
+export const canPaintInstantOverlay = (
+  follows: number,
+  route: RouteProps,
+  resolvedElements: Record<string, unknown>,
+) => !follows && hasCachedShell(route, resolvedElements);
+
+// symbol keys are client owned; they are carried, never fetched
+export const pinForSwr =
+  (getResolvedElements: () => Record<string, unknown>) =>
+  (key: string | symbol) =>
+    typeof key === 'symbol' ||
+    isMetaKey(key) ||
+    isImmutableElement(getResolvedElements(), key);

--- a/packages/waku/src/router/client-utils/router-state.ts
+++ b/packages/waku/src/router/client-utils/router-state.ts
@@ -1,7 +1,5 @@
-import { unstable_isImmutableElement as isImmutableElement } from '../../minimal/client.js';
 import {
   getRouteFromElements,
-  isMetaKey,
   isStaticFromElements,
 } from '../client-core-utils/element-meta.js';
 import { getRouteUrl } from '../client-core-utils/route-url.js';
@@ -92,11 +90,3 @@ export const getSettledRoute = (
     resolveServerRedirect(elements, routerState, fallback.path).route
   );
 };
-
-// symbol keys are client owned; they are carried, never fetched
-export const pinForSwr =
-  (getResolvedElements: () => Record<string, unknown>) =>
-  (key: string | symbol) =>
-    typeof key === 'symbol' ||
-    isMetaKey(key) ||
-    isImmutableElement(getResolvedElements(), key);

--- a/packages/waku/src/router/client-utils/scroll.ts
+++ b/packages/waku/src/router/client-utils/scroll.ts
@@ -1,5 +1,5 @@
+import { pathnameToCurrentRoutePath } from '../client-core-utils/route-url.js';
 import type { RouteProps } from '../isomorphic-utils/route-path.js';
-import { pathnameToCurrentRoutePath } from './route-url.js';
 
 // a run decodes together, so a multi byte character survives
 const decodeHash = (raw: string) =>

--- a/packages/waku/src/router/client.tsx
+++ b/packages/waku/src/router/client.tsx
@@ -43,7 +43,6 @@ import {
   createRscParams,
   getPrefetch,
   getPrefetchedElements,
-  hasCachedShell,
   learnStaticFromElements,
   prefetchRoute as prefetchCachedRoute,
 } from './client-core-utils/caches.js';
@@ -56,8 +55,13 @@ import {
   decideFollow,
   isFollowable,
 } from './client-core-utils/error-route.js';
+import { useHmrRefetch } from './client-core-utils/hmr.js';
 import { RouterHostContext } from './client-core-utils/host.js';
 import type { RouterHost } from './client-core-utils/host.js';
+import {
+  useInitialRoute,
+  useInitialRscParams,
+} from './client-core-utils/initial-route.js';
 import { abortable, load } from './client-core-utils/load.js';
 import { buildMergePatch } from './client-core-utils/merge-patch.js';
 import {
@@ -65,31 +69,29 @@ import {
   useResolveSearchCodec,
 } from './client-core-utils/route-hooks.js';
 import {
-  useHmrRefetch,
-  useInitialRoute,
-  useInitialRscParams,
-} from './client-core-utils/route-state-hooks.js';
-import {
   getRouteUrl,
   isSameRoute,
   isSameRscRoute,
   parseRoute,
 } from './client-core-utils/route-url.js';
-import {
-  scrollToHash,
-  shouldScrollByDefault,
-  shouldScrollForRouteChange,
-} from './client-core-utils/scroll.js';
 import type { SliceId } from './client-core-utils/slice.js';
+import {
+  canPaintInstantOverlay,
+  pinForSwr,
+} from './client-utils/instant-navigation.js';
 import {
   ROUTER_STATE_ID,
   getRouterState,
   getSettledRoute,
   makeRouterState,
-  pinForSwr,
   resolveServerRedirect,
 } from './client-utils/router-state.js';
 import type { RouterState } from './client-utils/router-state.js';
+import {
+  scrollToHash,
+  shouldScrollByDefault,
+  shouldScrollForRouteChange,
+} from './client-utils/scroll.js';
 import type {
   RouteParams,
   RouteSearch,
@@ -258,12 +260,6 @@ const RouterContext = createContext<{
   changeRoute: ChangeRoute;
   getElements?: () => Record<string, unknown>;
 } | null>(null);
-
-const canPaintInstantOverlay = (
-  follows: number,
-  route: RouteProps,
-  resolvedElements: Record<string, unknown>,
-) => !follows && hasCachedShell(route, resolvedElements);
 
 const dispatchChangeRoute = (
   changeRoute: ChangeRoute,

--- a/packages/waku/tests/router-caches.test.ts
+++ b/packages/waku/tests/router-caches.test.ts
@@ -5,15 +5,12 @@ import { unstable_fetchRsc as fetchRsc } from '../src/minimal/client.js';
 import {
   canReuseStaticRoute,
   clearCaches,
-  clearRegisteredLazySlices,
-  createCaches,
   createRscParams,
-  forEachRegisteredLazySlice,
   getPrefetch,
   getPrefetchedElements,
+  hasCachedShell,
   learnStaticFromElements,
   prefetchRoute,
-  registerLazySlice,
 } from '../src/router/client-core-utils/caches.js';
 import {
   IS_STATIC_ID,
@@ -42,13 +39,12 @@ const immutable = (path: string) => ({
 const pending = () => new Promise<Elements>(() => {});
 
 const settlePrefetch = async (
-  caches: ReturnType<typeof createCaches>,
   path: string,
   query: string,
   elements: Elements,
 ) => {
   vi.mocked(fetchRsc).mockImplementationOnce(async () => elements);
-  caches.prefetchRoute(route(path, query));
+  prefetchRoute(route(path, query));
   await Promise.resolve();
   await Promise.resolve();
 };
@@ -56,85 +52,76 @@ const settlePrefetch = async (
 describe('layer-1 router caches', () => {
   afterEach(() => {
     clearCaches();
-    clearRegisteredLazySlices();
     vi.mocked(fetchRsc).mockReset();
     vi.useRealTimers();
   });
 
   it('hasCachedShell is true when the current elements hold an immutable route slot', () => {
-    const caches = createCaches();
-    expect(caches.hasCachedShell(route('/a'), immutable('/a'))).toBe(true);
+    expect(hasCachedShell(route('/a'), immutable('/a'))).toBe(true);
   });
 
   it('hasCachedShell is true when only the prefetched elements hold the slot', async () => {
-    const caches = createCaches();
-    await settlePrefetch(caches, '/a', '', immutable('/a'));
-    expect(caches.hasCachedShell(route('/a'), {})).toBe(true);
+    await settlePrefetch('/a', '', immutable('/a'));
+    expect(hasCachedShell(route('/a'), {})).toBe(true);
   });
 
   it('hasCachedShell is false without an immutable etag for the slot', () => {
-    const caches = createCaches();
     expect(
-      caches.hasCachedShell(route('/a'), {
+      hasCachedShell(route('/a'), {
         [ETAG_ID_PREFIX + getRouteSlotId('/a')]: 'W/"mutable"',
       }),
     ).toBe(false);
   });
 
   it('getPrefetchedElements is keyed by route path, encoding the rscPath internally', async () => {
-    const caches = createCaches();
     const shell = { [getRouteSlotId('/next')]: 'shell' };
-    await settlePrefetch(caches, '/next', 'q=a', shell);
-    expect(caches.getPrefetchedElements(route('/next', 'q=b'))).toEqual(shell);
-    expect(caches.getPrefetchedElements(route('/other'))).toBeUndefined();
+    await settlePrefetch('/next', 'q=a', shell);
+    expect(getPrefetchedElements(route('/next', 'q=b'))).toEqual(shell);
+    expect(getPrefetchedElements(route('/other'))).toBeUndefined();
   });
 
   it('returns the stored elements object, not a clone', async () => {
-    const caches = createCaches();
     const shell = { [getRouteSlotId('/next')]: 'shell' };
-    await settlePrefetch(caches, '/next', '', shell);
-    expect(caches.getPrefetchedElements(route('/next'))).toBe(shell);
+    await settlePrefetch('/next', '', shell);
+    expect(getPrefetchedElements(route('/next'))).toBe(shell);
   });
 
   it('learnStaticFromElements records only static routes', () => {
-    const caches = createCaches();
-    caches.learnStaticFromElements({
+    learnStaticFromElements({
       [ROUTE_ID]: ['/static', ''],
       [IS_STATIC_ID]: true,
     });
-    caches.learnStaticFromElements({
+    learnStaticFromElements({
       [ROUTE_ID]: ['/dynamic', ''],
       [IS_STATIC_ID]: false,
     });
-    caches.learnStaticFromElements({});
-    expect(caches.canReuseStaticRoute(route('/static'), {})).toBe(false);
+    learnStaticFromElements({});
+    expect(canReuseStaticRoute(route('/static'), {})).toBe(false);
     expect(
-      caches.canReuseStaticRoute(route('/static'), {
+      canReuseStaticRoute(route('/static'), {
         [getRouteSlotId('/static')]: 'page',
       }),
     ).toBe(true);
     expect(
-      caches.canReuseStaticRoute(route('/dynamic'), {
+      canReuseStaticRoute(route('/dynamic'), {
         [getRouteSlotId('/dynamic')]: 'page',
       }),
     ).toBe(false);
   });
 
   it('prefetchRoute fetches a path already learned as static', () => {
-    const caches = createCaches();
-    caches.learnStaticFromElements({
+    learnStaticFromElements({
       [ROUTE_ID]: ['/static', ''],
       [IS_STATIC_ID]: true,
     });
     vi.mocked(fetchRsc).mockImplementation(pending);
-    caches.prefetchRoute(route('/static'));
+    prefetchRoute(route('/static'));
     expect(fetchRsc).toHaveBeenCalledTimes(1);
   });
 
   it('prefetchRoute fetches by encoded rscPath and sends the query as RSC params', () => {
     vi.mocked(fetchRsc).mockImplementation(pending);
-    const caches = createCaches();
-    caches.prefetchRoute(route('/next', 'x=1'));
+    prefetchRoute(route('/next', 'x=1'));
     expect(fetchRsc).toHaveBeenCalledTimes(1);
     const rscParams = vi.mocked(fetchRsc).mock.calls[0]?.[1];
     expect(rscParams).toBeInstanceOf(URLSearchParams);
@@ -154,25 +141,7 @@ describe('layer-1 router caches', () => {
     expect(createRscParams('a=1').get('query')).toBe('a=1');
   });
 
-  it('createCaches isolates prefetch and static paths', async () => {
-    const a = createCaches();
-    const b = createCaches();
-    await settlePrefetch(a, '/a', '', { a: 1 });
-    a.learnStaticFromElements({
-      [ROUTE_ID]: ['/static', ''],
-      [IS_STATIC_ID]: true,
-    });
-
-    expect(b.getPrefetchedElements(route('/a'))).toBeUndefined();
-    expect(
-      b.canReuseStaticRoute(route('/static'), {
-        [getRouteSlotId('/static')]: 'page',
-      }),
-    ).toBe(false);
-  });
-
-  it('clear() detaches an in-flight prefetch and forgets static paths', async () => {
-    const caches = createCaches();
+  it('clearCaches detaches an in-flight prefetch and forgets static paths', async () => {
     let resolveFetch!: (elements: Elements) => void;
     vi.mocked(fetchRsc).mockImplementationOnce(
       () =>
@@ -180,136 +149,79 @@ describe('layer-1 router caches', () => {
           resolveFetch = resolve;
         }),
     );
-    caches.prefetchRoute(route('/p'));
-    caches.learnStaticFromElements({
-      [ROUTE_ID]: ['/static', ''],
-      [IS_STATIC_ID]: true,
-    });
-    caches.clear();
-    resolveFetch({ a: 1 });
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(caches.getPrefetchedElements(route('/p'))).toBeUndefined();
-    expect(caches.getPrefetch(route('/p'))).toBeUndefined();
-    expect(
-      caches.canReuseStaticRoute(route('/static'), {
-        [getRouteSlotId('/static')]: 'page',
-      }),
-    ).toBe(false);
-    vi.mocked(fetchRsc).mockClear();
-    vi.mocked(fetchRsc).mockImplementation(pending);
-    caches.prefetchRoute(route('/static'));
-    expect(fetchRsc).toHaveBeenCalled();
-  });
-
-  it('getPrefetch is keyed by path and query', () => {
-    const caches = createCaches();
-    vi.mocked(fetchRsc).mockImplementation(pending);
-    caches.prefetchRoute(route('/p', 'q=1'));
-    expect(caches.getPrefetch(route('/p', 'q=1'))).toBeDefined();
-    expect(caches.getPrefetch(route('/p', 'q=2'))).toBeUndefined();
-  });
-
-  it('a build-id mismatch drops the prefetch store and keeps static paths', async () => {
-    const caches = createCaches();
-    await settlePrefetch(caches, '/a', '', { a: 1 });
-    caches.learnStaticFromElements({
-      [ROUTE_ID]: ['/static', ''],
-      [IS_STATIC_ID]: true,
-    });
-    vi.mocked(fetchRsc).mockImplementationOnce(pending);
-    caches.prefetchRoute(route('/c'));
-    const onBuildIdMismatch = vi.mocked(fetchRsc).mock.calls.at(-1)?.[2]
-      ?.onBuildIdMismatch as (() => void) | undefined;
-    onBuildIdMismatch?.();
-    expect(caches.getPrefetchedElements(route('/a'))).toBeUndefined();
-    expect(caches.getPrefetch(route('/c'))).toBeUndefined();
-    expect(
-      caches.canReuseStaticRoute(route('/static'), {
-        [getRouteSlotId('/static')]: 'page',
-      }),
-    ).toBe(true);
-    vi.mocked(fetchRsc).mockClear();
-    vi.mocked(fetchRsc).mockImplementation(pending);
-    caches.prefetchRoute(route('/static'));
-    expect(fetchRsc).toHaveBeenCalled();
-  });
-
-  it('module functions share one store that createCaches does not see', async () => {
-    vi.mocked(fetchRsc).mockResolvedValue({ shell: 1 });
-    prefetchRoute(route('/x'));
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(getPrefetchedElements(route('/x'))).toEqual({ shell: 1 });
-    expect(getPrefetch(route('/x', ''))).toBeDefined();
-    expect(createCaches().getPrefetchedElements(route('/x'))).toBeUndefined();
-
+    prefetchRoute(route('/p'));
     learnStaticFromElements({
       [ROUTE_ID]: ['/static', ''],
       [IS_STATIC_ID]: true,
     });
+    clearCaches();
+    resolveFetch({ a: 1 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getPrefetchedElements(route('/p'))).toBeUndefined();
+    expect(getPrefetch(route('/p'))).toBeUndefined();
+    expect(
+      canReuseStaticRoute(route('/static'), {
+        [getRouteSlotId('/static')]: 'page',
+      }),
+    ).toBe(false);
+    vi.mocked(fetchRsc).mockClear();
+    vi.mocked(fetchRsc).mockImplementation(pending);
+    prefetchRoute(route('/static'));
+    expect(fetchRsc).toHaveBeenCalled();
+  });
+
+  it('getPrefetch is keyed by path and query', () => {
+    vi.mocked(fetchRsc).mockImplementation(pending);
+    prefetchRoute(route('/p', 'q=1'));
+    expect(getPrefetch(route('/p', 'q=1'))).toBeDefined();
+    expect(getPrefetch(route('/p', 'q=2'))).toBeUndefined();
+  });
+
+  it('a build-id mismatch drops the prefetch store and keeps static paths', async () => {
+    await settlePrefetch('/a', '', { a: 1 });
+    learnStaticFromElements({
+      [ROUTE_ID]: ['/static', ''],
+      [IS_STATIC_ID]: true,
+    });
+    vi.mocked(fetchRsc).mockImplementationOnce(pending);
+    prefetchRoute(route('/c'));
+    const onBuildIdMismatch = vi.mocked(fetchRsc).mock.calls.at(-1)?.[2]
+      ?.onBuildIdMismatch as (() => void) | undefined;
+    onBuildIdMismatch?.();
+    expect(getPrefetchedElements(route('/a'))).toBeUndefined();
+    expect(getPrefetch(route('/c'))).toBeUndefined();
     expect(
       canReuseStaticRoute(route('/static'), {
         [getRouteSlotId('/static')]: 'page',
       }),
     ).toBe(true);
-    expect(
-      createCaches().canReuseStaticRoute(route('/static'), {
-        [getRouteSlotId('/static')]: 'page',
-      }),
-    ).toBe(false);
-
-    const params = createRscParams('q=1');
-    expect(createRscParams('q=1')).not.toBe(params);
-    expect(params.get('query')).toBe('q=1');
-
-    clearCaches();
-    expect(getPrefetchedElements(route('/x'))).toBeUndefined();
-    expect(
-      canReuseStaticRoute(route('/static'), {
-        [getRouteSlotId('/static')]: 'page',
-      }),
-    ).toBe(false);
+    vi.mocked(fetchRsc).mockClear();
+    vi.mocked(fetchRsc).mockImplementation(pending);
+    prefetchRoute(route('/static'));
+    expect(fetchRsc).toHaveBeenCalled();
   });
 
   it('getPrefetch is undefined after ttl expiry', () => {
     vi.useFakeTimers();
-    const caches = createCaches();
     vi.mocked(fetchRsc).mockImplementation(pending);
-    caches.prefetchRoute(route('/a'), { ttl: 1000 });
-    expect(caches.getPrefetch(route('/a'))).toBeDefined();
+    prefetchRoute(route('/a'), { ttl: 1000 });
+    expect(getPrefetch(route('/a'))).toBeDefined();
     vi.advanceTimersByTime(1001);
-    expect(caches.getPrefetch(route('/a'))).toBeUndefined();
+    expect(getPrefetch(route('/a'))).toBeUndefined();
   });
 
   it("mode 'once' skips a stored shell; 'always' dedupes by TTL only", async () => {
-    const caches = createCaches();
-    await settlePrefetch(caches, '/p', 'q=a', { a: 1 });
+    await settlePrefetch('/p', 'q=a', { a: 1 });
     vi.mocked(fetchRsc).mockClear();
     vi.mocked(fetchRsc).mockImplementation(pending);
 
-    caches.prefetchRoute(route('/p', 'q=b'), { mode: 'once' });
+    prefetchRoute(route('/p', 'q=b'), { mode: 'once' });
     expect(fetchRsc).not.toHaveBeenCalled();
 
-    caches.prefetchRoute(route('/p', 'q=b'), { mode: 'always' });
+    prefetchRoute(route('/p', 'q=b'), { mode: 'always' });
     expect(fetchRsc).toHaveBeenCalledTimes(1);
-    caches.prefetchRoute(route('/p', 'q=b'), { mode: 'always' });
+    prefetchRoute(route('/p', 'q=b'), { mode: 'always' });
     expect(fetchRsc).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('registered lazy slices', () => {
-  afterEach(() => {
-    clearCaches();
-    clearRegisteredLazySlices();
-  });
-
-  it('registration is permanent: ids survive clearCaches', () => {
-    registerLazySlice('a');
-    registerLazySlice('b');
-    clearCaches();
-    const ids: string[] = [];
-    forEachRegisteredLazySlice((id) => ids.push(id));
-    expect(ids.sort()).toEqual(['a', 'b']);
   });
 });

--- a/packages/waku/tests/router-client-core-surface.test.ts
+++ b/packages/waku/tests/router-client-core-surface.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
@@ -66,7 +66,6 @@ describe('waku/router/client-core surface', () => {
       'unstable_parseRoute',
       'unstable_pathnameToRoutePath',
       'unstable_prefetchRoute',
-      'unstable_registerLazySlice',
       'useHmrRefetch_UNSTABLE',
       'useInitialRoute_UNSTABLE',
       'useInitialRscParams_UNSTABLE',
@@ -168,31 +167,5 @@ describe('waku/router/client surface', () => {
     expect(clientCore.unstable_encodeRoutePath).toBe(
       client.unstable_encodeRoutePath,
     );
-  });
-});
-
-describe('folder membership is layer membership', () => {
-  test('client-utils holds only router-state', () => {
-    expect(readdirSync(join(routerSrc, 'client-utils')).sort()).toEqual([
-      'router-state.ts',
-    ]);
-  });
-
-  test('client-core-utils holds the L1 modules', () => {
-    expect(readdirSync(join(routerSrc, 'client-core-utils')).sort()).toEqual([
-      'caches.ts',
-      'element-meta.ts',
-      'error-boundary.tsx',
-      'error-route.ts',
-      'host.ts',
-      'load.ts',
-      'merge-patch.ts',
-      'prefetch-cache.ts',
-      'route-hooks.tsx',
-      'route-state-hooks.ts',
-      'route-url.ts',
-      'scroll.ts',
-      'slice.tsx',
-    ]);
   });
 });

--- a/packages/waku/tests/router-client-core-surface.test.ts
+++ b/packages/waku/tests/router-client-core-surface.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { readFileSync, readdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
 import {
@@ -173,16 +173,25 @@ describe('waku/router/client surface', () => {
 describe('client utility boundaries', () => {
   test('client-core-utils does not depend on client-utils', () => {
     const dir = join(routerSrc, 'client-core-utils');
-    for (const fileName of readdirSync(dir)) {
-      if (!/\.[cm]?[jt]sx?$/.test(fileName)) {
-        continue;
-      }
+    const clientUtilsDir = join(routerSrc, 'client-utils');
+    const fileNames = readdirSync(dir, { recursive: true }).filter((fileName) =>
+      /\.[cm]?[jt]sx?$/.test(fileName),
+    );
+    expect(fileNames.length).toBeGreaterThan(0);
+    for (const fileName of fileNames) {
       const src = readFileSync(join(dir, fileName), 'utf8');
       const specs = [
         ...src.matchAll(/(?:\bfrom\s+|\bimport\s*(?:\(\s*)?)["']([^"']+)["']/g),
       ].map((match) => match[1]!);
       expect(
-        specs.some((spec) => spec.startsWith('../client-utils/')),
+        specs.some((spec) => {
+          if (!spec.startsWith('.')) {
+            return false;
+          }
+          const target = resolve(dirname(join(dir, fileName)), spec);
+          const path = relative(clientUtilsDir, target);
+          return !path.startsWith('..') && !isAbsolute(path);
+        }),
         fileName,
       ).toBe(false);
     }

--- a/packages/waku/tests/router-client-core-surface.test.ts
+++ b/packages/waku/tests/router-client-core-surface.test.ts
@@ -179,9 +179,7 @@ describe('client utility boundaries', () => {
       }
       const src = readFileSync(join(dir, fileName), 'utf8');
       const specs = [
-        ...src.matchAll(
-          /(?:\bfrom\s+|\bimport\s*(?:\(\s*)?)["']([^"']+)["']/g,
-        ),
+        ...src.matchAll(/(?:\bfrom\s+|\bimport\s*(?:\(\s*)?)["']([^"']+)["']/g),
       ].map((match) => match[1]!);
       expect(
         specs.some((spec) => spec.startsWith('../client-utils/')),

--- a/packages/waku/tests/router-client-core-surface.test.ts
+++ b/packages/waku/tests/router-client-core-surface.test.ts
@@ -174,9 +174,10 @@ describe('client utility boundaries', () => {
   test('client-core-utils does not depend on client-utils', () => {
     const dir = join(routerSrc, 'client-core-utils');
     const clientUtilsDir = join(routerSrc, 'client-utils');
-    const fileNames = readdirSync(dir, { recursive: true }).filter((fileName) =>
-      /\.[cm]?[jt]sx?$/.test(fileName),
-    );
+    const fileNames = readdirSync(dir, {
+      encoding: 'utf8',
+      recursive: true,
+    }).filter((fileName) => /\.[cm]?[jt]sx?$/.test(fileName));
     expect(fileNames.length).toBeGreaterThan(0);
     for (const fileName of fileNames) {
       const src = readFileSync(join(dir, fileName), 'utf8');

--- a/packages/waku/tests/router-client-core-surface.test.ts
+++ b/packages/waku/tests/router-client-core-surface.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
@@ -167,5 +167,26 @@ describe('waku/router/client surface', () => {
     expect(clientCore.unstable_encodeRoutePath).toBe(
       client.unstable_encodeRoutePath,
     );
+  });
+});
+
+describe('client utility boundaries', () => {
+  test('client-core-utils does not depend on client-utils', () => {
+    const dir = join(routerSrc, 'client-core-utils');
+    for (const fileName of readdirSync(dir)) {
+      if (!/\.[cm]?[jt]sx?$/.test(fileName)) {
+        continue;
+      }
+      const src = readFileSync(join(dir, fileName), 'utf8');
+      const specs = [
+        ...src.matchAll(
+          /(?:\bfrom\s+|\bimport\s*(?:\(\s*)?)["']([^"']+)["']/g,
+        ),
+      ].map((match) => match[1]!);
+      expect(
+        specs.some((spec) => spec.startsWith('../client-utils/')),
+        fileName,
+      ).toBe(false);
+    }
   });
 });

--- a/packages/waku/tests/router-client.test.tsx
+++ b/packages/waku/tests/router-client.test.tsx
@@ -37,16 +37,14 @@ import {
   useMergeElements_UNSTABLE as useMergeElements,
 } from '../src/minimal/client.js';
 import * as routerCaches from '../src/router/client-core-utils/caches.js';
-import {
-  clearCaches,
-  clearRegisteredLazySlices,
-} from '../src/router/client-core-utils/caches.js';
+import { clearCaches } from '../src/router/client-core-utils/caches.js';
 import {
   RouterHostContext,
   useRouterHost,
 } from '../src/router/client-core-utils/host.js';
 import { PREFETCH_LIMIT } from '../src/router/client-core-utils/prefetch-cache.js';
 import {
+  clearRegisteredLazySlices,
   fetchSlice,
   getInFlightSliceCount,
   resetSliceFetches,

--- a/packages/waku/tests/router-instant-navigation.test.ts
+++ b/packages/waku/tests/router-instant-navigation.test.ts
@@ -1,0 +1,51 @@
+/** @vitest-environment happy-dom */
+import { describe, expect, test } from 'vitest';
+import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
+import {
+  canPaintInstantOverlay,
+  pinForSwr,
+} from '../src/router/client-utils/instant-navigation.js';
+import { ROUTER_STATE_ID } from '../src/router/client-utils/router-state.js';
+import {
+  HAS404_ID,
+  IS_STATIC_ID,
+  ROUTE_ID,
+  getRouteSlotId,
+} from '../src/router/isomorphic-utils/route-path.js';
+
+const immutable = (slotId: string) => ({
+  [ETAG_ID_PREFIX + slotId]: IMMUTABLE_ETAG,
+});
+
+describe('canPaintInstantOverlay', () => {
+  const route = { path: '/a', query: '', hash: '' };
+
+  test('uses an immutable route shell only on the first attempt', () => {
+    const elements = immutable(getRouteSlotId(route.path));
+    expect(canPaintInstantOverlay(0, route, elements)).toBe(true);
+    expect(canPaintInstantOverlay(1, route, elements)).toBe(false);
+  });
+});
+
+describe('pinForSwr', () => {
+  test('pins meta keys and immutable slots, not mutable ones', () => {
+    const pin = pinForSwr(() => immutable('layout:/'));
+    expect(pin(ROUTE_ID)).toBe(true);
+    expect(pin(HAS404_ID)).toBe(true);
+    expect(pin(IS_STATIC_ID)).toBe(true);
+    // a legacy-style prefix is not meta; only the exact IS_STATIC key is
+    expect(pin(`${IS_STATIC_ID}:layout:/`)).toBe(false);
+    // the client's own state rides the merge instead of becoming a hole
+    expect(pin(ROUTER_STATE_ID)).toBe(true);
+    expect(pin('layout:/')).toBe(true);
+    expect(pin('page:/a')).toBe(false);
+  });
+
+  test('reads the resolved elements at call time', () => {
+    let resolved: Record<string, unknown> = {};
+    const pin = pinForSwr(() => resolved);
+    expect(pin('layout:/')).toBe(false);
+    resolved = immutable('layout:/');
+    expect(pin('layout:/')).toBe(true);
+  });
+});

--- a/packages/waku/tests/router-route-state-hooks.test.tsx
+++ b/packages/waku/tests/router-route-state-hooks.test.tsx
@@ -25,6 +25,7 @@ import {
 import * as slice from '../src/router/client-core-utils/slice.js';
 import {
   clearRegisteredLazySlices,
+  forEachRegisteredLazySlice,
   registerLazySlice,
 } from '../src/router/client-core-utils/slice.js';
 import {
@@ -171,6 +172,14 @@ describe('useHmrRefetch', () => {
     (
       globalThis as { __WAKU_RSC_RELOAD_LISTENERS__?: (() => void)[] }
     ).__WAKU_RSC_RELOAD_LISTENERS__ = [];
+  });
+
+  test('cache clearing preserves lazy-slice registrations', () => {
+    registerLazySlice('slice-a');
+    clearCaches();
+    const ids: string[] = [];
+    forEachRegisteredLazySlice((id) => ids.push(id));
+    expect(ids).toEqual(['slice-a']);
   });
 
   test('clears caches then refetches the settled route and lazy slices', async () => {

--- a/packages/waku/tests/router-route-state-hooks.test.tsx
+++ b/packages/waku/tests/router-route-state-hooks.test.tsx
@@ -16,17 +16,17 @@ import {
 import * as minimalClient from '../src/minimal/client.js';
 import { INTERNAL_ServerRoot } from '../src/minimal/client.js';
 import * as caches from '../src/router/client-core-utils/caches.js';
+import { clearCaches } from '../src/router/client-core-utils/caches.js';
+import { useHmrRefetch } from '../src/router/client-core-utils/hmr.js';
 import {
-  clearCaches,
-  clearRegisteredLazySlices,
-  registerLazySlice,
-} from '../src/router/client-core-utils/caches.js';
-import {
-  useHmrRefetch,
   useInitialRoute,
   useInitialRscParams,
-} from '../src/router/client-core-utils/route-state-hooks.js';
+} from '../src/router/client-core-utils/initial-route.js';
 import * as slice from '../src/router/client-core-utils/slice.js';
+import {
+  clearRegisteredLazySlices,
+  registerLazySlice,
+} from '../src/router/client-core-utils/slice.js';
 import {
   ROUTE_ID,
   encodeRoutePath,

--- a/packages/waku/tests/router-scroll.test.ts
+++ b/packages/waku/tests/router-scroll.test.ts
@@ -5,7 +5,7 @@ import {
   scrollToHash,
   shouldScrollByDefault,
   shouldScrollForRouteChange,
-} from '../src/router/client-core-utils/scroll.js';
+} from '../src/router/client-utils/scroll.js';
 
 beforeEach(() => {
   vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/');

--- a/packages/waku/tests/router-state.test.ts
+++ b/packages/waku/tests/router-state.test.ts
@@ -1,16 +1,13 @@
 /** @vitest-environment happy-dom */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { ETAG_ID_PREFIX, IMMUTABLE_ETAG } from '../src/lib/utils/etags.js';
 import {
   ROUTER_STATE_ID,
   getRouterState,
   getSettledRoute,
   makeRouterState,
-  pinForSwr,
   resolveServerRedirect,
 } from '../src/router/client-utils/router-state.js';
 import {
-  HAS404_ID,
   IS_STATIC_ID,
   ROUTE_ID,
 } from '../src/router/isomorphic-utils/route-path.js';
@@ -222,32 +219,5 @@ describe('getSettledRoute', () => {
     );
 
     expect(getSettledRoute(elements, fallback)).toEqual(settledRoute);
-  });
-});
-
-describe('pinForSwr', () => {
-  const immutable = (slotId: string) => ({
-    [ETAG_ID_PREFIX + slotId]: IMMUTABLE_ETAG,
-  });
-
-  test('pins meta keys and immutable slots, not mutable ones', () => {
-    const pin = pinForSwr(() => immutable('layout:/'));
-    expect(pin(ROUTE_ID)).toBe(true);
-    expect(pin(HAS404_ID)).toBe(true);
-    expect(pin(IS_STATIC_ID)).toBe(true);
-    // a legacy-style prefix is not meta; only the exact IS_STATIC key is
-    expect(pin(`${IS_STATIC_ID}:layout:/`)).toBe(false);
-    // the client's own state rides the merge instead of becoming a hole
-    expect(pin(ROUTER_STATE_ID)).toBe(true);
-    expect(pin('layout:/')).toBe(true);
-    expect(pin('page:/a')).toBe(false);
-  });
-
-  test('reads the resolved elements at call time', () => {
-    let resolved: Record<string, unknown> = {};
-    const pin = pinForSwr(() => resolved);
-    expect(pin('layout:/')).toBe(false);
-    resolved = immutable('layout:/');
-    expect(pin('layout:/')).toBe(true);
   });
 });


### PR DESCRIPTION
Keep router cache state direct and move lazy-slice bookkeeping beside Slice. Separate initial route and HMR hooks, and keep scroll and instant helpers in the history binding.