### PR TITLE
fix(e2e): preserve RSC server asset URLs

### DIFF
--- a/e2e/fixtures/rsc-asset/waku.config.ts
+++ b/e2e/fixtures/rsc-asset/waku.config.ts
@@ -20,9 +20,12 @@ function importMetaUrlServerPlugin(): VitePlugin {
   // https://github.com/vitejs/vite/blob/0f56e1724162df76fffd5508148db118767ebe32/packages/vite/src/node/plugins/assetImportMetaUrl.ts#L51-L52
   const assetImportMetaUrlRE =
     /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/dg;
+  const referenceIds = new Set<string>();
 
   return {
     name: 'test-server-asset',
+    // Vite's resolveFileUrl always returns, so this plugin must run first.
+    enforce: 'pre',
     transform(code, id) {
       return code.replace(assetImportMetaUrlRE, (s, match) => {
         const absPath = path.resolve(path.dirname(id), match.slice(1, -1));
@@ -32,10 +35,17 @@ function importMetaUrlServerPlugin(): VitePlugin {
             name: path.basename(absPath),
             source: new Uint8Array(fs.readFileSync(absPath)),
           });
+          referenceIds.add(referenceId);
           return `new URL(import.meta.ROLLUP_FILE_URL_${referenceId})`;
         }
         return s;
       });
     },
-  };
+    resolveFileUrl(options: { referenceId: string; relativePath: string }) {
+      if (!referenceIds.has(options.referenceId)) {
+        return null;
+      }
+      return `new URL(${JSON.stringify(options.relativePath)}, import.meta.url).href`;
+    },
+  } as VitePlugin;
 }


### PR DESCRIPTION
Resolve server assets relative to the emitted chunk with newer Vite versions.

Keep browser asset URLs handled by Vite.

Resolve server assets relative to the emitted chunk with newer Vite versions.
Keep browser asset URLs handled by Vite.

## Background

`e2e/fixtures/rsc-asset` covers asset references originating inside an RSC, in
two directions that have to resolve differently within the same `rsc`
environment:

- `new URL('./test-server.txt', import.meta.url)` + `readFileSync` needs a URL
  the Node process can open on disk, relative to the emitted chunk.
- `./test-client.txt?no-inline` rendered as an `<a href>` needs a public URL the
  browser can fetch (`/assets/...`).

Vite doesn't handle `new URL(..., import.meta.url)` for SSR, so the fixture ships
its own plugin that rewrites the call into `this.emitFile()` +
`new URL(import.meta.ROLLUP_FILE_URL_<id>)`. That relied on Rollup's default
`resolveFileUrl`, which produces `new URL('./x', import.meta.url).href`.

vitejs/vite#22888 ("use `import.meta.ROLLDOWN_FILE_URL_*` for assets in JS")
added a `resolveFileUrl` hook to `vite:asset`. It was written for Vite's own
emitters, but `resolveFileUrl` is a global Rollup hook, so it also intercepts
references emitted by user plugins. Those have no `asFileUrl` metadata attached,
so they fall through to `toOutputFilePathInJS`, which for a server-consumer
environment always returns a base-joined path.

The fixture's server chunk therefore built as:

```js
const testServerTxtUrl = new URL("/assets/test-server-BTC3QXxI.txt");
```

`new URL()` on a root-relative path with no base throws, so the RSC render failed
with `TypeError: Invalid URL`, `data-testid="server-file"` never rendered, and
`[chromium-prd] rsc-asset › basic` timed out. The client `?no-inline` half was
unaffected. Failing job: <CI job URL>

## This change

The plugin implements its own `resolveFileUrl`, scoped to the reference IDs it
emitted, and returns `null` for everything else so Vite continues to handle
browser asset URLs. `enforce: 'pre'` is required because `resolveFileUrl` is a
*first* hook and `vite:asset` is registered ahead of normal user plugins, so
without it the hook is never consulted.

Whether Vite intends to intercept third-party file references is a question for
upstream; this fixture works either way, since its hook returns first.