### PR TITLE
fix(rsc): keep an error digest through serializeRsc

### DIFF
--- a/e2e/ssr-catch-error.spec.ts
+++ b/e2e/ssr-catch-error.spec.ts
@@ -33,6 +33,17 @@ test.describe(`ssr-catch-error`, () => {
     expect(res.status()).toBe(200);
   });
 
+  test('a redirect from a cached static element is followed', async ({
+    request,
+  }) => {
+    const res = await request.get(`http://localhost:${port}/redirect-static`, {
+      maxRedirects: 0,
+    });
+
+    expect(res.status()).toBe(307);
+    expect(res.headers()['location']).toBe('/no-error');
+  });
+
   test('error inside Suspense inside ErrorBoundary', async ({ page }) => {
     const res = await page.goto(`http://localhost:${port}/suspense`);
     expect(res?.status()).toBe(200);

--- a/packages/waku/src/lib/react-types.d.ts
+++ b/packages/waku/src/lib/react-types.d.ts
@@ -40,7 +40,7 @@ declare module 'react-server-dom-webpack/server.edge' {
     identifierPrefix?: string;
     signal?: AbortSignal;
     temporaryReferences?: TemporaryReferenceSet | undefined;
-    onError?: ((error: unknown) => void) | undefined;
+    onError?: ((error: unknown) => string | undefined) | undefined;
     onPostpone?: ((reason: string) => void) | undefined;
   };
 

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -11,8 +11,6 @@ export async function serializeRsc(element: unknown): Promise<Uint8Array> {
       element,
       {},
       {
-        // react drops the digest unless a handler returns it, and waku reads
-        // its own control flow back out of that digest after the round trip
         onError: (e: unknown) => {
           if (!getErrorInfo(e)) {
             console.error('Error during rendering:', sanitizeLog(e));

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -1,10 +1,27 @@
 import { renderToReadableStream } from 'react-server-dom-webpack/server.edge';
+import { getDigest, getErrorInfo } from './lib/utils/custom-errors.js';
+import { sanitizeLog } from './lib/utils/log.js';
 import { bytesToStream, streamToBytes } from './lib/utils/stream.js';
 
 export { getEnv } from './lib/env.js';
 
 export async function serializeRsc(element: unknown): Promise<Uint8Array> {
-  return streamToBytes(renderToReadableStream(element, {}));
+  return streamToBytes(
+    renderToReadableStream(
+      element,
+      {},
+      {
+        // react drops the digest unless a handler returns it, and waku reads
+        // its own control flow back out of that digest after the round trip
+        onError: (e: unknown) => {
+          if (!getErrorInfo(e)) {
+            console.error('Error during rendering:', sanitizeLog(e));
+          }
+          return getDigest(e);
+        },
+      },
+    ),
+  );
 }
 
 export async function deserializeRsc(bytes: Uint8Array): Promise<unknown> {

--- a/packages/waku/tests/server-rsc.test.ts
+++ b/packages/waku/tests/server-rsc.test.ts
@@ -78,6 +78,8 @@ describe('waku/server RSC helpers', () => {
         onError: (e: unknown) => string | undefined;
       };
 
+      // react stores whatever onError returns as the error's digest, so
+      // handing it back is what carries a redirect or a 404 to the reader
       const custom = createCustomError('not found', { status: 404 });
       expect(options.onError(custom)).toBe(
         (custom as { digest?: string }).digest,

--- a/packages/waku/tests/server-rsc.test.ts
+++ b/packages/waku/tests/server-rsc.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test, vi } from 'vitest';
-import { createCustomError } from '../src/lib/utils/custom-errors.js';
+import {
+  createCustomError,
+  getErrorInfo,
+} from '../src/lib/utils/custom-errors.js';
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -78,12 +81,11 @@ describe('waku/server RSC helpers', () => {
         onError: (e: unknown) => string | undefined;
       };
 
-      // react stores whatever onError returns as the error's digest, so
-      // handing it back is what carries a redirect or a 404 to the reader
+      // react stores whatever onError returns as the error's digest
       const custom = createCustomError('not found', { status: 404 });
-      expect(options.onError(custom)).toBe(
-        (custom as { digest?: string }).digest,
-      );
+      expect(getErrorInfo({ digest: options.onError(custom) })).toEqual({
+        status: 404,
+      });
       expect(consoleError).not.toHaveBeenCalled();
 
       expect(options.onError(new Error('boom'))).toBeUndefined();

--- a/packages/waku/tests/server-rsc.test.ts
+++ b/packages/waku/tests/server-rsc.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
+import { createCustomError } from '../src/lib/utils/custom-errors.js';
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -25,14 +26,16 @@ const rsdwClient = vi.hoisted(() => ({
 }));
 
 const rsdwServer = vi.hoisted(() => ({
-  renderToReadableStream: vi.fn((element: unknown, _webpackMap: object) => {
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(encoder.encode(String(element)));
-        controller.close();
-      },
-    });
-  }),
+  renderToReadableStream: vi.fn(
+    (element: unknown, _webpackMap: object, _options?: object) => {
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(String(element)));
+          controller.close();
+        },
+      });
+    },
+  ),
 }));
 
 vi.mock('react-server-dom-webpack/client.edge', () => ({
@@ -52,11 +55,39 @@ describe('waku/server RSC helpers', () => {
     expect(rsdwServer.renderToReadableStream).toHaveBeenCalledWith(
       'cached element',
       {},
+      expect.objectContaining({ onError: expect.any(Function) }),
     );
 
     await expect(deserializeRsc(bytes)).resolves.toBe('cached element');
     expect(rsdwClient.createFromReadableStream).toHaveBeenCalledWith(
       expect.any(ReadableStream),
     );
+  });
+
+  test('serializeRsc returns a waku digest and logs anything else', async () => {
+    const { serializeRsc } = await import('../src/server.js');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      await serializeRsc('element');
+      const options = rsdwServer.renderToReadableStream.mock.calls.at(
+        -1,
+      )![2] as {
+        onError: (e: unknown) => string | undefined;
+      };
+
+      const custom = createCustomError('not found', { status: 404 });
+      expect(options.onError(custom)).toBe(
+        (custom as { digest?: string }).digest,
+      );
+      expect(consoleError).not.toHaveBeenCalled();
+
+      expect(options.onError(new Error('boom'))).toBeUndefined();
+      expect(consoleError).toHaveBeenCalledOnce();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
React drops an error's digest unless a handler returns it, and the element cache round-trips every static element through serializeRsc. A redirect or a not found thrown by one of those was therefore swallowed and read back as an ordinary error, so the router could not act on it and the request answered 500.

The onError option was typed as returning void, which hid the value this depends on, so it now says what react accepts.