### PR TITLE
fix(core): avoid blank no-SSR not-found pages with patching `react-dom`

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -853,6 +853,17 @@ test.describe(`create-pages`, () => {
     ).toBeVisible();
   });
 
+  test('no ssr not found with a layout stylesheet', async ({ page }) => {
+    await page.goto(`http://localhost:${port}/no-ssr-not-found`);
+    await expect(
+      page.getByRole('heading', { name: 'Not Found', exact: true }),
+    ).toBeVisible();
+    await expect(page.locator('body')).toHaveCSS(
+      'background-color',
+      'rgb(254, 254, 254)',
+    );
+  });
+
   test('slices with render=dynamic', async ({ page }) => {
     await page.goto(`http://localhost:${port}/slices`);
     await waitForHydration(page);

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -2,7 +2,11 @@ import { readFile } from 'node:fs/promises';
 import { Slice } from 'waku';
 import adapter from 'waku/adapters/default';
 import type { PathsForPages } from 'waku/router';
-import { createPages, unstable_redirect as redirect } from 'waku/router/server';
+import {
+  createPages,
+  unstable_notFound as notFound,
+  unstable_redirect as redirect,
+} from 'waku/router/server';
 import { DeeplyNestedLayout } from './components/DeeplyNestedLayout.js';
 import DynamicLayout from './components/DynamicLayout.js';
 import ErrorPage from './components/ErrorPage.js';
@@ -534,6 +538,13 @@ const pages: ReturnType<typeof createPages> = createPages(
       render: 'dynamic',
       path: '/no-ssr-server-only',
       component: () => <h2>No SSR Server Only</h2>,
+      unstable_disableSSR: true,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/no-ssr-not-found',
+      component: () => notFound(),
       unstable_disableSSR: true,
     }),
 

--- a/packages/waku/src/lib/vite-plugins/combined-plugins.ts
+++ b/packages/waku/src/lib/vite-plugins/combined-plugins.ts
@@ -11,6 +11,7 @@ import { extraPlugins } from './extra-plugins.js';
 import { fsRouterTypegenPlugin } from './fs-router-typegen.js';
 import { htmlShellPlugin } from './html-shell.js';
 import { notFoundPlugin } from './not-found.js';
+import { patchReactDomPlugin } from './patch-react-dom.js';
 import { patchRsdwPlugin } from './patch-rsdw.js';
 import { privateDirPlugin } from './private-dir.js';
 import { rscDevtoolsPlugin } from './rsc-devtools.js';
@@ -54,6 +55,7 @@ export function combinedPlugins(config: Required<Config>): PluginOption {
     virtualConfigPlugin(config),
     adapterAliasPlugin(config),
     notFoundPlugin(),
+    patchReactDomPlugin(),
     patchRsdwPlugin(),
     buildMetadataPlugin(config),
     staticBuildPlugin(config),

--- a/packages/waku/src/lib/vite-plugins/patch-react-dom.ts
+++ b/packages/waku/src/lib/vite-plugins/patch-react-dom.ts
@@ -1,0 +1,26 @@
+import type { Plugin } from 'vite';
+
+// React 19.2 can wait on a stylesheet preload detached by an abandoned render.
+// Remove this patch after Waku's minimum React version handles that case.
+const SEARCH = '(hoistableRoot = resource.state.preload) &&';
+const REPLACE = SEARCH + ' hoistableRoot.isConnected &&';
+
+const isReactDomClient = (id: string) =>
+  /[/\\](?:react-dom-client\.(?:development|production)|react-dom_client)\.js$/.test(
+    id.split('?')[0]!,
+  );
+
+export const patchReactDomPlugin = (): Plugin => ({
+  name: 'waku:vite-plugins:patch-react-dom',
+  enforce: 'pre',
+  transform(code, id) {
+    if (!isReactDomClient(id)) {
+      return;
+    }
+    const patched = code.replace(SEARCH, REPLACE);
+    if (patched === code) {
+      return;
+    }
+    return patched;
+  },
+});

--- a/packages/waku/tests/vite-plugin-patch-react-dom.test.ts
+++ b/packages/waku/tests/vite-plugin-patch-react-dom.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { expect, test } from 'vitest';
+import { patchReactDomPlugin } from '../src/lib/vite-plugins/patch-react-dom.js';
+
+const require = createRequire(import.meta.url);
+
+const runTransform = async (code: string, id: string) => {
+  const plugin = patchReactDomPlugin();
+  if (typeof plugin.transform !== 'function') {
+    throw new Error('Plugin transform is not defined');
+  }
+  return plugin.transform.call({} as never, code, id);
+};
+
+test('patches the optimized React DOM client', async () => {
+  const output = await runTransform(
+    '(hoistableRoot = resource.state.preload) && check();',
+    '/tmp/react-dom_client.js?v=123',
+  );
+  expect(output).toContain(
+    '(hoistableRoot = resource.state.preload) && hoistableRoot.isConnected &&',
+  );
+});
+
+test.each(['development', 'production'])(
+  'patches the installed React DOM %s client',
+  async (mode) => {
+    const packagePath = require.resolve('react-dom/package.json');
+    const id = join(dirname(packagePath), 'cjs', `react-dom-client.${mode}.js`);
+    const code = readFileSync(id, 'utf8');
+    const output = await runTransform(code, id);
+    expect(output).toContain(
+      '(hoistableRoot = resource.state.preload) && hoistableRoot.isConnected &&',
+    );
+  },
+);
+
+test('skips unrelated files', async () => {
+  const output = await runTransform(
+    '(hoistableRoot = resource.state.preload) && check();',
+    '/tmp/unrelated.js',
+  );
+  expect(output).toBeUndefined();
+});


### PR DESCRIPTION
Ignore detached React stylesheet preloads when an abandoned render retries.

Keep stylesheet precedence and split-style ordering unchanged.

close #2281