### PR TITLE
feat(router): let middleware match a route without the RSC url shape

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,11 +150,18 @@ incomplete.
 - Comment why a branch exists, which invariant must be preserved, or which
   external behavior requires a workaround.
 - Do not restate names or repeat the same fact in multiple places.
+- Treat a cluster of inline comments as a design signal. If a function needs
+  several of them to be followed, name the constant, rename the binding, or
+  split the function. The comment is usually describing something the code
+  should say.
 - `TODO`, `FIXME`, and `HACK` are acceptable when they describe an unresolved
   issue. Remove them only when the issue is actually resolved.
 - Public APIs should have complete JSDoc suitable for editor documentation.
   Cover the behavior, parameters, return values, caveats, and examples needed to
-  use the API correctly. Public API documentation does not need to be short.
+  use the API correctly, in as few lines as that takes. A caller should be able
+  to read it in one pass. Explain what a caller must know, not how the
+  implementation arrives there. Documentation that grows past a screenful
+  usually means the API needs splitting rather than more prose.
 - Document non-obvious behavior and caveats without enumerating every edge case
   already captured by tests.
 - Public unstable APIs should have the same useful editor documentation as

--- a/docs/guides/redirect-maps.mdx
+++ b/docs/guides/redirect-maps.mdx
@@ -52,13 +52,16 @@ const redirectsMiddleware = (): MiddlewareHandler => async (c, next) => {
   const parsed = parseRouterRequest(c.req.raw);
   const destination =
     parsed?.type === 'route' ? redirects[parsed.path] : undefined;
-  if (destination) {
-    // Rebuilds the same kind of url, so client-side navigation gets a payload
-    // and a direct visit gets the page.
-    const location = formatRouterRequest(c.req.raw, destination);
+  // Rebuilds the same kind of url, so client-side navigation gets a payload
+  // and a direct visit gets the page. `null` means this request cannot be
+  // rewritten without losing state, so leave it alone.
+  const location = destination
+    ? formatRouterRequest(c.req.raw, destination)
+    : null;
+  if (location) {
     c.res = new Response(null, {
       status: 302,
-      headers: { location: location!.toString() },
+      headers: { location: location.toString() },
     });
     return;
   }

--- a/docs/guides/redirect-maps.mdx
+++ b/docs/guides/redirect-maps.mdx
@@ -14,19 +14,19 @@ This guide is for redirect maps that sit in front of the Waku server, such as mi
 When a Waku app uses the client router, a navigation usually fetches both:
 
 - the browser route, such as `/old`
-- the corresponding RSC payload route, such as `/RSC/R/old.txt`
+- the RSC payload for the same route, at a separate url
 
-If you want `/old` to behave like a redirect to `/new` even during client-side navigation, you usually need to redirect both paths.
+Both have to be redirected. If you redirect only `/old`, a direct visit works while client-side navigation still lands on the old route.
 
-With Waku's default config:
+Inside the app, `unstable_parseRouterRequest` reads either url as the route it addresses, and `unstable_formatRouterRequest` builds the matching url for the destination, so middleware never has to spell the RSC url out. Outside the app — a CDN or a hosting platform's redirect rules — there is no way to call into Waku, so those rules do have to name the url. With Waku's default config:
 
 - `basePath` is `/`
 - `rscBase` is `RSC`
 - the route `/old` maps to the RSC path `/RSC/R/old.txt`
 
-> The `/RSC/` file naming convention is [subject to change](https://github.com/wakujs/waku/discussions/929#discussioncomment-10825975) in future versions of Waku.
+> The `/RSC/` file naming convention is [subject to change](https://github.com/wakujs/waku/discussions/929#discussioncomment-10825975) in future versions of Waku. Prefer the middleware approach below, which does not depend on it.
 
-If you customize `basePath` or `rscBase`, adjust the redirect rules accordingly.
+If you customize `basePath` or `rscBase`, adjust any hand-written rules accordingly.
 
 For application-level redirects implemented inside Waku routes or server actions, see [Redirects and Not Found](/guides/redirects-and-not-found) instead. That is a separate use case from the redirect-map approach described here.
 
@@ -37,23 +37,28 @@ Create a new middleware file in `src/middleware/`. Waku automatically discovers 
 ```typescript
 // ./src/middleware/redirects.ts
 import type { MiddlewareHandler } from 'hono';
+import {
+  unstable_formatRouterRequest as formatRouterRequest,
+  unstable_parseRouterRequest as parseRouterRequest,
+} from 'waku/router/server';
+
+const redirects: Record<string, string> = {
+  '/old': '/new',
+  // ... add more redirects here
+};
 
 const redirectsMiddleware = (): MiddlewareHandler => async (c, next) => {
-  const url = new URL(c.req.raw.url);
-
-  // With the default Waku config, redirect both the browser route
-  // and the corresponding RSC payload route.
-  const redirects: Record<string, string> = {
-    '/old': '/new',
-    '/RSC/R/old.txt': '/RSC/R/new.txt',
-    // ... add more redirects here
-  };
-
-  if (url.pathname in redirects) {
-    url.pathname = redirects[url.pathname]!;
+  // Reads the browser route and the RSC payload request the same way.
+  const parsed = parseRouterRequest(c.req.raw);
+  const destination =
+    parsed?.type === 'route' ? redirects[parsed.path] : undefined;
+  if (destination) {
+    // Rebuilds the same kind of url, so client-side navigation gets a payload
+    // and a direct visit gets the page.
+    const location = formatRouterRequest(c.req.raw, destination);
     c.res = new Response(null, {
       status: 302,
-      headers: { location: url.toString() },
+      headers: { location: location!.toString() },
     });
     return;
   }
@@ -64,9 +69,15 @@ const redirectsMiddleware = (): MiddlewareHandler => async (c, next) => {
 export default redirectsMiddleware;
 ```
 
-This only handles the paths you explicitly match. If you redirect only `/old` and not `/RSC/R/old.txt`, direct requests may work while client-side navigation can still fail or land on the wrong state.
+Matching on `parsed.path` covers both requests with one entry per route, and keeps the redirect map readable as a list of routes.
+
+> In a production build the adapter serves statically generated files before middleware runs, so a middleware redirect does not fire for a route rendered with `render: 'static'`. Redirect those from the hosting environment instead, or make the route dynamic.
+
+Note the `type` check: a server action is dispatched by function id and carries no route, so it can never be matched by a path rule. That is a limitation of any path-based rule, not of this helper — see [Authentication](/guides/integrations/authentication) for where to put checks that must not be bypassed.
 
 ### Redirect via hosting environment
+
+A redirect map outside the app cannot call into Waku, so these rules name both urls explicitly and depend on the `/RSC/` convention noted above.
 
 This very much depends on the hosting environment you are using. For example, on [Vercel](https://vercel.com/docs/projects/project-configuration#redirects) you can use the `vercel.json` file to define redirects.
 

--- a/docs/guides/redirect-maps.mdx
+++ b/docs/guides/redirect-maps.mdx
@@ -73,7 +73,7 @@ Matching on `parsed.path` covers both requests with one entry per route, and kee
 
 > In a production build the adapter serves statically generated files before middleware runs, so a middleware redirect does not fire for a route rendered with `render: 'static'`. Redirect those from the hosting environment instead, or make the route dynamic.
 
-Note the `type` check: a server action is dispatched by function id and carries no route, so it can never be matched by a path rule. That is a limitation of any path-based rule, not of this helper — see [Authentication](/guides/integrations/authentication) for where to put checks that must not be bypassed.
+Note the `type` check: an action dispatched from the client is addressed by function id and carries no route, so a path rule can never match it. A progressively enhanced form submitted without JavaScript is the other way around — it posts to the route's own url, so it parses as `'route'` and a rule for that path does apply to it. Either way, a path rule is a redirect, not an authorization boundary; see [Authentication](/guides/integrations/authentication) for where to put checks that must not be bypassed.
 
 ### Redirect via hosting environment
 

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -98,8 +98,9 @@ export function parseRouterRequest(req: Request): RouterRequest | null {
  * payload url, so a rewrite keeps the kind of response the caller expects.
  *
  * Returns `null` when `req` is not a route request, since an action or a slice
- * has no route to rewrite, and when the incoming request carries its query in
- * its body and no `query` is given — rewriting would drop it. Handle `null` by
+ * has no route to rewrite, and when the incoming request carries the router's
+ * params in its body: a redirect drops that body, and `query` can replace the
+ * route query but not the rest of a transformed payload. Handle `null` by
  * leaving the request alone.
  */
 export function formatRouterRequest(
@@ -125,10 +126,12 @@ export function formatRouterRequest(
       : canonicalPath,
     basePath,
   );
-  const nextQuery = query ?? parsed.query;
-  if (nextQuery === undefined) {
+  if (parsed.query === undefined) {
+    // A body-backed request carries a whole transformed payload, and a redirect
+    // drops the body, so no url can stand in for it.
     return null;
   }
+  const nextQuery = query ?? parsed.query;
   if (isRscRequest) {
     // The envelope can carry params a fetch RSC input transformer added, and
     // the handler still receives them, so update the query in place.

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -14,30 +14,9 @@ import {
 const getBasePath = () => import.meta.env?.WAKU_CONFIG_BASE_PATH ?? '/';
 const getRscBase = () => import.meta.env?.WAKU_CONFIG_RSC_BASE ?? 'RSC';
 
-/**
- * What the router makes of an incoming request.
- *
- * A route is reported the same way whether the browser asked for the document
- * or the client router asked for its RSC payload, so a check written against
- * `path` covers both.
- *
- * `'action'` is a client-dispatched action, addressed by function id with no
- * route attached. A progressively enhanced form submitted without JavaScript
- * is not one of these: it posts to the route's own url and is reported as
- * `'route'`, which is what it addresses. Waku itself only tells the two apart
- * after decoding the body.
- */
 type RouterRequest =
-  /**
-   * A page request: the document, or the RSC payload for the same route.
-   *
-   * `query` is `undefined` when the request carries the router's params in its
-   * body rather than its url — see `parseRouterRequest`.
-   */
   | { type: 'route'; path: string; query: string | undefined }
-  /** A slice payload request. */
   | { type: 'slice'; id: string }
-  /** A client-dispatched server action. Carries no route — see the type docs. */
   | { type: 'action' };
 
 /**
@@ -50,6 +29,13 @@ type RouterRequest =
  * This reports how the url is *read*, not whether a route exists: a request for
  * `/favicon.ico` parses as a route with that path. Deciding which paths matter
  * is the caller's job.
+ *
+ * A route is reported the same way whether the browser asked for the document
+ * or the client router asked for its RSC payload, so a check written against
+ * `path` covers both. `'action'` is an action dispatched from the client,
+ * addressed by function id with no route attached; a progressively enhanced
+ * form submitted without JavaScript is not one, since it posts to the route's
+ * own url and is reported as `'route'`.
  *
  * `query` is read from the url. An app that registers an
  * `unstable_registerFetchRscInputTransformer` returning something other than
@@ -82,10 +68,8 @@ export function parseRouterRequest(req: Request): RouterRequest | null {
       query: url.searchParams.toString(),
     };
   }
-  // The client router sends the route query inside a `query` parameter
-  // (`createRscParams`), and the server reads it back the same way, so an RSC
-  // url's own search string is an envelope, not the route's query. When the
-  // params ride in the body instead, the query is not visible from here at all.
+  // `createRscParams` nests the route query in a `query` parameter, so an RSC
+  // url's search string is an envelope; a body-backed request has none.
   const query = req.body ? undefined : (url.searchParams.get('query') ?? '');
   let rscPath: string;
   try {
@@ -133,9 +117,7 @@ export function formatRouterRequest(
   const isRscRequest = removeBase(url.pathname, basePath).startsWith(
     '/' + rscBase + '/',
   );
-  // `encodeRoutePath` rejects a trailing slash and `/index.html`, which a
-  // hand-written redirect table is free to contain, so canonicalize first and
-  // keep both url shapes pointing at the same route.
+  // `encodeRoutePath` rejects a trailing slash and `/index.html`.
   const canonicalPath = pathnameToRoutePath(routePath);
   url.pathname = addBase(
     isRscRequest
@@ -145,11 +127,8 @@ export function formatRouterRequest(
   );
   const nextQuery = query ?? parsed.query;
   if (nextQuery === undefined) {
-    // The incoming query rode in the body, so rewriting it would silently drop
-    // it. Pass an explicit `query` to say what the destination should carry.
     return null;
   }
-  // Match how the client router sends a route query for each url shape.
   url.search = isRscRequest
     ? new URLSearchParams({ query: nextQuery }).toString()
     : nextQuery;

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -129,8 +129,12 @@ export function formatRouterRequest(
   if (nextQuery === undefined) {
     return null;
   }
-  url.search = isRscRequest
-    ? new URLSearchParams({ query: nextQuery }).toString()
-    : nextQuery;
+  if (isRscRequest) {
+    // The envelope can carry params a fetch RSC input transformer added, and
+    // the handler still receives them, so update the query in place.
+    url.searchParams.set('query', nextQuery);
+  } else {
+    url.search = nextQuery;
+  }
   return url;
 }

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -28,8 +28,13 @@ const getRscBase = () => import.meta.env?.WAKU_CONFIG_RSC_BASE ?? 'RSC';
  * after decoding the body.
  */
 type RouterRequest =
-  /** A page request: the document, or the RSC payload for the same route. */
-  | { type: 'route'; path: string; query: string }
+  /**
+   * A page request: the document, or the RSC payload for the same route.
+   *
+   * `query` is `undefined` when the request carries the router's params in its
+   * body rather than its url — see `parseRouterRequest`.
+   */
+  | { type: 'route'; path: string; query: string | undefined }
   /** A slice payload request. */
   | { type: 'slice'; id: string }
   /** A client-dispatched server action. Carries no route — see the type docs. */
@@ -47,9 +52,12 @@ type RouterRequest =
  * is the caller's job.
  *
  * `query` is read from the url. An app that registers an
- * `unstable_registerFetchRscInputTransformer` which moves the router's params
- * into the request body gets `query: ''` here, since reading the body would
- * consume it before the handler sees it. `path` is unaffected.
+ * `unstable_registerFetchRscInputTransformer` returning something other than
+ * `URLSearchParams` makes the client send the router's params in an encoded
+ * POST body instead, which cannot be read here without consuming the body
+ * before the handler sees it. Such a request reports `query: undefined` rather
+ * than an empty query, so a caller can tell "no query" from "not visible", and
+ * `formatRouterRequest` refuses to invent one. `path` is unaffected.
  *
  * A route-matched check here is an optimistic redirect, not an authorization
  * boundary — it cannot cover a client-dispatched `type: 'action'`, and it runs
@@ -76,8 +84,9 @@ export function parseRouterRequest(req: Request): RouterRequest | null {
   }
   // The client router sends the route query inside a `query` parameter
   // (`createRscParams`), and the server reads it back the same way, so an RSC
-  // url's own search string is an envelope, not the route's query.
-  const query = url.searchParams.get('query') ?? '';
+  // url's own search string is an envelope, not the route's query. When the
+  // params ride in the body instead, the query is not visible from here at all.
+  const query = req.body ? undefined : (url.searchParams.get('query') ?? '');
   let rscPath: string;
   try {
     rscPath = decodeRscPath(pathname.slice(rscPathPrefix.length));
@@ -105,7 +114,9 @@ export function parseRouterRequest(req: Request): RouterRequest | null {
  * payload url, so a rewrite keeps the kind of response the caller expects.
  *
  * Returns `null` when `req` is not a route request, since an action or a slice
- * has no route to rewrite.
+ * has no route to rewrite, and when the incoming request carries its query in
+ * its body and no `query` is given — rewriting would drop it. Handle `null` by
+ * leaving the request alone.
  */
 export function formatRouterRequest(
   req: Request,
@@ -133,6 +144,11 @@ export function formatRouterRequest(
     basePath,
   );
   const nextQuery = query ?? parsed.query;
+  if (nextQuery === undefined) {
+    // The incoming query rode in the body, so rewriting it would silently drop
+    // it. Pass an explicit `query` to say what the destination should carry.
+    return null;
+  }
   // Match how the client router sends a route query for each url shape.
   url.search = isRscRequest
     ? new URLSearchParams({ query: nextQuery }).toString()

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -19,15 +19,20 @@ const getRscBase = () => import.meta.env?.WAKU_CONFIG_RSC_BASE ?? 'RSC';
  *
  * A route is reported the same way whether the browser asked for the document
  * or the client router asked for its RSC payload, so a check written against
- * `path` covers both. An action carries no route: it is dispatched by function
- * id, so no path-based rule can scope it.
+ * `path` covers both.
+ *
+ * `'action'` is a client-dispatched action, addressed by function id with no
+ * route attached. A progressively enhanced form submitted without JavaScript
+ * is not one of these: it posts to the route's own url and is reported as
+ * `'route'`, which is what it addresses. Waku itself only tells the two apart
+ * after decoding the body.
  */
 export type Unstable_RouterRequest =
   /** A page request: the document, or the RSC payload for the same route. */
   | { type: 'route'; path: string; query: string }
   /** A slice payload request. */
   | { type: 'slice'; id: string }
-  /** A server action call. Carries no route — see the type docs. */
+  /** A client-dispatched server action. Carries no route — see the type docs. */
   | { type: 'action' };
 
 /**
@@ -42,8 +47,9 @@ export type Unstable_RouterRequest =
  * is the caller's job.
  *
  * A route-matched check here is an optimistic redirect, not an authorization
- * boundary — it cannot cover `type: 'action'`, and it runs before the router
- * has resolved anything. Enforce authorization where the data is read.
+ * boundary — it cannot cover a client-dispatched `type: 'action'`, and it runs
+ * before the router has resolved anything. Enforce authorization where the data
+ * is read.
  */
 export function parseRouterRequest(
   req: Request,
@@ -57,11 +63,18 @@ export function parseRouterRequest(
   } catch {
     return null;
   }
-  const query = url.searchParams.toString();
   const rscPathPrefix = '/' + rscBase + '/';
   if (!pathname.startsWith(rscPathPrefix)) {
-    return { type: 'route', path: pathnameToRoutePath(pathname), query };
+    return {
+      type: 'route',
+      path: pathnameToRoutePath(pathname),
+      query: url.searchParams.toString(),
+    };
   }
+  // The client router sends the route query inside a `query` parameter
+  // (`createRscParams`), and the server reads it back the same way, so an RSC
+  // url's own search string is an envelope, not the route's query.
+  const query = url.searchParams.get('query') ?? '';
   let rscPath: string;
   try {
     rscPath = decodeRscPath(pathname.slice(rscPathPrefix.length));
@@ -106,12 +119,20 @@ export function formatRouterRequest(
   const isRscRequest = removeBase(url.pathname, basePath).startsWith(
     '/' + rscBase + '/',
   );
+  // `encodeRoutePath` rejects a trailing slash and `/index.html`, which a
+  // hand-written redirect table is free to contain, so canonicalize first and
+  // keep both url shapes pointing at the same route.
+  const canonicalPath = pathnameToRoutePath(routePath);
   url.pathname = addBase(
     isRscRequest
-      ? '/' + rscBase + '/' + encodeRscPath(encodeRoutePath(routePath))
-      : routePath,
+      ? '/' + rscBase + '/' + encodeRscPath(encodeRoutePath(canonicalPath))
+      : canonicalPath,
     basePath,
   );
-  url.search = query ?? parsed.query;
+  const nextQuery = query ?? parsed.query;
+  // Match how the client router sends a route query for each url shape.
+  url.search = isRscRequest
+    ? new URLSearchParams({ query: nextQuery }).toString()
+    : nextQuery;
   return url;
 }

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -27,7 +27,7 @@ const getRscBase = () => import.meta.env?.WAKU_CONFIG_RSC_BASE ?? 'RSC';
  * `'route'`, which is what it addresses. Waku itself only tells the two apart
  * after decoding the body.
  */
-export type Unstable_RouterRequest =
+type RouterRequest =
   /** A page request: the document, or the RSC payload for the same route. */
   | { type: 'route'; path: string; query: string }
   /** A slice payload request. */
@@ -56,9 +56,7 @@ export type Unstable_RouterRequest =
  * before the router has resolved anything. Enforce authorization where the data
  * is read.
  */
-export function parseRouterRequest(
-  req: Request,
-): Unstable_RouterRequest | null {
+export function parseRouterRequest(req: Request): RouterRequest | null {
   const basePath = getBasePath();
   const rscBase = getRscBase();
   const url = new URL(req.url);

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -1,0 +1,117 @@
+import { addBase, removeBase } from '../../lib/utils/path.js';
+import {
+  decodeFuncId,
+  decodeRscPath,
+  encodeRscPath,
+} from '../../lib/utils/rsc-path.js';
+import {
+  decodeRoutePath,
+  decodeSliceId,
+  encodeRoutePath,
+  pathnameToRoutePath,
+} from '../isomorphic-utils/route-path.js';
+
+const getBasePath = () => import.meta.env?.WAKU_CONFIG_BASE_PATH ?? '/';
+const getRscBase = () => import.meta.env?.WAKU_CONFIG_RSC_BASE ?? 'RSC';
+
+/**
+ * What the router makes of an incoming request.
+ *
+ * A route is reported the same way whether the browser asked for the document
+ * or the client router asked for its RSC payload, so a check written against
+ * `path` covers both. An action carries no route: it is dispatched by function
+ * id, so no path-based rule can scope it.
+ */
+export type Unstable_RouterRequest =
+  /** A page request: the document, or the RSC payload for the same route. */
+  | { type: 'route'; path: string; query: string }
+  /** A slice payload request. */
+  | { type: 'slice'; id: string }
+  /** A server action call. Carries no route — see the type docs. */
+  | { type: 'action' };
+
+/**
+ * Reads a request the way `waku/router` will read it, so middleware can match
+ * on a route path instead of on Waku's internal RSC url shape.
+ *
+ * Returns `null` when the request is not addressed to this app (outside
+ * `basePath`) or when an RSC url does not decode.
+ *
+ * This reports how the url is *read*, not whether a route exists: a request for
+ * `/favicon.ico` parses as a route with that path. Deciding which paths matter
+ * is the caller's job.
+ *
+ * A route-matched check here is an optimistic redirect, not an authorization
+ * boundary — it cannot cover `type: 'action'`, and it runs before the router
+ * has resolved anything. Enforce authorization where the data is read.
+ */
+export function parseRouterRequest(
+  req: Request,
+): Unstable_RouterRequest | null {
+  const basePath = getBasePath();
+  const rscBase = getRscBase();
+  const url = new URL(req.url);
+  let pathname: string;
+  try {
+    pathname = removeBase(url.pathname, basePath);
+  } catch {
+    return null;
+  }
+  const query = url.searchParams.toString();
+  const rscPathPrefix = '/' + rscBase + '/';
+  if (!pathname.startsWith(rscPathPrefix)) {
+    return { type: 'route', path: pathnameToRoutePath(pathname), query };
+  }
+  let rscPath: string;
+  try {
+    rscPath = decodeRscPath(pathname.slice(rscPathPrefix.length));
+  } catch {
+    return null;
+  }
+  if (decodeFuncId(rscPath) !== null) {
+    return { type: 'action' };
+  }
+  const sliceId = decodeSliceId(rscPath);
+  if (sliceId !== null) {
+    return { type: 'slice', id: sliceId };
+  }
+  try {
+    return { type: 'route', path: decodeRoutePath(rscPath), query };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The inverse of `parseRouterRequest` for routes: the url that addresses
+ * `routePath` the same way `req` addressed its own route. A request for the
+ * document gets the document url back; a request for an RSC payload gets the
+ * payload url, so a rewrite keeps the kind of response the caller expects.
+ *
+ * Returns `null` when `req` is not a route request, since an action or a slice
+ * has no route to rewrite.
+ */
+export function formatRouterRequest(
+  req: Request,
+  routePath: string,
+  query?: string,
+): URL | null {
+  const parsed = parseRouterRequest(req);
+  if (parsed?.type !== 'route') {
+    return null;
+  }
+  const basePath = getBasePath();
+  const rscBase = getRscBase();
+  const url = new URL(req.url);
+  const isRscRequest = removeBase(url.pathname, basePath).startsWith(
+    '/' + rscBase + '/',
+  );
+  url.pathname = addBase(
+    isRscRequest
+      ? '/' + rscBase + '/' + encodeRscPath(encodeRoutePath(routePath))
+      : routePath,
+    basePath,
+  );
+  url.search = query ?? parsed.query;
+  return url;
+}

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -46,6 +46,11 @@ export type Unstable_RouterRequest =
  * `/favicon.ico` parses as a route with that path. Deciding which paths matter
  * is the caller's job.
  *
+ * `query` is read from the url. An app that registers an
+ * `unstable_registerFetchRscInputTransformer` which moves the router's params
+ * into the request body gets `query: ''` here, since reading the body would
+ * consume it before the handler sees it. `path` is unaffected.
+ *
  * A route-matched check here is an optimistic redirect, not an authorization
  * boundary — it cannot cover a client-dispatched `type: 'action'`, and it runs
  * before the router has resolved anything. Enforce authorization where the data

--- a/packages/waku/src/router/server-utils/parse-router-request.ts
+++ b/packages/waku/src/router/server-utils/parse-router-request.ts
@@ -14,41 +14,26 @@ import {
 const getBasePath = () => import.meta.env?.WAKU_CONFIG_BASE_PATH ?? '/';
 const getRscBase = () => import.meta.env?.WAKU_CONFIG_RSC_BASE ?? 'RSC';
 
+/** Where `createRscParams` nests the route query inside an RSC url. */
+const RSC_QUERY_PARAM = 'query';
+
 type RouterRequest =
   | { type: 'route'; path: string; query: string | undefined }
   | { type: 'slice'; id: string }
   | { type: 'action' };
 
 /**
- * Reads a request the way `waku/router` will read it, so middleware can match
- * on a route path instead of on Waku's internal RSC url shape.
+ * Reads a request the way `waku/router` will, so middleware can match on a
+ * route path rather than Waku's RSC url shape: a document request and the RSC
+ * request for the same route both report that route.
  *
- * Returns `null` when the request is not addressed to this app (outside
- * `basePath`) or when an RSC url does not decode.
+ * Returns `null` outside `basePath`, or for an RSC url that does not decode.
+ * `query` is `undefined` when a fetch RSC input transformer puts the router's
+ * params in the request body, out of reach without consuming it.
  *
- * This reports how the url is *read*, not whether a route exists: a request for
- * `/favicon.ico` parses as a route with that path. Deciding which paths matter
- * is the caller's job.
- *
- * A route is reported the same way whether the browser asked for the document
- * or the client router asked for its RSC payload, so a check written against
- * `path` covers both. `'action'` is an action dispatched from the client,
- * addressed by function id with no route attached; a progressively enhanced
- * form submitted without JavaScript is not one, since it posts to the route's
- * own url and is reported as `'route'`.
- *
- * `query` is read from the url. An app that registers an
- * `unstable_registerFetchRscInputTransformer` returning something other than
- * `URLSearchParams` makes the client send the router's params in an encoded
- * POST body instead, which cannot be read here without consuming the body
- * before the handler sees it. Such a request reports `query: undefined` rather
- * than an empty query, so a caller can tell "no query" from "not visible", and
- * `formatRouterRequest` refuses to invent one. `path` is unaffected.
- *
- * A route-matched check here is an optimistic redirect, not an authorization
- * boundary — it cannot cover a client-dispatched `type: 'action'`, and it runs
- * before the router has resolved anything. Enforce authorization where the data
- * is read.
+ * A path rule is an optimistic redirect, not an authorization boundary: it
+ * cannot see a client-dispatched action, though a form posted without
+ * JavaScript reports as the route it posts to.
  */
 export function parseRouterRequest(req: Request): RouterRequest | null {
   const basePath = getBasePath();
@@ -68,9 +53,10 @@ export function parseRouterRequest(req: Request): RouterRequest | null {
       query: url.searchParams.toString(),
     };
   }
-  // `createRscParams` nests the route query in a `query` parameter, so an RSC
-  // url's search string is an envelope; a body-backed request has none.
-  const query = req.body ? undefined : (url.searchParams.get('query') ?? '');
+  const paramsInBody = req.body !== null;
+  const query = paramsInBody
+    ? undefined
+    : (url.searchParams.get(RSC_QUERY_PARAM) ?? '');
   let rscPath: string;
   try {
     rscPath = decodeRscPath(pathname.slice(rscPathPrefix.length));
@@ -92,16 +78,13 @@ export function parseRouterRequest(req: Request): RouterRequest | null {
 }
 
 /**
- * The inverse of `parseRouterRequest` for routes: the url that addresses
- * `routePath` the same way `req` addressed its own route. A request for the
- * document gets the document url back; a request for an RSC payload gets the
- * payload url, so a rewrite keeps the kind of response the caller expects.
+ * The url that addresses `routePath` the way `req` addressed its own route, so
+ * a rewrite returns the kind of response the caller expects: a document for a
+ * document request, an RSC payload for an RSC one.
  *
- * Returns `null` when `req` is not a route request, since an action or a slice
- * has no route to rewrite, and when the incoming request carries the router's
- * params in its body: a redirect drops that body, and `query` can replace the
- * route query but not the rest of a transformed payload. Handle `null` by
- * leaving the request alone.
+ * Returns `null` when `req` is not a route request, and when it carries the
+ * router's params in its body — a redirect drops that body, and `query`
+ * replaces the route query alone. Leave such a request as it is.
  */
 export function formatRouterRequest(
   req: Request,
@@ -109,7 +92,7 @@ export function formatRouterRequest(
   query?: string,
 ): URL | null {
   const parsed = parseRouterRequest(req);
-  if (parsed?.type !== 'route') {
+  if (parsed?.type !== 'route' || parsed.query === undefined) {
     return null;
   }
   const basePath = getBasePath();
@@ -118,7 +101,6 @@ export function formatRouterRequest(
   const isRscRequest = removeBase(url.pathname, basePath).startsWith(
     '/' + rscBase + '/',
   );
-  // `encodeRoutePath` rejects a trailing slash and `/index.html`.
   const canonicalPath = pathnameToRoutePath(routePath);
   url.pathname = addBase(
     isRscRequest
@@ -126,16 +108,9 @@ export function formatRouterRequest(
       : canonicalPath,
     basePath,
   );
-  if (parsed.query === undefined) {
-    // A body-backed request carries a whole transformed payload, and a redirect
-    // drops the body, so no url can stand in for it.
-    return null;
-  }
   const nextQuery = query ?? parsed.query;
   if (isRscRequest) {
-    // The envelope can carry params a fetch RSC input transformer added, and
-    // the handler still receives them, so update the query in place.
-    url.searchParams.set('query', nextQuery);
+    url.searchParams.set(RSC_QUERY_PARAM, nextQuery);
   } else {
     url.search = nextQuery;
   }

--- a/packages/waku/src/router/server.ts
+++ b/packages/waku/src/router/server.ts
@@ -20,3 +20,8 @@ export type {
   CreateInterceptor,
 } from './create-pages.js';
 export { fsRouter } from './fs-router.js';
+export {
+  formatRouterRequest as unstable_formatRouterRequest,
+  parseRouterRequest as unstable_parseRouterRequest,
+} from './server-utils/parse-router-request.js';
+export type { Unstable_RouterRequest } from './server-utils/parse-router-request.js';

--- a/packages/waku/src/router/server.ts
+++ b/packages/waku/src/router/server.ts
@@ -24,4 +24,3 @@ export {
   formatRouterRequest as unstable_formatRouterRequest,
   parseRouterRequest as unstable_parseRouterRequest,
 } from './server-utils/parse-router-request.js';
-export type { Unstable_RouterRequest } from './server-utils/parse-router-request.js';

--- a/packages/waku/tests/parse-router-request.test.ts
+++ b/packages/waku/tests/parse-router-request.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { encodeFuncId, encodeRscPath } from '../src/lib/utils/rsc-path.js';
+import {
+  encodeRoutePath,
+  encodeSliceId,
+} from '../src/router/isomorphic-utils/route-path.js';
+import {
+  formatRouterRequest,
+  parseRouterRequest,
+} from '../src/router/server-utils/parse-router-request.js';
+
+const req = (url: string) => new Request(url);
+
+// the url the client router actually fetches for a route
+const rscUrl = (routePath: string, query = '') =>
+  'http://localhost/RSC/' +
+  encodeRscPath(encodeRoutePath(routePath)) +
+  (query ? '?' + query : '');
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('parseRouterRequest', () => {
+  it('reads a document request as its route', () => {
+    expect(parseRouterRequest(req('http://localhost/dashboard'))).toEqual({
+      type: 'route',
+      path: '/dashboard',
+      query: '',
+    });
+  });
+
+  it('reads the rsc request for the same route identically', () => {
+    expect(parseRouterRequest(req(rscUrl('/dashboard')))).toEqual({
+      type: 'route',
+      path: '/dashboard',
+      query: '',
+    });
+  });
+
+  it.each(['/', '/_foo', '/dashboard/invoices', '/a/b/c'])(
+    'agrees between both url shapes for %s',
+    (path) => {
+      expect(parseRouterRequest(req(rscUrl(path)))).toEqual(
+        parseRouterRequest(req('http://localhost' + path)),
+      );
+    },
+  );
+
+  it('keeps the query from either shape', () => {
+    expect(parseRouterRequest(req('http://localhost/x?a=1'))).toMatchObject({
+      query: 'a=1',
+    });
+    expect(parseRouterRequest(req(rscUrl('/x', 'a=1')))).toMatchObject({
+      query: 'a=1',
+    });
+  });
+
+  it('reports a server action as an action, with no route', () => {
+    const url =
+      'http://localhost/RSC/' +
+      encodeRscPath(encodeFuncId('src/actions.ts#deleteInvoice'));
+    expect(parseRouterRequest(req(url))).toEqual({ type: 'action' });
+  });
+
+  it('reports a slice request', () => {
+    const url = 'http://localhost/RSC/' + encodeRscPath(encodeSliceId('one'));
+    expect(parseRouterRequest(req(url))).toEqual({ type: 'slice', id: 'one' });
+  });
+
+  it('honours a custom basePath and rscBase', () => {
+    vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/app/');
+    vi.stubEnv('WAKU_CONFIG_RSC_BASE', '_rsc');
+    expect(parseRouterRequest(req('http://localhost/app/dashboard'))).toEqual({
+      type: 'route',
+      path: '/dashboard',
+      query: '',
+    });
+    const url =
+      'http://localhost/app/_rsc/' +
+      encodeRscPath(encodeRoutePath('/dashboard'));
+    expect(parseRouterRequest(req(url))).toEqual({
+      type: 'route',
+      path: '/dashboard',
+      query: '',
+    });
+  });
+
+  it('returns null outside basePath', () => {
+    vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/app/');
+    expect(parseRouterRequest(req('http://localhost/elsewhere'))).toBeNull();
+  });
+
+  it('returns null for an undecodable rsc url', () => {
+    expect(
+      parseRouterRequest(req('http://localhost/RSC/not-encoded')),
+    ).toBeNull();
+  });
+
+  it('reads a path with no route as a route: existence is the caller’s job', () => {
+    expect(parseRouterRequest(req('http://localhost/favicon.ico'))).toEqual({
+      type: 'route',
+      path: '/favicon.ico',
+      query: '',
+    });
+  });
+});
+
+describe('formatRouterRequest', () => {
+  it('rewrites a document request to the document url of another route', () => {
+    const out = formatRouterRequest(req('http://localhost/old'), '/new');
+    expect(out?.pathname).toBe('/new');
+  });
+
+  it('rewrites an rsc request to the rsc url of another route', () => {
+    const out = formatRouterRequest(req(rscUrl('/old')), '/new');
+    expect(out?.pathname).toBe(new URL(rscUrl('/new')).pathname);
+  });
+
+  it('round-trips through parseRouterRequest', () => {
+    for (const path of ['/', '/_foo', '/a/b/c']) {
+      for (const from of ['http://localhost/old', rscUrl('/old')]) {
+        const out = formatRouterRequest(req(from), path);
+        expect(parseRouterRequest(req(out!.href))).toMatchObject({
+          type: 'route',
+          path,
+        });
+      }
+    }
+  });
+
+  it('carries the original query unless one is given', () => {
+    expect(
+      formatRouterRequest(req('http://localhost/old?a=1'), '/new')?.search,
+    ).toBe('?a=1');
+    expect(
+      formatRouterRequest(req('http://localhost/old?a=1'), '/new', 'b=2')
+        ?.search,
+    ).toBe('?b=2');
+  });
+
+  it('honours a custom basePath', () => {
+    vi.stubEnv('WAKU_CONFIG_BASE_PATH', '/app/');
+    expect(
+      formatRouterRequest(req('http://localhost/app/old'), '/new')?.pathname,
+    ).toBe('/app/new');
+  });
+
+  it('returns null for an action, which has no route to rewrite', () => {
+    const url =
+      'http://localhost/RSC/' + encodeRscPath(encodeFuncId('src/a.ts#go'));
+    expect(formatRouterRequest(req(url), '/new')).toBeNull();
+  });
+});

--- a/packages/waku/tests/parse-router-request.test.ts
+++ b/packages/waku/tests/parse-router-request.test.ts
@@ -75,6 +75,20 @@ describe('parseRouterRequest', () => {
     expect([parsed.path, parsed.query]).toEqual(['/x', 'a=1']);
   });
 
+  it('reports an unknown query when the params ride in the body', () => {
+    // a fetch RSC input transformer that returns anything but URLSearchParams
+    // makes the client POST the params as an encoded body
+    const bodyBacked = new Request(rscUrl('/x'), {
+      method: 'POST',
+      body: 'encoded-reply',
+    });
+    expect(parseRouterRequest(bodyBacked)).toEqual({
+      type: 'route',
+      path: '/x',
+      query: undefined,
+    });
+  });
+
   it('reports an empty query for an RSC url with no envelope', () => {
     const url = 'http://localhost/RSC/' + encodeRscPath(encodeRoutePath('/x'));
     expect(parseRouterRequest(req(url))).toMatchObject({ query: '' });
@@ -184,6 +198,16 @@ describe('formatRouterRequest', () => {
         query: 'b=2&c=3',
       });
     }
+  });
+
+  it('refuses to rewrite a body-backed request rather than drop its query', () => {
+    const bodyBacked = () =>
+      new Request(rscUrl('/old'), { method: 'POST', body: 'encoded-reply' });
+    expect(formatRouterRequest(bodyBacked(), '/new')).toBe(null);
+    // an explicit query says what the destination should carry, so it can build
+    expect(formatRouterRequest(bodyBacked(), '/new', 'b=2')?.search).toBe(
+      '?query=b%3D2',
+    );
   });
 
   it('canonicalizes a destination path in either shape', () => {

--- a/packages/waku/tests/parse-router-request.test.ts
+++ b/packages/waku/tests/parse-router-request.test.ts
@@ -65,6 +65,16 @@ describe('parseRouterRequest', () => {
     });
   });
 
+  it('narrows to the route members without a named type', () => {
+    const parsed = parseRouterRequest(req('http://localhost/x?a=1'));
+    if (parsed?.type !== 'route') {
+      throw new Error('expected a route');
+    }
+    // `path` and `query` are reachable by inference alone, which is why the
+    // union is not exported.
+    expect([parsed.path, parsed.query]).toEqual(['/x', 'a=1']);
+  });
+
   it('reports an empty query for an RSC url with no envelope', () => {
     const url = 'http://localhost/RSC/' + encodeRscPath(encodeRoutePath('/x'));
     expect(parseRouterRequest(req(url))).toMatchObject({ query: '' });

--- a/packages/waku/tests/parse-router-request.test.ts
+++ b/packages/waku/tests/parse-router-request.test.ts
@@ -197,13 +197,12 @@ describe('formatRouterRequest', () => {
     }
   });
 
-  it('refuses to rewrite a body-backed request rather than drop its query', () => {
+  it('refuses to rewrite a body-backed request', () => {
     const bodyBacked = () =>
       new Request(rscUrl('/old'), { method: 'POST', body: 'encoded-reply' });
     expect(formatRouterRequest(bodyBacked(), '/new')).toBe(null);
-    expect(formatRouterRequest(bodyBacked(), '/new', 'b=2')?.search).toBe(
-      '?query=b%3D2',
-    );
+    // an explicit query cannot stand in for the rest of the payload either
+    expect(formatRouterRequest(bodyBacked(), '/new', 'b=2')).toBe(null);
   });
 
   it('keeps envelope params a transformer added', () => {

--- a/packages/waku/tests/parse-router-request.test.ts
+++ b/packages/waku/tests/parse-router-request.test.ts
@@ -11,8 +11,7 @@ import {
 
 const req = (url: string) => new Request(url);
 
-// the url the client router actually fetches for a route: the route query
-// travels inside a `query` parameter, exactly as `createRscParams` sends it
+// the url the client router actually fetches, envelope and all
 const rscUrl = (routePath: string, query = '') =>
   'http://localhost/RSC/' +
   encodeRscPath(encodeRoutePath(routePath)) +
@@ -70,14 +69,12 @@ describe('parseRouterRequest', () => {
     if (parsed?.type !== 'route') {
       throw new Error('expected a route');
     }
-    // `path` and `query` are reachable by inference alone, which is why the
-    // union is not exported.
     expect([parsed.path, parsed.query]).toEqual(['/x', 'a=1']);
   });
 
   it('reports an unknown query when the params ride in the body', () => {
-    // a fetch RSC input transformer that returns anything but URLSearchParams
-    // makes the client POST the params as an encoded body
+    // what `fetchRsc` sends when a transformer returns anything but
+    // `URLSearchParams`
     const bodyBacked = new Request(rscUrl('/x'), {
       method: 'POST',
       body: 'encoded-reply',
@@ -204,7 +201,6 @@ describe('formatRouterRequest', () => {
     const bodyBacked = () =>
       new Request(rscUrl('/old'), { method: 'POST', body: 'encoded-reply' });
     expect(formatRouterRequest(bodyBacked(), '/new')).toBe(null);
-    // an explicit query says what the destination should carry, so it can build
     expect(formatRouterRequest(bodyBacked(), '/new', 'b=2')?.search).toBe(
       '?query=b%3D2',
     );

--- a/packages/waku/tests/parse-router-request.test.ts
+++ b/packages/waku/tests/parse-router-request.test.ts
@@ -11,11 +11,13 @@ import {
 
 const req = (url: string) => new Request(url);
 
-// the url the client router actually fetches for a route
+// the url the client router actually fetches for a route: the route query
+// travels inside a `query` parameter, exactly as `createRscParams` sends it
 const rscUrl = (routePath: string, query = '') =>
   'http://localhost/RSC/' +
   encodeRscPath(encodeRoutePath(routePath)) +
-  (query ? '?' + query : '');
+  '?' +
+  new URLSearchParams({ query }).toString();
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -54,6 +56,18 @@ describe('parseRouterRequest', () => {
     expect(parseRouterRequest(req(rscUrl('/x', 'a=1')))).toMatchObject({
       query: 'a=1',
     });
+  });
+
+  it('unwraps a multi-parameter query from an RSC url', () => {
+    // the envelope is `?query=a%3D1%26b%3D2`, not `?a=1&b=2`
+    expect(parseRouterRequest(req(rscUrl('/x', 'a=1&b=2')))).toMatchObject({
+      query: 'a=1&b=2',
+    });
+  });
+
+  it('reports an empty query for an RSC url with no envelope', () => {
+    const url = 'http://localhost/RSC/' + encodeRscPath(encodeRoutePath('/x'));
+    expect(parseRouterRequest(req(url))).toMatchObject({ query: '' });
   });
 
   it('reports a server action as an action, with no route', () => {
@@ -137,6 +151,39 @@ describe('formatRouterRequest', () => {
       formatRouterRequest(req('http://localhost/old?a=1'), '/new', 'b=2')
         ?.search,
     ).toBe('?b=2');
+  });
+
+  it('wraps the query again when rewriting an RSC url', () => {
+    expect(
+      formatRouterRequest(req(rscUrl('/old', 'a=1')), '/new')?.search,
+    ).toBe('?query=a%3D1');
+    expect(
+      formatRouterRequest(req(rscUrl('/old', 'a=1')), '/new', 'b=2')?.search,
+    ).toBe('?query=b%3D2');
+  });
+
+  it('round-trips a rewritten query through parseRouterRequest', () => {
+    for (const original of [
+      'http://localhost/old?a=1',
+      rscUrl('/old', 'a=1'),
+    ]) {
+      const rewritten = formatRouterRequest(req(original), '/new', 'b=2&c=3');
+      expect(parseRouterRequest(req(rewritten!.toString()))).toEqual({
+        type: 'route',
+        path: '/new',
+        query: 'b=2&c=3',
+      });
+    }
+  });
+
+  it('canonicalizes a destination path in either shape', () => {
+    expect(
+      formatRouterRequest(req('http://localhost/old'), '/new/')?.pathname,
+    ).toBe('/new');
+    const rsc = formatRouterRequest(req(rscUrl('/old')), '/new/');
+    expect(parseRouterRequest(req(rsc!.toString()))).toMatchObject({
+      path: '/new',
+    });
   });
 
   it('honours a custom basePath', () => {

--- a/packages/waku/tests/parse-router-request.test.ts
+++ b/packages/waku/tests/parse-router-request.test.ts
@@ -206,6 +206,17 @@ describe('formatRouterRequest', () => {
     );
   });
 
+  it('keeps envelope params a transformer added', () => {
+    const withExtras =
+      'http://localhost/RSC/' +
+      encodeRscPath(encodeRoutePath('/old')) +
+      '?' +
+      new URLSearchParams({ query: 'a=1', tenant: 'acme' }).toString();
+    const rewritten = formatRouterRequest(req(withExtras), '/new');
+    expect(rewritten?.searchParams.get('tenant')).toBe('acme');
+    expect(rewritten?.searchParams.get('query')).toBe('a=1');
+  });
+
   it('canonicalizes a destination path in either shape', () => {
     expect(
       formatRouterRequest(req('http://localhost/old'), '/new/')?.pathname,


### PR DESCRIPTION
Middleware sees the raw url, so a path rule written for `/dashboard` misses the `/RSC/R/dashboard.txt` that a client-side navigation fetches. Covering both means hardcoding the RSC url shape, which is wrong under a custom `basePath` or `rscBase`, and already wrong for the root route.

`unstable_parseRouterRequest` decodes a request into what it addresses, so both url shapes for a route give the same `{ type: 'route', path }`. It returns a union rather than a boolean so that an action, dispatched by function id and carrying no route, is a visible `{ type: 'action' }`.

`unstable_formatRouterRequest` is the inverse a redirect map needs, so `/RSC/R/old.txt` rewrites to `/RSC/R/new.txt` rather than to /new.

The redirect-maps guide now uses both, and spells the url shape out only for CDN and hosting rules, which cannot call into Waku.

