### PR TITLE
fix(router): allow no-SSR on dynamic pages with slugs

### DIFF
--- a/docs/create-pages.mdx
+++ b/docs/create-pages.mdx
@@ -241,7 +241,7 @@ export default adapter(pages);
 
 #### Disabling SSR
 
-`unstable_disableSSR` disables document SSR for a page. Runtime document requests return Waku's fallback HTML shell, and build output uses fallback HTML for that route. The RSC payload is still available to the client router.
+`unstable_disableSSR` disables document SSR for a page. Runtime document requests return Waku's fallback HTML shell, and the build writes that shell for a static page. The RSC payload is still available to the client router.
 
 ```tsx
 // ./src/waku.server.tsx

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -864,6 +864,18 @@ test.describe(`create-pages`, () => {
     ).toBeVisible();
   });
 
+  test('no ssr with render=dynamic and a slug', async ({ page, request }) => {
+    const response = await request.get(
+      `http://localhost:${port}/no-ssr-slug/abc`,
+    );
+    expect(await response.text()).not.toContain('No SSR Slug');
+
+    await page.goto(`http://localhost:${port}/no-ssr-slug/abc`);
+    await expect(
+      page.getByRole('heading', { name: 'No SSR Slug abc', exact: true }),
+    ).toBeVisible();
+  });
+
   test('no ssr', async ({ page }) => {
     await page.goto(`http://localhost:${port}/no-ssr`);
     await expect(
@@ -957,7 +969,10 @@ test.describe(`create-pages STATIC`, { tag: '@prd' }, () => {
     await stopApp();
   });
 
-  test('no ssr', async ({ page }) => {
+  test('no ssr', async ({ page, request }) => {
+    const response = await request.get(`http://localhost:${port}/no-ssr`);
+    expect(await response.text()).not.toContain('No SSR');
+
     await page.goto(`http://localhost:${port}/no-ssr`);
     await expect(
       page.getByRole('heading', { name: 'No SSR', exact: true }),

--- a/e2e/fixtures/create-pages/src/waku.server.tsx
+++ b/e2e/fixtures/create-pages/src/waku.server.tsx
@@ -577,6 +577,13 @@ const pages: ReturnType<typeof createPages> = createPages(
 
     createPage({
       render: 'dynamic',
+      path: '/no-ssr-slug/[id]',
+      component: ({ id }) => <h2>No SSR Slug {id}</h2>,
+      unstable_disableSSR: true,
+    }),
+
+    createPage({
+      render: 'dynamic',
       path: '/slices',
       slices: ['slice001', 'slice002'],
       component: () => (

--- a/packages/waku/src/router/define-router-utils/build-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/build-handler.tsx
@@ -239,53 +239,36 @@ export const createBuildHandler = ({
               unstable_clientModuleCallback: (ids) =>
                 ids.forEach((id) => moduleIds.add(id)),
             });
-            const [stream1, stream2] = stream.tee();
-            await generateFile(rscPath2pathname(rscPath), stream1);
+            if (item.noSsr) {
+              await generateFile(rscPath2pathname(rscPath), stream);
+              await generateDefaultHtml(routePathToHtmlFilePath(routePath));
+            } else {
+              const [stream1, stream2] = stream.tee();
+              await generateFile(rscPath2pathname(rscPath), stream1);
+              htmlRenderTasks.add(() =>
+                runHandled(req, async () => {
+                  const html = (
+                    <INTERNAL_ServerRouter
+                      route={{ path: routePath, query: '', hash: '' }}
+                    />
+                  );
+                  const res = await renderHtml(stream2, html, {
+                    rscPath,
+                    unstable_extraScriptContent:
+                      getRouterPrefetchCode(path2moduleIds) +
+                      setupRouterSearchCodecs(configs),
+                  });
+                  await generateFile(
+                    routePathToHtmlFilePath(routePath),
+                    res.body || '',
+                  );
+                }),
+              );
+            }
             path2moduleIds[path2regexp(item.pathPattern || item.path)] =
               Array.from(moduleIds);
-            htmlRenderTasks.add(() =>
-              // Run inside the same request/router/interceptor scope as the RSC
-              // render, so the deferred HTML render is consistent with it.
-              runHandled(req, async () => {
-                const html = (
-                  <INTERNAL_ServerRouter
-                    route={{ path: routePath, query: '', hash: '' }}
-                  />
-                );
-                const res = await renderHtml(stream2, html, {
-                  rscPath,
-                  unstable_extraScriptContent:
-                    getRouterPrefetchCode(path2moduleIds) +
-                    setupRouterSearchCodecs(configs),
-                });
-                await generateFile(
-                  routePathToHtmlFilePath(routePath),
-                  res.body || '',
-                );
-              }),
-            );
           });
         });
-      }
-    };
-
-    const generateNoSsrDefaultHtml = () => {
-      for (const item of configs) {
-        if (item.type !== 'route') {
-          continue;
-        }
-        if (item.noSsr) {
-          const routePath = pathSpecToRoutePath(item.path);
-          if (!routePath) {
-            throw new Error('Pathname is required for noSsr routes on build');
-          }
-          if (skipBuild?.(routePath)) {
-            continue;
-          }
-          runTask(async () => {
-            await generateDefaultHtml(routePathToHtmlFilePath(routePath));
-          });
-        }
       }
     };
 
@@ -345,7 +328,6 @@ export const createBuildHandler = ({
     // HACK hopefully there is a better way than this
     await waitForTasks();
     htmlRenderTasks.forEach(runTask);
-    generateNoSsrDefaultHtml();
     buildStaticSlices();
     await waitForTasks();
     await persistBuildMetadata();


### PR DESCRIPTION
The build wrote the fallback html for every noSsr route in a separate pass that needed a literal path, so a dynamic page with a slug and unstable_disableSSR failed with "Pathname is required for noSsr routes on build". Write it where the static route's RSC file is written and drop the pass.

A dynamic noSsr route no longer gets a prebuilt html file. The handler answers its document request with the same fallback, as in dev, so middleware now sees that request too. The static noSsr route was also rendered to html before, racing the fallback write, and is not anymore.

ref: https://github.com/wakujs/waku/pull/2294#issuecomment-5578912941