### PR TITLE
docs: avoid createPages type inference cycle

### DIFF
--- a/docs/create-pages.mdx
+++ b/docs/create-pages.mdx
@@ -310,19 +310,18 @@ declare module 'waku/router' {
   interface RouteConfig {
     paths: PathsForPages<typeof pages>;
   }
-  interface CreatePagesConfig {
-    pages: typeof pages;
-  }
 }
 
 export default adapter(pages);
 ```
 
-Once this is done, any `<Link />` component or hook from `waku/router` that uses paths in your app will use this type. In this case, the one valid use would be `<Link to="/" />`, but as you add more pages to the router, this type will grow to include them.
+Once this is done, string navigation targets use the inferred paths. In this case, the one valid use would be `<Link to="/" />`, but as you add more pages to the router, this type will grow to include them.
 
 #### PageProps
 
-The `PageProps` type gives you type safety for the path and slug parameters in your pages.
+The `PageProps` type derives the page path and slug parameter types.
+
+With `createPages`, structured navigation targets such as `<Link to={{ to: '/missing' }} />` and route-pattern APIs such as `PageProps` and `useParams_UNSTABLE` are not checked against the route table. Augmenting `CreatePagesConfig` with `typeof pages` can create a circular type dependency through the page components.
 
 ```tsx
 // ./src/templates/about-page.tsx

--- a/docs/create-pages.mdx
+++ b/docs/create-pages.mdx
@@ -317,19 +317,7 @@ export default adapter(pages);
 
 Once this is done, string navigation targets use the inferred paths. In this case, the one valid use would be `<Link to="/" />`, but as you add more pages to the router, this type will grow to include them.
 
-This does not check structured navigation targets or route-pattern APIs against the route table. Structured targets still infer their parameters from the supplied pattern, but a pattern such as `{ to: '/missing' }` is accepted. The same applies to `PageProps` and `useParams_UNSTABLE`.
-
-Do not add the following augmentation:
-
-```tsx
-declare module 'waku/router' {
-  interface CreatePagesConfig {
-    pages: typeof pages;
-  }
-}
-```
-
-A manual `createPages` table contains the page components, so using `PageProps` in one imported module and typed navigation in another creates a circular type dependency through that table. The file-system router can safely provide this augmentation because its generated type table contains only route metadata.
+This does not check structured navigation targets against the route table. Structured targets still infer their parameters from the supplied pattern, but `<Link to={{ to: '/missing' }} />` is accepted.
 
 #### PageProps
 
@@ -344,6 +332,18 @@ export const AboutPage = ({ foo }: PageProps<'/about/[foo]'>) => {
   return <>{/* ...*/}</>;
 };
 ```
+
+The route patterns passed to `PageProps` and `useParams_UNSTABLE` are not checked against the route table. Do not add the following augmentation:
+
+```tsx
+declare module 'waku/router' {
+  interface CreatePagesConfig {
+    pages: typeof pages;
+  }
+}
+```
+
+A manual `createPages` table contains the page components, so using `PageProps` in one imported module and `<Link>` in another creates a circular type dependency through that table. The file-system router can safely provide this augmentation because its generated type table contains only route metadata.
 
 ### Layouts
 

--- a/docs/create-pages.mdx
+++ b/docs/create-pages.mdx
@@ -317,11 +317,23 @@ export default adapter(pages);
 
 Once this is done, string navigation targets use the inferred paths. In this case, the one valid use would be `<Link to="/" />`, but as you add more pages to the router, this type will grow to include them.
 
+This does not check structured navigation targets or route-pattern APIs against the route table. Structured targets still infer their parameters from the supplied pattern, but a pattern such as `{ to: '/missing' }` is accepted. The same applies to `PageProps` and `useParams_UNSTABLE`.
+
+Do not add the following augmentation:
+
+```tsx
+declare module 'waku/router' {
+  interface CreatePagesConfig {
+    pages: typeof pages;
+  }
+}
+```
+
+A manual `createPages` table contains the page components, so using `PageProps` in one imported module and typed navigation in another creates a circular type dependency through that table. The file-system router can safely provide this augmentation because its generated type table contains only route metadata.
+
 #### PageProps
 
 The `PageProps` type derives the page path and slug parameter types.
-
-With `createPages`, structured navigation targets such as `<Link to={{ to: '/missing' }} />` and route-pattern APIs such as `PageProps` and `useParams_UNSTABLE` are not checked against the route table. Augmenting `CreatePagesConfig` with `typeof pages` can create a circular type dependency through the page components.
 
 ```tsx
 // ./src/templates/about-page.tsx

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -606,9 +606,6 @@ declare module 'waku/router' {
   interface RouteConfig {
     paths: PathsForPages<typeof pages>;
   }
-  interface CreatePagesConfig {
-    pages: typeof pages;
-  }
 }
 
 export default adapter(pages);

--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -21,9 +21,14 @@ export interface RouteConfig {
   // routes to be overridden by users
 }
 
-export interface CreatePagesConfig {
-  // routes to be overridden by users
-}
+/**
+ * Route metadata used by page, layout, and structured navigation types.
+ *
+ * The file-system router augments this from generated metadata. Manual
+ * augmentations must not refer to a `createPages` result because it includes
+ * component types and can create circular inference.
+ */
+export interface CreatePagesConfig {}
 
 export interface SearchCodecsConfig {
   // route path -> search codec, to be overridden by users (or fs-router typegen)

--- a/packages/waku/tests/create-pages-types.test.ts
+++ b/packages/waku/tests/create-pages-types.test.ts
@@ -1,0 +1,31 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { test } from 'vitest';
+
+const formatHost: ts.FormatDiagnosticsHost = {
+  getCanonicalFileName: (fileName) => fileName,
+  getCurrentDirectory: ts.sys.getCurrentDirectory,
+  getNewLine: () => ts.sys.newLine,
+};
+
+test('createPages route types compile without circular inference', () => {
+  const configPath = fileURLToPath(
+    new URL('./fixtures/create-pages-types/tsconfig.json', import.meta.url),
+  );
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (config.error) {
+    throw new Error(ts.formatDiagnostic(config.error, formatHost));
+  }
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    dirname(configPath),
+  );
+  const diagnostics = ts.getPreEmitDiagnostics(
+    ts.createProgram(parsed.fileNames, parsed.options),
+  );
+  if (diagnostics.length) {
+    throw new Error(ts.formatDiagnostics(diagnostics, formatHost));
+  }
+});

--- a/packages/waku/tests/create-pages-types.test.ts
+++ b/packages/waku/tests/create-pages-types.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
@@ -10,6 +11,10 @@ const formatHost: ts.FormatDiagnosticsHost = {
 };
 
 test('createPages route types compile without circular inference', () => {
+  const mainDts = fileURLToPath(new URL('../dist/main.d.ts', import.meta.url));
+  if (!existsSync(mainDts)) {
+    throw new Error('Run `pnpm -F waku run compile` before this test.');
+  }
   const configPath = fileURLToPath(
     new URL('./fixtures/create-pages-types/tsconfig.json', import.meta.url),
   );
@@ -22,6 +27,9 @@ test('createPages route types compile without circular inference', () => {
     ts.sys,
     dirname(configPath),
   );
+  if (parsed.errors.length) {
+    throw new Error(ts.formatDiagnostics(parsed.errors, formatHost));
+  }
   const diagnostics = ts.getPreEmitDiagnostics(
     ts.createProgram(parsed.fileNames, parsed.options),
   );

--- a/packages/waku/tests/fixtures/create-pages-types/src/not-found-page.tsx
+++ b/packages/waku/tests/fixtures/create-pages-types/src/not-found-page.tsx
@@ -1,0 +1,9 @@
+import { Link } from 'waku';
+
+export const NotFoundPage = () => (
+  <p>
+    <Link to="/">Home</Link>
+    {/* @ts-expect-error unknown route */}
+    <Link to="/missing">Missing</Link>
+  </p>
+);

--- a/packages/waku/tests/fixtures/create-pages-types/src/post-page.tsx
+++ b/packages/waku/tests/fixtures/create-pages-types/src/post-page.tsx
@@ -1,3 +1,7 @@
 import type { PageProps } from 'waku/router';
 
-export const PostPage = ({ id }: PageProps<'/posts/[id]'>) => <p>{id}</p>;
+export const PostPage = (props: PageProps<'/posts/[id]'>) => {
+  // @ts-expect-error the route has no slug named "missing"
+  void props.missing;
+  return <p>{props.id}</p>;
+};

--- a/packages/waku/tests/fixtures/create-pages-types/src/post-page.tsx
+++ b/packages/waku/tests/fixtures/create-pages-types/src/post-page.tsx
@@ -1,0 +1,3 @@
+import type { PageProps } from 'waku/router';
+
+export const PostPage = ({ id }: PageProps<'/posts/[id]'>) => <p>{id}</p>;

--- a/packages/waku/tests/fixtures/create-pages-types/src/waku.server.tsx
+++ b/packages/waku/tests/fixtures/create-pages-types/src/waku.server.tsx
@@ -1,0 +1,31 @@
+import { createPages } from 'waku';
+import adapter from 'waku/adapters/default';
+import type { PathsForPages } from 'waku/router';
+import { NotFoundPage } from './not-found-page.js';
+import { PostPage } from './post-page.js';
+
+const pages = createPages(async ({ createPage }) => [
+  createPage({
+    render: 'dynamic',
+    path: '/',
+    component: () => <p>Home</p>,
+  }),
+  createPage({
+    render: 'dynamic',
+    path: '/posts/[id]',
+    component: PostPage,
+  }),
+  createPage({
+    render: 'static',
+    path: '/404',
+    component: NotFoundPage,
+  }),
+]);
+
+declare module 'waku/router' {
+  interface RouteConfig {
+    paths: PathsForPages<typeof pages>;
+  }
+}
+
+export default adapter(pages);

--- a/packages/waku/tests/fixtures/create-pages-types/tsconfig.json
+++ b/packages/waku/tests/fixtures/create-pages-types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/waku/tests/tsconfig.json
+++ b/packages/waku/tests/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": ["."],
+  "exclude": ["dist", "fixtures/create-pages-types"],
   "references": [
     {
       "path": ".."

--- a/packages/waku/tests/tsconfig.json
+++ b/packages/waku/tests/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": ["."],
-  "exclude": ["node_modules", "dist", "fixtures/create-pages-types"],
+  "exclude": ["dist", "fixtures/create-pages-types"],
   "references": [
     {
       "path": ".."

--- a/packages/waku/tests/tsconfig.json
+++ b/packages/waku/tests/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": ["."],
-  "exclude": ["dist", "fixtures/create-pages-types"],
+  "exclude": ["node_modules", "dist", "fixtures/create-pages-types"],
   "references": [
     {
       "path": ".."


### PR DESCRIPTION
Remove the circular CreatePagesConfig augmentation from the documented setup.

Add a compile-only fixture that keeps links typed while PageProps remains usable.

close #2282