### PR TITLE
fix(vite-plugins): keep a Flight wake-up that lands during a render

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -305,6 +305,27 @@ test.describe(`create-pages`, () => {
     await expect(page.locator('body')).not.toContainText('getRerender');
   });
 
+  // wakujs/waku#2288: the rerendered page suspends inside a Suspense boundary
+  // that is already showing content, and a row lands while React is yielding
+  // on it (the fixture's fetch enhancer arranges that). React 19.2 drops the
+  // wake-up for that row, so without the patch the old elements stay on
+  // screen even though the action returned the new ones.
+  test('server action rerender survives a layout-first stream', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${port}/rerender-layout-first`);
+    await waitForHydration(page);
+    const count = page.getByTestId('rerender-order-count');
+    await expect(count).toHaveText(/^count: \d+$/);
+    for (let i = 0; i < 3; i++) {
+      const before = Number(
+        (await count.textContent())!.slice('count: '.length),
+      );
+      await page.getByRole('button', { name: 'Bump layout-first' }).click();
+      await expect(count).toHaveText(`count: ${before + 1}`);
+    }
+  });
+
   test('server action rerenders route without js', async ({ browser }) => {
     const context = await browser.newContext({
       javaScriptEnabled: false,

--- a/e2e/fixtures/create-pages/src/components/RerenderOrder.tsx
+++ b/e2e/fixtures/create-pages/src/components/RerenderOrder.tsx
@@ -1,0 +1,71 @@
+import { Suspense } from 'react';
+import type { ReactNode } from 'react';
+import { getRerenderOrderCount } from './rerender-order-store.js';
+import {
+  RerenderOrderBoundary,
+  RerenderOrderForm,
+  RerenderOrderTrigger,
+} from './RerenderOrderClient.js';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const createRerenderOrderLayout = (delay: number) => {
+  const Layout = async ({ children }: { children: ReactNode }) => {
+    if (delay) {
+      await sleep(delay);
+    }
+    return (
+      <div>
+        <h2>Rerender Order Layout ({delay}ms)</h2>
+        {children}
+      </div>
+    );
+  };
+  return Layout;
+};
+
+// An async component streams as its own lazy row after the content that
+// references it.
+const Row = async ({ index }: { index: number }) => {
+  await sleep(index);
+  return <li>{`row ${index}`}</li>;
+};
+
+const SlowContent = async ({
+  mode,
+  delay,
+}: {
+  mode: string;
+  delay: number;
+}) => {
+  await sleep(delay);
+  return (
+    <div>
+      <p data-testid="rerender-order-count">{`count: ${getRerenderOrderCount(mode)}`}</p>
+      <RerenderOrderForm mode={mode} />
+      <RerenderOrderTrigger />
+      <ul>
+        {Array.from({ length: 5 }, (_, i) => (
+          <Row key={i} index={i + 1} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export const createRerenderOrderPage = (mode: string, delay: number) => {
+  const Page = async () => {
+    await sleep(10);
+    return (
+      <div>
+        <h3>Rerender Order Page</h3>
+        <RerenderOrderBoundary>
+          <Suspense key="1" fallback={<p>loading...</p>}>
+            <SlowContent mode={mode} delay={delay} />
+          </Suspense>
+        </RerenderOrderBoundary>
+      </div>
+    );
+  };
+  return Page;
+};

--- a/e2e/fixtures/create-pages/src/components/RerenderOrderClient.tsx
+++ b/e2e/fixtures/create-pages/src/components/RerenderOrderClient.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Component } from 'react';
+import type { ReactNode } from 'react';
+import { unstable_registerFetchEnhancer } from 'waku/minimal/client';
+import { bumpRerenderOrder } from './funcs.js';
+
+declare global {
+  interface Window {
+    __rerenderOrderRelease?: () => void;
+  }
+}
+
+// wakujs/waku#2288 needs a Flight row to land while React is yielding on it.
+// Hold back the rows that follow the page content and let the component
+// rendered just before them release the first one in a microtask: React has
+// already suspended on that row by then, and it resumes in a later task.
+if (typeof window !== 'undefined') {
+  const encoder = new TextEncoder();
+  unstable_registerFetchEnhancer((fetchFn) => async (input, init) => {
+    const response = await fetchFn(input, init);
+    if (!String(input).includes('bumpRerenderOrder')) {
+      return response;
+    }
+    const lines = (await response.text()).split('\n');
+    const gateAfter = lines.findIndex((line) =>
+      line.includes('rerender-order-count'),
+    );
+    const held = lines.splice(gateAfter + 1);
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+        c.enqueue(encoder.encode(lines.join('\n') + '\n'));
+      },
+    });
+    const release = () => {
+      const line = held.shift();
+      if (line !== undefined) {
+        controller.enqueue(encoder.encode(line + '\n'));
+      }
+      if (!held.length) {
+        controller.close();
+        delete window.__rerenderOrderRelease;
+      }
+    };
+    window.__rerenderOrderRelease = release;
+    // the rest of the response has to arrive eventually
+    setTimeout(() => {
+      while (window.__rerenderOrderRelease) {
+        release();
+      }
+    }, 100);
+    return new Response(stream, response);
+  });
+}
+
+export const RerenderOrderTrigger = () => {
+  if (typeof window !== 'undefined') {
+    queueMicrotask(() => window.__rerenderOrderRelease?.());
+  }
+  return null;
+};
+
+export class RerenderOrderBoundary extends Component<
+  { children: ReactNode },
+  { error: unknown }
+> {
+  state = { error: null as unknown };
+  static getDerivedStateFromError(error: unknown) {
+    return { error };
+  }
+  render() {
+    if (this.state.error) {
+      return <p>error: {String(this.state.error)}</p>;
+    }
+    return this.props.children;
+  }
+}
+
+export const RerenderOrderForm = ({ mode }: { mode: string }) => {
+  const bump = bumpRerenderOrder.bind(null, mode);
+  return (
+    <form action={bump}>
+      <button type="submit">Bump {mode}</button>
+    </form>
+  );
+};

--- a/e2e/fixtures/create-pages/src/components/funcs.ts
+++ b/e2e/fixtures/create-pages/src/components/funcs.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { unstable_rerenderRoute } from 'waku/router/server';
+import { incrementRerenderOrderCount } from './rerender-order-store.js';
 
 const PAGES = ['/nested/foo', '/nested/bar', '/nested/aaa', '/nested/bbb'];
 
@@ -19,4 +20,10 @@ export const throws = async (input: string): Promise<string> => {
     throw new Error('Input is required');
   }
   return input;
+};
+
+// wakujs/waku#2288
+export const bumpRerenderOrder = async (mode: string) => {
+  incrementRerenderOrderCount(mode);
+  unstable_rerenderRoute(`/rerender-${mode}`);
 };

--- a/e2e/fixtures/create-pages/src/components/rerender-order-store.ts
+++ b/e2e/fixtures/create-pages/src/components/rerender-order-store.ts
@@ -1,0 +1,8 @@
+// wakujs/waku#2288: module-level state shared by the page and the action
+const counts: Record<string, number> = {};
+
+export const getRerenderOrderCount = (mode: string) => counts[mode] ?? 0;
+
+export const incrementRerenderOrderCount = (mode: string) => {
+  counts[mode] = (counts[mode] ?? 0) + 1;
+};

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -24,6 +24,10 @@ import NoSsr from './components/NoSsr.js';
 import NoSsrDynamic from './components/NoSsrDynamic.js';
 import RedirectToSearchPage from './components/RedirectToSearchPage.js';
 import { RerenderActionPage } from './components/RerenderActionPage.js';
+import {
+  createRerenderOrderLayout,
+  createRerenderOrderPage,
+} from './components/RerenderOrder.js';
 import SearchPage from './components/SearchPage.js';
 import { Slice001 } from './components/slice001.js';
 import { Slice002 } from './components/slice002.js';
@@ -416,6 +420,29 @@ const pages: ReturnType<typeof createPages> = createPages(
       render: 'dynamic',
       path: '/rerender-action',
       component: RerenderActionPage,
+    }),
+
+    // wakujs/waku#2288: the layout slot streams before the page slot
+    createLayout({
+      render: 'dynamic',
+      path: '/rerender-layout-first',
+      component: createRerenderOrderLayout(0),
+    }),
+    createPage({
+      render: 'dynamic',
+      path: '/rerender-layout-first',
+      component: createRerenderOrderPage('layout-first', 30),
+    }),
+    // control: the page slot streams before the layout slot
+    createLayout({
+      render: 'dynamic',
+      path: '/rerender-page-first',
+      component: createRerenderOrderLayout(400),
+    }),
+    createPage({
+      render: 'dynamic',
+      path: '/rerender-page-first',
+      component: createRerenderOrderPage('page-first', 30),
     }),
 
     createLayout({

--- a/packages/waku/src/lib/vite-plugins/patch-react-dom.ts
+++ b/packages/waku/src/lib/vite-plugins/patch-react-dom.ts
@@ -2,8 +2,22 @@ import type { Plugin } from 'vite';
 
 // React 19.2 can wait on a stylesheet preload detached by an abandoned render.
 // Remove this patch after Waku's minimum React version handles that case.
-const SEARCH = '(hoistableRoot = resource.state.preload) &&';
-const REPLACE = SEARCH + ' hoistableRoot.isConnected &&';
+const PRELOAD_SEARCH = '(hoistableRoot = resource.state.preload) &&';
+const PRELOAD_REPLACE = PRELOAD_SEARCH + ' hoistableRoot.isConnected &&';
+
+// React 19.2 throws away a ping that arrives while the root is rendering, and
+// Flight produces exactly that: React's lazy path throws a chunk without
+// subscribing to it, so a row that lands while React is yielding leaves the
+// chunk in "resolved_model". React unwinds, marks the render as delayed and
+// only then attaches its ping listener, which Flight calls synchronously,
+// inside the render phase. The transition never re-renders, so a route
+// rerendered by a server action silently keeps the old elements. React main
+// records the pinged lanes instead of dropping the ping. Remove this patch
+// after Waku's minimum React version does the same.
+// https://github.com/wakujs/waku/issues/2288
+const PING_SEARCH =
+  /(\(executionContext & RenderContext\) === NoContext|0 === \(executionContext & 2\))\s*&&\s*(prepareFreshStack\(root, 0\))/;
+const PING_REPLACE = '$1 ? $2 : (workInProgressRootPingedLanes |= pingedLanes)';
 
 const isReactDomClient = (id: string) =>
   /[/\\](?:react-dom-client\.(?:development|production)|react-dom_client)\.js$/.test(
@@ -17,7 +31,9 @@ export const patchReactDomPlugin = (): Plugin => ({
     if (!isReactDomClient(id)) {
       return;
     }
-    const patched = code.replace(SEARCH, REPLACE);
+    const patched = code
+      .replace(PRELOAD_SEARCH, PRELOAD_REPLACE)
+      .replace(PING_SEARCH, PING_REPLACE);
     if (patched === code) {
       return;
     }

--- a/packages/waku/tests/vite-plugin-patch-react-dom.test.ts
+++ b/packages/waku/tests/vite-plugin-patch-react-dom.test.ts
@@ -37,6 +37,41 @@ test.each(['development', 'production'])(
   },
 );
 
+const PING_PATCHED =
+  '? prepareFreshStack(root, 0) : (workInProgressRootPingedLanes |= pingedLanes)';
+
+// wakujs/waku#2288
+test('records a ping that arrives during a render in the optimized client', async () => {
+  const output = await runTransform(
+    '? (executionContext & RenderContext) === NoContext && prepareFreshStack(root, 0) : workInProgressRootPingedLanes |= pingedLanes,',
+    '/tmp/react-dom_client.js?v=123',
+  );
+  expect(output).toContain(PING_PATCHED);
+});
+
+test.each(['development', 'production'])(
+  'records a ping that arrives during a render in the installed %s client',
+  async (mode) => {
+    const packagePath = require.resolve('react-dom/package.json');
+    const id = join(dirname(packagePath), 'cjs', `react-dom-client.${mode}.js`);
+    const code = readFileSync(id, 'utf8');
+    const output = await runTransform(code, id);
+    expect(output).toContain(PING_PATCHED);
+    expect(output).not.toContain('&& prepareFreshStack(root, 0)');
+  },
+);
+
+test('leaves a React that already records the pinged lanes alone', async () => {
+  const output = await runTransform(
+    `? (executionContext & RenderContext) === NoContext
+      ? prepareFreshStack(root, 0)
+      : (workInProgressRootPingedLanes |= pingedLanes)
+    : (workInProgressRootPingedLanes |= pingedLanes),`,
+    '/tmp/react-dom_client.js',
+  );
+  expect(output).toBeUndefined();
+});
+
 test('skips unrelated files', async () => {
   const output = await runTransform(
     '(hoistableRoot = resource.state.preload) && check();',


### PR DESCRIPTION
React's lazy path throws a Flight chunk without subscribing to it, so a row that arrives while React is yielding on that chunk leaves it in "resolved_model" — never initialized, never fulfilled. React unwinds, marks the render as delayed and only then attaches its ping listener, which Flight calls synchronously, inside the render phase. React 19.2 throws away a ping that arrives in that state, so the transition never re-renders: a route rerendered by a server action keeps the old elements even though the action returned the new ones, with nothing logged.

React main records the pinged lanes instead of dropping the ping. Apply that same change in patchReactDomPlugin, and delete it once the fix is in Waku's minimum React version — the test against the installed React fails when that happens.

The e2e fixture holds back the Flight rows that follow the page content and releases the first from a microtask queued while React renders that content, which reproduces the lost wake-up deterministically: the new test fails 5 of 5 against production builds without the patch and passes 5 of 5 with it. React 19.3.0-canary-d9f4e76b-20260903 passes it with no patch at all.

Fixes wakujs/waku#2288.
