### PR TITLE
fix(router): stop a cached element error from killing the server

### DIFF
--- a/e2e/fixtures/ssr-catch-error/src/pages/redirect-static.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/pages/redirect-static.tsx
@@ -1,0 +1,16 @@
+import { unstable_redirect as redirect } from 'waku/router/server';
+
+const Redirect = async () => {
+  await Promise.resolve();
+  return redirect('/no-error');
+};
+
+export default function RedirectStaticPage() {
+  return <Redirect />;
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'static',
+  } as const;
+};

--- a/e2e/ssr-catch-error.spec.ts
+++ b/e2e/ssr-catch-error.spec.ts
@@ -22,6 +22,17 @@ test.describe(`ssr-catch-error`, () => {
     await expect(page.getByText('Something went wrong')).toBeVisible();
   });
 
+  test('a static element that throws does not take the server down', async ({
+    request,
+  }) => {
+    await request.get(`http://localhost:${port}/redirect-static`, {
+      maxRedirects: 0,
+    });
+
+    const res = await request.get(`http://localhost:${port}/no-error`);
+    expect(res.status()).toBe(200);
+  });
+
   test('error inside Suspense inside ErrorBoundary', async ({ page }) => {
     const res = await page.goto(`http://localhost:${port}/suspense`);
     expect(res?.status()).toBe(200);

--- a/packages/waku/src/router/define-router-utils/build-handler.tsx
+++ b/packages/waku/src/router/define-router-utils/build-handler.tsx
@@ -177,7 +177,7 @@ export const createBuildHandler = ({
         cacheId: CacheId,
         el: { isStatic: boolean; renderer: (o: RendererOption) => ReactNode },
       ) => {
-        if (!el.isStatic || buildElementCache.get(cacheId)) {
+        if (!el.isStatic || buildElementCache.has(cacheId)) {
           return;
         }
         const result = buildElementCache.set(cacheId, el.renderer(option));

--- a/packages/waku/src/router/define-router-utils/element-cache.ts
+++ b/packages/waku/src/router/define-router-utils/element-cache.ts
@@ -20,6 +20,8 @@ export const createElementCache = (
     preload: (cacheId: CacheId, bytes: Uint8Array) => {
       cache.set(cacheId, Promise.resolve(bytes));
     },
+    has: (cacheId: CacheId) => cache.has(cacheId),
+    // every call builds a new promise, so ask has() when only presence matters
     get: (cacheId: CacheId) => {
       const cachedBytes = cache.get(cacheId);
       if (!cachedBytes) {

--- a/packages/waku/src/router/define-router-utils/element-cache.ts
+++ b/packages/waku/src/router/define-router-utils/element-cache.ts
@@ -21,7 +21,6 @@ export const createElementCache = (
       cache.set(cacheId, Promise.resolve(bytes));
     },
     has: (cacheId: CacheId) => cache.has(cacheId),
-    // every call builds a new promise, so ask has() when only presence matters
     get: (cacheId: CacheId) => {
       const cachedBytes = cache.get(cacheId);
       if (!cachedBytes) {

--- a/packages/waku/src/router/define-router-utils/route-entries.tsx
+++ b/packages/waku/src/router/define-router-utils/route-entries.tsx
@@ -134,7 +134,7 @@ export const createRouteEntries = (configRegistry: ConfigRegistry) => {
         ? {
             immutable: true,
             render: async () => {
-              if (!elementCache.get(cacheId)) {
+              if (!elementCache.has(cacheId)) {
                 await elementCache.set(cacheId, await render());
               }
               return elementCache.get(cacheId);


### PR DESCRIPTION
The element cache builds a fresh promise on every get, and two callers called it only to ask whether the entry exists, then dropped it. When a static element's own root throws, that promise rejects with nobody holding it, and node takes the process down after the request has already been answered. Both callers ask has() now.